### PR TITLE
print more information when sock.recv error occurs

### DIFF
--- a/bitmessagemain.py
+++ b/bitmessagemain.py
@@ -244,7 +244,7 @@ class receiveDataThread(QThread):
                 break
             except Exception, err:
                 printLock.acquire()
-                print 'sock.recv error. Closing receiveData thread.'
+                print 'sock.recv error. Closing receiveData thread.', err
                 printLock.release()
                 break
             #print 'Received', repr(self.data)


### PR DESCRIPTION
User reported that a connection to a remote node was dropped almost immediately and we don't know why. Might be as simple as a firewall issue.
