### PR TITLE
Fix a typo in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ git fetch --all
 git reset --hard origin/master
 python bitmessagemain.py
 ```
-Viola! Bitmessage is updated!
+Voilà! Bitmessage is updated!
 
 ####Linux
 To run PyBitmessage from the command-line, you must download the source, then


### PR DESCRIPTION
Pretty sure what's intended here is http://en.wiktionary.org/wiki/voil%C3%A0, not the musical instrument.
