### PR TITLE
Added 'sqlite3' to the includes when building for OS X

### DIFF
--- a/src/build_osx.py
+++ b/src/build_osx.py
@@ -21,7 +21,7 @@ if sys.platform == 'darwin':
         setup_requires=['py2app'],
         app=[mainscript],
         options=dict(py2app=dict(argv_emulation=True,
-                                 includes = ['PyQt4.QtCore','PyQt4.QtGui', 'sip'],
+                                 includes = ['PyQt4.QtCore','PyQt4.QtGui', 'sip', 'sqlite3'],
                                  packages = ['bitmessageqt'],
                                  frameworks = ['/usr/local/opt/openssl/lib/libcrypto.dylib'],
                                  iconfile='images/bitmessage.icns',


### PR DESCRIPTION
Sqlite3 must be included when building the package for OS X or else the app bundle will not launch successfully. This is because OS X (even the latest 10.8.4) does not have a new enough version of sqlite for Bitmessage. When including sqlite3, the OS X package builds and launches successfully.

Py2App, OSX 10.8.4, Bitmessage latest
