### PR TITLE
Updated & simplified build_osx.py for a reliable Mac app without requiring any homebrew dependencies for users

### DIFF
--- a/src/build_osx.py
+++ b/src/build_osx.py
@@ -1,80 +1,16 @@
-"""
-py2app/py2exe build script for Bitmessage
-
-Usage (Mac OS X):
-     python setup.py py2app
-
-Usage (Windows):
-     python setup.py py2exe
-"""
-
-import sys, os, shutil, re
-from setuptools import setup  # @UnresolvedImport
-
+from setuptools import setup
 
 name = "Bitmessage"
-mainscript = 'bitmessagemain.py'
-version = "0.3.5"
-
-if sys.platform == 'darwin':
-    extra_options = dict(
-        setup_requires=['py2app'],
-        app=[mainscript],
-        options=dict(py2app=dict(argv_emulation=True,
-                                 includes = ['PyQt4.QtCore','PyQt4.QtGui', 'sip', 'sqlite3'],
-                                 packages = ['bitmessageqt'],
-                                 frameworks = ['/usr/local/opt/openssl/lib/libcrypto.dylib'],
-                                 iconfile='images/bitmessage.icns',
-                                 resources=["images"])),
-    )
-elif sys.platform == 'win32':
-    extra_options = dict(
-        setup_requires=['py2exe'],
-        app=[mainscript],
-    )
-else:
-    extra_options = dict(
-        # Normally unix-like platforms will use "setup.py install"
-        # and install the main script as such
-        scripts=[mainscript],
-    )
+version = "0.3.4"
+mainscript = ["bitmessagemain.py"]
 
 setup(
-    name = name,
-    version = version,
-    **extra_options
+     name = name,
+	version = version,
+	app = mainscript,
+	setup_requires = ["py2app"],
+	options = dict(py2app=dict(
+		resources = ["images"],
+		iconfile = "images/bitmessage.icns"
+    ))
 )
-from distutils import dir_util
-import glob
-
-if sys.platform == 'darwin':
-    resource = "dist/" + name + ".app/Contents/Resources/"
-    framework = "dist/" + name + ".app/Contents/Frameworks/"
-
-    # The pyElliptive module only works with hardcoded libcrypto paths so rename it so it can actually find it.
-    libs = glob.glob(framework + "libcrypto*.dylib")
-    for lib in libs:
-      os.rename(lib, framework + "libcrypto.dylib")
-      break
-
-    # Try to locate qt_menu
-    # Let's try the port version first!
-    if os.path.isfile("/opt/local/lib/Resources/qt_menu.nib"):
-      qt_menu_location = "/opt/local/lib/Resources/qt_menu.nib"
-    else:
-      # No dice? Then let's try the brew version
-      qt_menu_location = os.popen("find /usr/local/Cellar -name qt_menu.nib | tail -n 1").read()
-      qt_menu_location = re.sub('\n','', qt_menu_location)
-
-    if(len(qt_menu_location) == 0):
-      print "Sorry couldn't find your qt_menu.nib this probably won't work"
-    else:
-      print "Found your qib: " + qt_menu_location
-
-    # Need to include a copy of qt_menu.nib
-    shutil.copytree(qt_menu_location, resource + "qt_menu.nib")
-    # Need to touch qt.conf to avoid loading 2 sets of Qt libraries
-    fname = resource + "qt.conf"
-    with file(fname, 'a'):
-        os.utime(fname, None)
-


### PR DESCRIPTION
This simplified py2app config allows OS X users to download and run BitMessage without needing to install any homebrew dependencies. Just download and run.

It works reliably for 10.8.4, tested across different machines, and has received good feedback from other users: https://bitmessage.org/forum/index.php/topic,2761.0.html

The issue with the current build_osx.py is that it tends to produce an app that doesn't work reliably across different Macs (even when they're running the same 10.8.4 version). I started from scratch and built up a new py2app config one line at a time until everything worked reliably and still didn't require any dependencies to be installed by the end user. 

I think this is the better one to use because it's greatly simplified and more reliable. Then it can be tweaked as needed in the future. (The current osx.sh produces a very nice DMG, so I didn't change that at all.)

Also, can we get a download link on the homepage to a Mac DMG please? Probably should specify "for OS X 10.8.4+". http://sourceforge.net/projects/bitmessagemac/files/
