### PR TITLE
Fix Archlinux package creation

### DIFF
--- a/arch.sh
+++ b/arch.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+GIT_APP=PyBitmessage
 APP=pybitmessage
 PREV_VERSION=0.3.5
 VERSION=0.3.5
@@ -25,24 +26,12 @@ make clean
 rm -f archpackage/*.gz
 
 # having the root directory called name-version seems essential
-mv ../${APP} ../${APP}-${VERSION}
+mv ../${GIT_APP} ../${APP}-${VERSION}
 tar -cvzf ${SOURCE} ../${APP}-${VERSION} --exclude-vcs
 
 # rename the root directory without the version number
-mv ../${APP}-${VERSION} ../${APP}
+mv ../${APP}-${VERSION} ../${GIT_APP}
 
 # calculate the MD5 checksum
 CHECKSM=$(md5sum ${SOURCE})
 sed -i "s/md5sums[^)]*)/md5sums=(${CHECKSM%% *})/g" archpackage/PKGBUILD
-
-cd archpackage
-
-# Create the package
-tar -c -f ${APP}-${VERSION}.pkg.tar .
-sync
-xz ${APP}-${VERSION}.pkg.tar
-sync
-
-# Move back to the original directory
-cd ${CURRDIR}
-


### PR DESCRIPTION
- When simply cloning from the repo, the folder name is PyBitmessage, not just pybitmessage.
- Building the `xxx-pkg.tar.xz` is the job of Archlinux's `makepkg`, not the job of upstream (ie bitmessage). You just need to build the `xxx.tar.gz` part

An archer still has to manually clone the repo to install it with the provided PKGBUILD. Is there any reason why you don't provide `xxx.tar.gz`-ified extracts of the code on each release ? (I also notice that you don't use tags, which could be really helpful with github). This would greatly help, because then all you'd need to distribute is the PKGBUILD along with an url pointing to the `xxx.tar.gz` (I think github hosts them automatically)
