### PR TITLE
Add api method decodeAddress

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -818,6 +818,15 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             else:
                 networkStatus = 'connectedAndReceivingIncomingConnections'
             return json.dumps({'networkConnections':len(shared.connectedHostsList),'numberOfMessagesProcessed':shared.numberOfMessagesProcessed, 'numberOfBroadcastsProcessed':shared.numberOfBroadcastsProcessed, 'numberOfPubkeysProcessed':shared.numberOfPubkeysProcessed, 'networkStatus':networkStatus, 'softwareName':'PyBitmessage','softwareVersion':shared.softwareVersion}, indent=4, separators=(',', ': '))
+        elif method == 'decodeAddress':
+            #decode an address
+            if len(params) != 1:
+                raise APIError(0, 'I need 1 parameter!')
+            address, = params
+            status, addressVersion, streamNumber, ripe = decodeAddress(address)
+            return json.dumps({'status':status, 'addressVersion':addressVersion,
+                               'streamNumber':streamNumber, 'ripe':ripe.encode('base64')}, indent=4,
+                               separators=(',', ': '))
         else:
             raise APIError(20, 'Invalid method: %s' % method)
 


### PR DESCRIPTION
Add decodeAddress as an api call. Like the addresses.decodeAddress function it return status, addressVersion, streamNumber, and ripe. ripe is base64 encoded.
