### PR TITLE
Add FreeBSD OpenSSL support exception

### DIFF
--- a/src/pyelliptic/openssl.py
+++ b/src/pyelliptic/openssl.py
@@ -423,7 +423,7 @@ except:
                     lib_path = path.join(sys._MEIPASS, "libeay32.dll")
                     OpenSSL = _OpenSSL(lib_path)
                 except:
-                    if 'linux' in sys.platform or 'darwin' in sys.platform:
+                    if 'linux' in sys.platform or 'darwin' in sys.platform or 'freebsd' in sys.platform:
                         try:
                             from ctypes.util import find_library
                             OpenSSL = _OpenSSL(find_library('ssl'))


### PR DESCRIPTION
Checks for OpenSSL library on FreeBSD installations
