### PR TITLE
Restore "import shared" to helper_inbox

### DIFF
--- a/src/helper_inbox.py
+++ b/src/helper_inbox.py
@@ -1,4 +1,5 @@
 from helper_sql import *
+import shared
 
 def insert(t):
     sqlExecute('''INSERT INTO inbox VALUES (?,?,?,?,?,?,?,?,?)''', *t)


### PR DESCRIPTION
Commit 5b23d9 removed the line "import shared" from helper_inbox. Almost
all of what shared was used for became covered by helper_sql. But, shared
still needs to be imported because there is still one line that uses
shared:
9:    shared.UISignalQueue.put(('removeInboxRowByMsgid',msgid))
