### PR TITLE
"Mark Unread" in Inbox

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -2280,7 +2280,7 @@ class MyForm(QtGui.QMainWindow):
         # self.ui.tableWidgetInbox.selectRow(currentRow + 1) 
         # This doesn't de-select the last message if you try to mark it unread, but that doesn't interfere. Might not be necessary.
         # We could also select upwards, but then our problem would be with the topmost message.
-        # Is there a way to deselect all rows? The Qt documentation does not indicate so.
+        # self.ui.tableWidgetInbox.clearSelection() manages to mark the message as read again.
 
     def on_action_InboxReply(self):
         currentInboxRow = self.ui.tableWidgetInbox.currentRow()


### PR DESCRIPTION
This is one of the feature requests in the wiki. My implementation works when multiple messages are selected (ctrl+click, shift+click), which any normal user would expect.

Hopefully there isn't any Unicode voodoo I'm missing.

Is it possible to deselect all rows, and revert to the state that PyBitmessage is in on startup (nothing in message textbox, no message selected)? I tried selecting the next row, which worked reasonably well, but it doesn't behave the same when the last row is selected (nothing happens), so I went with "nothing happens" all the time.
Luckily, this works: even when only one message is selected, it stays "unread" after the operation until it is reopened. 
