### PR TITLE
#708 : Use default locale encoding

### DIFF
--- a/src/l10n.py
+++ b/src/l10n.py
@@ -18,7 +18,7 @@ language = DEFAULT_LANGUAGE
 
 try:
     import locale
-    encoding = locale.getpreferredencoding(False) or DEFAULT_ENCODING
+    encoding = locale.getpreferredencoding(True) or DEFAULT_ENCODING
     language = locale.getlocale()[0] or locale.getdefaultlocale()[0] or DEFAULT_LANGUAGE
 except:
     logger.exception('Could not determine language or encoding')


### PR DESCRIPTION
Use locale endoding else this generate error in GU : as default time format can have non ascii char on non english locale, but using ascii in locale can generate UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 :

In PyBitmessage/src/bitmessageqt/**init**.py"
    l10n.formatTimestamp())

In PyBitmessage/src/l10n.py", line 81, in formatTimestamp
    return unicode(timestring, encoding)
