### PR TITLE
Fix bad namecoin config lookup on OSX

### DIFF
--- a/src/namecoin.py
+++ b/src/namecoin.py
@@ -23,6 +23,7 @@ import base64
 import json
 import socket
 import sys
+import os
 
 import shared
 import tr # translate


### PR DESCRIPTION
When starting on OSX with the new namecoin integration, this error message flies by in the console:

```
Failure reading namecoin config file: global name 'os' is not defined
```

After adding the require, I get the proper error indicating I've never configured namecoin settings:

```
Failure reading namecoin config file: [Errno 2] No such file or directory: '/Users/grant/Library/Application Support/namecoin/namecoin.conf'
```
