### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,41 +2,42 @@ APP=pybitmessage
 VERSION=0.3.4
 RELEASE=1
 ARCH_TYPE=`uname -m`
+PREFIX?=/usr/local
 
 all:
 debug:
 source:
 	tar -cvzf ../${APP}_${VERSION}.orig.tar.gz ../${APP}-${VERSION} --exclude-vcs
 install:
-	mkdir -p ${DESTDIR}/usr
-	mkdir -p ${DESTDIR}/usr/bin
-	mkdir -m 755 -p ${DESTDIR}/usr/share
-	mkdir -m 755 -p ${DESTDIR}/usr/share/man
-	mkdir -m 755 -p ${DESTDIR}/usr/share/man/man1
-	install -m 644 man/${APP}.1.gz ${DESTDIR}/usr/share/man/man1
-	mkdir -m 755 -p ${DESTDIR}/usr/share/${APP}
-	mkdir -m 755 -p ${DESTDIR}/usr/share/applications
-	mkdir -m 755 -p ${DESTDIR}/usr/share/pixmaps
-	mkdir -m 755 -p ${DESTDIR}/usr/share/icons
-	mkdir -m 755 -p ${DESTDIR}/usr/share/icons/hicolor
-	mkdir -m 755 -p ${DESTDIR}/usr/share/icons/hicolor/scalable
-	mkdir -m 755 -p ${DESTDIR}/usr/share/icons/hicolor/scalable/apps
-	mkdir -m 755 -p ${DESTDIR}/usr/share/icons/hicolor/24x24
-	mkdir -m 755 -p ${DESTDIR}/usr/share/icons/hicolor/24x24/apps
-	install -m 644 desktop/${APP}.desktop ${DESTDIR}/usr/share/applications/${APP}.desktop
-	install -m 644 desktop/icon24.png ${DESTDIR}/usr/share/icons/hicolor/24x24/apps/${APP}.png
-	cp -rf src/* ${DESTDIR}/usr/share/${APP}
-	echo '#!/bin/sh' > ${DESTDIR}/usr/bin/${APP}
-	echo 'cd /usr/share/pybitmessage' >> ${DESTDIR}/usr/bin/${APP}
-	echo 'LD_LIBRARY_PATH="/opt/openssl-compat-bitcoin/lib/" exec python2 bitmessagemain.py' >> ${DESTDIR}/usr/bin/${APP}
-	chmod +x ${DESTDIR}/usr/bin/${APP}
+	mkdir -p ${DESTDIR}${PREFIX}
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/man
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/man/man1
+	install -m 644 man/${APP}.1.gz ${DESTDIR}${PREFIX}/share/man/man1
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/${APP}
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/applications
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/pixmaps
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/icons
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/icons/hicolor
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/icons/hicolor/scalable
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/icons/hicolor/scalable/apps
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/icons/hicolor/24x24
+	mkdir -m 755 -p ${DESTDIR}${PREFIX}/share/icons/hicolor/24x24/apps
+	install -m 644 desktop/${APP}.desktop ${DESTDIR}${PREFIX}/share/applications/${APP}.desktop
+	install -m 644 desktop/icon24.png ${DESTDIR}${PREFIX}/share/icons/hicolor/24x24/apps/${APP}.png
+	cp -rf src/* ${DESTDIR}${PREFIX}/share/${APP}
+	echo '#!/bin/sh' > ${DESTDIR}${PREFIX}/bin/${APP}
+	echo 'cd ${PREFIX}/share/pybitmessage' >> ${DESTDIR}${PREFIX}/bin/${APP}
+	echo 'LD_LIBRARY_PATH="/opt/openssl-compat-bitcoin/lib/" exec python2 bitmessagemain.py' >> ${DESTDIR}${PREFIX}/bin/${APP}
+	chmod +x ${DESTDIR}${PREFIX}/bin/${APP}
 uninstall:
-	rm -f /usr/share/man/man1/${APP}.1.gz
-	rm -rf /usr/share/${APP}
-	rm -f /usr/bin/${APP}
-	rm -f /usr/share/applications/${APP}.desktop
-	rm -f /usr/share/icons/hicolor/scalable/apps/${APP}.svg
-	rm -f /usr/share/pixmaps/${APP}.svg
+	rm -f ${PREFIX}/share/man/man1/${APP}.1.gz
+	rm -rf ${PREFIX}/share/${APP}
+	rm -f ${PREFIX}/bin/${APP}
+	rm -f ${PREFIX}/share/applications/${APP}.desktop
+	rm -f ${PREFIX}/share/icons/hicolor/scalable/apps/${APP}.svg
+	rm -f ${PREFIX}/share/pixmaps/${APP}.svg
 clean:
 	rm -f ${APP} \#* \.#* gnuplot* *.png debian/*.substvars debian/*.log
 	rm -fr deb.* debian/${APP} rpmpackage/${ARCH_TYPE}


### PR DESCRIPTION
- Fixed a typo in `uninstall` where a `.svg` wasn't being `rm -f'ed.
- Install into `/usr/local` by default, but allow the `PREFIX` variable to be overridden.
