### PR TITLE
More Multi-core work

### DIFF
--- a/src/proofofwork.py
+++ b/src/proofofwork.py
@@ -64,6 +64,7 @@ def _doFastPoW(target, initialHash):
             if result[i].ready():
                 result = result[i].get()
                 pool.terminate()
+                pool.join() #Wait for the workers to exit...
                 return result[0], result[1]
         time.sleep(0.2)
 


### PR DESCRIPTION
I added a sys.platform check.

If it's linux, it runs a multi-core PoW function. Otherwise, (e.g. Windows) it defaults to a safer, single-core version.
