### PR TITLE
Fix unicode handling in 'View HTML code as formated text'. Fixes #667

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -2585,19 +2585,20 @@ class MyForm(QtGui.QMainWindow):
             for row in queryreturn:
                 messageText, = row
 
-        messageText = shared.fixPotentiallyInvalidUTF8Data(messageText)
-        messageText = unicode(messageText, 'utf-8)')
         lines = messageText.split('\n')
-        for i in xrange(len(lines)):
+        totalLines = len(lines)
+        for i in xrange(totalLines):
             if 'Message ostensibly from ' in lines[i]:
-                lines[i] = u'<p style="font-size: 12px; color: grey;">%s</span></p>' % (
+                lines[i] = '<p style="font-size: 12px; color: grey;">%s</span></p>' % (
                     lines[i])
             elif lines[i] == '------------------------------------------------------':
                 lines[i] = '<hr>'
-        content = u''
-        for i in xrange(len(lines)):
-            content += lines[i]
-        content = content.replace('\n\n', '<br><br>')
+            elif lines[i] == '' and (i+1) < totalLines and \
+                 lines[i+1] != '------------------------------------------------------':
+                lines[i] = '<br><br>'
+        content = ' '.join(lines) # To keep the whitespace between lines
+        content = shared.fixPotentiallyInvalidUTF8Data(content)
+        content = unicode(content, 'utf-8)')
         self.ui.textEditInboxMessage.setHtml(QtCore.QString(content))
 
     def on_action_InboxMarkUnread(self):


### PR DESCRIPTION
Implemented like in main view (`def tableWidgetInboxItemClicked(self)`) except for substitution logic.
