### PR TITLE
run -c without python-qt installed

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -214,15 +214,15 @@ class Main:
         singleListenerThread.start()
 
         if daemon == False and shared.safeConfigGetBoolean('bitmessagesettings', 'daemon') == False:
-            try:
-                from PyQt4 import QtCore, QtGui
-            except Exception as err:
-                print 'PyBitmessage requires PyQt unless you want to run it as a daemon and interact with it using the API. You can download PyQt from http://www.riverbankcomputing.com/software/pyqt/download   or by searching Google for \'PyQt Download\'. If you want to run in daemon mode, see https://bitmessage.org/wiki/Daemon'
-                print 'Error message:', err
-                print 'You can also run PyBitmessage with the new curses interface by providing \'-c\' as a commandline argument.'
-                os._exit(0)
-
             if curses == False:
+                try:
+                    from PyQt4 import QtCore, QtGui
+                except Exception as err:
+                    print 'PyBitmessage requires PyQt unless you want to run it as a daemon and interact with it using the API. You can download PyQt from http://www.riverbankcomputing.com/software/pyqt/download   or by searching Google for \'PyQt Download\'. If you want to run in daemon mode, see https://bitmessage.org/wiki/Daemon'
+                    print 'Error message:', err
+                    print 'You can also run PyBitmessage with the new curses interface by providing \'-c\' as a commandline argument.'
+                    os._exit(0)
+
                 import bitmessageqt
                 bitmessageqt.run()
             else:


### PR DESCRIPTION
moved the check for PyQt so that we don't need to install it when running -c

updated readme to add python-dialog requirement and note that they're sort of optional.
