### PR TITLE
Fix for traceback on OSX.  Fixes Bitmessage/PyBitmessage#401

### DIFF
--- a/src/shared.py
+++ b/src/shared.py
@@ -355,7 +355,7 @@ def checkSensitiveFilePermissions(filename):
                 return True
         except:
             # Swallow exception here, but we might run into trouble later!
-            logger.error('Could not determine filesystem type.', filename)
+            logger.error('Could not determine filesystem type. %s', filename)
         present_permissions = os.stat(filename)[0]
         disallowed_permissions = stat.S_IRWXG | stat.S_IRWXO
         return present_permissions & disallowed_permissions == 0


### PR DESCRIPTION
Fixes issue Bitmessage/PyBitmessage#401 where we get a traceback in OSX.
