### PR TITLE
== should be =

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -643,7 +643,7 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
                 raise APIError(0, 'I need parameters!')
             if len(params) == 1:
                 address, = params
-                label == ''
+                label = ''
             if len(params) == 2:
                 address, label = params
                 label = self._decode(label, "base64")


### PR DESCRIPTION
In the addSubscription API call, if 1 paramater is given the label should be set to ''. 
