### PR TITLE
Use 'inf' as large value instead of 1e20

### DIFF
--- a/src/proofofwork.py
+++ b/src/proofofwork.py
@@ -24,7 +24,7 @@ def _set_idle():
 
 def _pool_worker(nonce, initialHash, target, pool_size):
     _set_idle()
-    trialValue = 99999999999999999999
+    trialValue = float('inf')
     while trialValue > target:
         nonce += pool_size
         trialValue, = unpack('>Q',hashlib.sha512(hashlib.sha512(pack('>Q',nonce) + initialHash).digest()).digest()[0:8])
@@ -32,7 +32,7 @@ def _pool_worker(nonce, initialHash, target, pool_size):
 
 def _doSafePoW(target, initialHash):
     nonce = 0
-    trialValue = 99999999999999999999
+    trialValue = float('inf')
     while trialValue > target:
         nonce += 1
         trialValue, = unpack('>Q',hashlib.sha512(hashlib.sha512(pack('>Q',nonce) + initialHash).digest()).digest()[0:8])


### PR DESCRIPTION
'inf' is always bigger than any number, 1e20 is not.

8 bytes have a maximum value of (2**8)**8 ~ 1.8e19, so 1e20 will work in this case, but could break when more bytes are used.
