### PR TITLE
Fixed typo in getInboxMessagesByAddress

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -461,7 +461,7 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             if len(params) == 0:
                 raise APIError(0, 'I need parameters!')
             toAddress = params[0]
-            queryReturn = sqlQuery('''SELECT msgid, toaddress, fromaddress, subject, received, message, encodingtype FROM inbox WHERE folder='inbox' AND toAddress=?''', toAddress)
+            queryreturn = sqlQuery('''SELECT msgid, toaddress, fromaddress, subject, received, message, encodingtype FROM inbox WHERE folder='inbox' AND toAddress=?''', toAddress)
             data = '{"inboxMessages":['
             for row in queryreturn:
                 msgid, toAddress, fromAddress, subject, received, message, encodingtype = row


### PR DESCRIPTION
A typo in the "queryreturn" variable was causing this API call to fail.
