### PR TITLE
New API command getSentMessageByAckData and made other commands return ackData

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -4401,18 +4401,18 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             return data
         elif method == 'getAllSentMessages':
             shared.sqlLock.acquire()
-            shared.sqlSubmitQueue.put('''SELECT msgid, toaddress, fromaddress, subject, lastactiontime, message, encodingtype, status FROM sent where folder='sent' ORDER BY lastactiontime''')
+            shared.sqlSubmitQueue.put('''SELECT msgid, toaddress, fromaddress, subject, lastactiontime, message, encodingtype, status, ackdata FROM sent where folder='sent' ORDER BY lastactiontime''')
             shared.sqlSubmitQueue.put('')
             queryreturn = shared.sqlReturnQueue.get()
             shared.sqlLock.release()
             data = '{"sentMessages":['
             for row in queryreturn:
-                msgid, toAddress, fromAddress, subject, lastactiontime, message, encodingtype, status = row
+                msgid, toAddress, fromAddress, subject, lastactiontime, message, encodingtype, status, ackdata = row
                 subject = shared.fixPotentiallyInvalidUTF8Data(subject)
                 message = shared.fixPotentiallyInvalidUTF8Data(message)
                 if len(data) > 25:
                     data += ','
-                data += json.dumps({'msgid':msgid.encode('hex'),'toAddress':toAddress,'fromAddress':fromAddress,'subject':subject.encode('base64'),'message':message.encode('base64'),'encodingType':encodingtype,'lastActionTime':lastactiontime,'status':status},indent=4, separators=(',', ': '))
+                data += json.dumps({'msgid':msgid.encode('hex'),'toAddress':toAddress,'fromAddress':fromAddress,'subject':subject.encode('base64'),'message':message.encode('base64'),'encodingType':encodingtype,'lastActionTime':lastactiontime,'status':status,'ackData':ackdata.encode('hex')},indent=4, separators=(',', ': '))
             data += ']}'
             return data
         elif method == 'getInboxMessagesByAddress':
@@ -4439,16 +4439,34 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             msgid = params[0].decode('hex')
             v = (msgid,)
             shared.sqlLock.acquire()
-            shared.sqlSubmitQueue.put('''SELECT msgid, toaddress, fromaddress, subject, lastactiontime, message, encodingtype, status FROM sent WHERE msgid=?''')
+            shared.sqlSubmitQueue.put('''SELECT msgid, toaddress, fromaddress, subject, lastactiontime, message, encodingtype, status, ackdata FROM sent WHERE msgid=?''')
             shared.sqlSubmitQueue.put(v)
             queryreturn = shared.sqlReturnQueue.get()
             shared.sqlLock.release()
             data = '{"sentMessage":['
             for row in queryreturn:
-                msgid, toAddress, fromAddress, subject, lastactiontime, message, encodingtype, status = row
+                msgid, toAddress, fromAddress, subject, lastactiontime, message, encodingtype, status, ackdata = row
                 subject = shared.fixPotentiallyInvalidUTF8Data(subject)
                 message = shared.fixPotentiallyInvalidUTF8Data(message)
-                data += json.dumps({'msgid':msgid.encode('hex'),'toAddress':toAddress,'fromAddress':fromAddress,'subject':subject.encode('base64'),'message':message.encode('base64'),'encodingType':encodingtype,'lastActionTime':lastactiontime,'status':status},indent=4, separators=(',', ': '))
+                data += json.dumps({'msgid':msgid.encode('hex'),'toAddress':toAddress,'fromAddress':fromAddress,'subject':subject.encode('base64'),'message':message.encode('base64'),'encodingType':encodingtype,'lastActionTime':lastactiontime,'status':status,'ackData':ackdata.encode('hex')},indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+        elif method == 'getSentMessageByAckData':
+            if len(params) == 0:
+                return 'API Error 0000: I need parameters!'
+            ackData = params[0].decode('hex')
+            v = (ackData,)
+            shared.sqlLock.acquire()
+            shared.sqlSubmitQueue.put('''SELECT msgid, toaddress, fromaddress, subject, lastactiontime, message, encodingtype, status, ackdata FROM sent WHERE ackdata=?''')
+            shared.sqlSubmitQueue.put(v)
+            queryreturn = shared.sqlReturnQueue.get()
+            shared.sqlLock.release()
+            data = '{"sentMessage":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, lastactiontime, message, encodingtype, status, ackdata = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                data += json.dumps({'msgid':msgid.encode('hex'),'toAddress':toAddress,'fromAddress':fromAddress,'subject':subject.encode('base64'),'message':message.encode('base64'),'encodingType':encodingtype,'lastActionTime':lastactiontime,'status':status,'ackData':ackdata.encode('hex')},indent=4, separators=(',', ': '))
             data += ']}'
             return data
         elif (method == 'trashMessage') or (method == 'trashInboxMessage'):


### PR DESCRIPTION
Added getSentMessageByAckData commands (similar to getStatus, but returns all message details, not just the status).

Modified getAllSentMessages and getSentMessageById commands to also return ackData.
