### PR TITLE
App fails with system python before OSX system check

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -23,6 +23,14 @@ import json
 import singleton
 import os
 
+# OSX python version check
+import sys
+if sys.platform == 'darwin':
+    if float("{1}.{2}".format(*sys.version_info)) < 7.5:
+        print "You should use python 2.7.5 or greater."
+        print "Your version: {0}.{1}.{2}".format(*sys.version_info)
+        sys.exit(0)
+
 # Classes
 from class_sqlThread import *
 from class_singleCleaner import *
@@ -33,13 +41,6 @@ from class_addressGenerator import *
 
 # Helper Functions
 import helper_bootstrap
-
-import sys
-if sys.platform == 'darwin':
-    if float("{1}.{2}".format(*sys.version_info)) < 7.5:
-        print "You should use python 2.7.5 or greater."
-        print "Your version: {0}.{1}.{2}".format(*sys.version_info)
-        sys.exit(0)
 
 def connectToStream(streamNumber):
     selfInitiatedConnections[streamNumber] = {}


### PR DESCRIPTION
Got the following error when running python instead of python2.7.

This pull request moves up the existing version check so we get the nice error message.

```
master-blaster:PyBitmessage grant$ python src/bitmessagemain.py 
Not using the gevent module as it was not found. No need to worry.
Loading existing config files from /Users/grant/Library/Application Support/PyBitmessage/
Traceback (most recent call last):
  File "src/bitmessagemain.py", line 27, in <module>
    from class_sqlThread import *
  File "/Users/grant/src/PyBitmessage/src/class_sqlThread.py", line 2, in <module>
    import shared
  File "/Users/grant/src/PyBitmessage/src/shared.py", line 398, in <module>
    from debug import logger
  File "/Users/grant/src/PyBitmessage/src/debug.py", line 71, in <module>
    configureLogging()   
  File "/Users/grant/src/PyBitmessage/src/debug.py", line 27, in configureLogging
    logging.config.dictConfig({
AttributeError: 'module' object has no attribute 'dictConfig'
```
