### PR TITLE
Eliminate futile multiprocessing

### DIFF
--- a/src/proofofwork.py
+++ b/src/proofofwork.py
@@ -52,6 +52,10 @@ def _doFastPoW(target, initialHash):
         maxCores = 99999
     if pool_size > maxCores:
         pool_size = maxCores
+
+    if pool_size == 1: # Don't mess around with multiprocessing on a single core machine
+        return _doSafePoW(target, initialHash)
+
     pool = Pool(processes=pool_size)
     result = []
     for i in range(pool_size):


### PR DESCRIPTION
Even if we're on a platform that supports fast PoW calculation, we should use safe PoWs when we're only utilizing a single core.  It doesn't make sense to introduce the overhead of multiprocessing when we won't actually parallelize the work.  This may have caused PyBitmessage to blow up on a resource-limited VPS.
