### PR TITLE
Create bitmessage_no.pro

### DIFF
--- a/src/translations/bitmessage_no.pro
+++ b/src/translations/bitmessage_no.pro
@@ -1,0 +1,33 @@
+SOURCES	= 	../addresses.py\
+			../bitmessagemain.py\
+			../class_addressGenerator.py\
+			../class_outgoingSynSender.py\
+			../class_receiveDataThread.py\
+			../class_sendDataThread.py\
+			../class_singleCleaner.py\
+			../class_singleListener.py\
+			../class_singleWorker.py\
+			../class_sqlThread.py\
+			../helper_bitcoin.py\
+			../helper_bootstrap.py\
+			../helper_generic.py\
+			../helper_inbox.py\
+			../helper_sent.py\
+			../helper_startup.py\
+			../shared.py\
+			../bitmessageqt/__init__.py\
+			../bitmessageqt/about.py\
+			../bitmessageqt/bitmessageui.py\
+			../bitmessageqt/connect.py\
+			../bitmessageqt/help.py\
+			../bitmessageqt/iconglossary.py\
+			../bitmessageqt/newaddressdialog.py\
+			../bitmessageqt/newchandialog.py\
+			../bitmessageqt/newsubscriptiondialog.py\
+			../bitmessageqt/regenerateaddresses.py\
+			../bitmessageqt/settings.py\
+			../bitmessageqt/specialaddressbehavior.py
+
+			
+TRANSLATIONS	= bitmessage_no.ts
+CODECFORTR      = UTF-8


### PR DESCRIPTION
A simple .pro file like the other languages have, with correct name for the norwegian translation file.

(I guess a .qm file is also needed, but I could not make heads or tails of it since Notepad++ shows gibberish and they all differ in size)
