### PR TITLE
Allow specification of alternate settings dir via BITMESSAGE_HOME

### DIFF
--- a/src/shared.py
+++ b/src/shared.py
@@ -126,7 +126,11 @@ def assembleVersionMessage(remoteHost, remotePort, myStreamNumber):
 def lookupAppdataFolder():
     APPNAME = "PyBitmessage"
     from os import path, environ
-    if sys.platform == 'darwin':
+    if "BITMESSAGE_HOME" in environ:
+        dataFolder = environ["BITMESSAGE_HOME"]
+        if dataFolder[-1] not in [os.path.sep, os.path.altsep]:
+            dataFolder += os.path.sep
+    elif sys.platform == 'darwin':
         if "HOME" in environ:
             dataFolder = path.join(os.environ["HOME"], "Library/Application Support/", APPNAME) + '/'
         else:


### PR DESCRIPTION
This feature is for Bitmessage/PyBitmessage#434.  It allows you to set an alternate home directory so that you can run multiple instances of bitmessage with different settings.  To use a different settings dir, specify the `BITMESSAGE_HOME` var:

```
BITMESSAGE_HOME=~/.mailing_list_server python src/bitmessagemain.py
```

@atheros1 note that I put the code in lookupAppdataFolder in shared.py rather than loadConfig(), because we need to know where the new keys.dat file is _before_ we load the config.
