### PR TITLE
Recreated API and excluded it to a single class including unittests

### DIFF
--- a/src/class_api.py
+++ b/src/class_api.py
@@ -419,6 +419,7 @@ def getAPI(workingdir=None,silent=False):
                 networkStatus = 'connectedAndReceivingIncomingConnections'
             
             info = {}
+            info['externalIPAddress'] = bitmessagemain.shared.myExternalIP
             info['networkConnections'] = len(bitmessagemain.shared.connectedHostsList)
             info['numberOfMessagesProcessed'] = bitmessagemain.shared.numberOfMessagesProcessed
             info['numberOfBroadcastsProcessed'] = bitmessagemain.shared.numberOfBroadcastsProcessed

--- a/src/class_receiveDataThread.py
+++ b/src/class_receiveDataThread.py
@@ -1960,6 +1960,7 @@ class receiveDataThread(threading.Thread):
                 return
             # print 'remoteProtocolVersion', self.remoteProtocolVersion
             self.myExternalIP = socket.inet_ntoa(data[40:44])
+            shared.myExternalIP = self.myExternalIP
             # print 'myExternalIP', self.myExternalIP
             self.remoteNodeIncomingPort, = unpack('>H', data[70:72])
             # print 'remoteNodeIncomingPort', self.remoteNodeIncomingPort

--- a/src/shared.py
+++ b/src/shared.py
@@ -6,7 +6,7 @@ lengthOfTimeToHoldOnToAllPubkeys = 2419200  # Equals 4 weeks. You could make thi
 maximumAgeOfObjectsThatIAdvertiseToOthers = 216000  # Equals two days and 12 hours
 maximumAgeOfNodesThatIAdvertiseToOthers = 10800  # Equals three hours
 useVeryEasyProofOfWorkForTesting = False  # If you set this to True while on the normal network, you won't be able to send or sometimes receive messages.
-
+myExternalIP = None
 
 # Libraries.
 import collections


### PR DESCRIPTION
With the new environment variable, I was able to create a complete abstracted API without any change in bitmessagemain.
Also the logfilelocation-problem should be solved.

It can be used like:
import class_api
api = class_api.getAPI(workingdir='/tmp/testfolder',silent=True)
api.[...]
api.stop()
