### PR TITLE
Use FastPoW on OSX

### DIFF
--- a/src/proofofwork.py
+++ b/src/proofofwork.py
@@ -73,5 +73,7 @@ def _doFastPoW(target, initialHash):
 def run(target, initialHash):
     if 'linux' in sys.platform:
         return _doFastPoW(target, initialHash)
+    elif sys.platform == 'darwin':
+        return _doFastPoW(target, initialHash)
     else:
         return _doSafePoW(target, initialHash)


### PR DESCRIPTION
Use FastPoW on OSX.

I tested a .dmg since frozen windows app has problems, and it works just fine.  Also works from the source distribution.
