### PR TITLE
Catch the standard Unix SIGTERM kill signal and do a graceful shutdown

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -172,6 +172,7 @@ class Main:
             curses = True
 
         signal.signal(signal.SIGINT, helper_generic.signal_handler)
+        signal.signal(signal.SIGTERM, helper_generic.signal_handler)
         # signal.signal(signal.SIGINT, signal.SIG_DFL)
 
         helper_bootstrap.knownNodes()


### PR DESCRIPTION
We already do this for the SIGINT kill signal. The change allows us to also do a clean shutdown of PyBitmessage when its process has been separated from the terminal. Otherwise, an attempt to stop the PyBitmessage process simply terminates it, and we lose any data not already written to disk. 
