### PR TITLE
fixed the bug with getting the wrong locale

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3286,7 +3286,7 @@ def run():
     translator = QtCore.QTranslator()
 
     try:
-        translator.load("translations/bitmessage_" + str(locale.getlocale()[0]))
+        translator.load("translations/bitmessage_" + str(locale.getdefaultlocale()[0]))
     except:
         # The above is not compatible with all versions of OSX.
         translator.load("translations/bitmessage_en_US") # Default to english.


### PR DESCRIPTION
getlocale() always returns (None, None) unless setlocale() is used before. (It is supposed to return the active locale, which is none if not selected).

This bug prevents the automatic switching of the language depending on the locale as a fallback option of English is always used instead.

What is probably meant here is getdefaultlocale(), not getlocale().

Just a little change in 1 line.
