### PR TITLE
Fix OpenSSL loading error on OS X

### DIFF
--- a/pyelliptic/openssl.py
+++ b/pyelliptic/openssl.py
@@ -419,7 +419,7 @@ except:
                 lib_path = path.join(sys._MEIPASS, "libeay32.dll")
                 OpenSSL = _OpenSSL(lib_path)
             except:
-                if 'linux' in sys.platform:
+                if 'linux' in sys.platform or 'darwin' in sys.platform:
                     try:
                         from ctypes.util import find_library
                         OpenSSL = _OpenSSL(find_library('ssl'))


### PR DESCRIPTION
I changed openssl.py so it treats Mac OS X the same as it treats Linux when trying to load OpenSSL libraries. This makes sense since they're both Unix relatives, and more importantly it works.
