### PR TITLE
C library for PoW

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -38,6 +38,7 @@ from class_singleWorker import singleWorker
 #from class_addressGenerator import *
 from class_addressGenerator import addressGenerator
 from debug import logger
+import cwrapper
 
 # Helper Functions
 import helper_bootstrap
@@ -205,6 +206,9 @@ class Main:
             singleAPIThread = singleAPI()
             singleAPIThread.daemon = True  # close the main program even if there are threads left
             singleAPIThread.start()
+
+        if not shared.safeConfigGetBoolean('bitmessagesettings', 'disableclib'):
+            shared.clibAvaible = cwrapper.init()
 
         connectToStream(1)
 

--- a/src/c/proofofwork.c
+++ b/src/c/proofofwork.c
@@ -1,5 +1,5 @@
 #include "sha512.h"
-#include <inttypes.h>
+#include <stdint.h>
 
 /*
  * 64-bit integer manipulation macros (big endian)
@@ -33,30 +33,27 @@
 #endif /* PUT_UINT64_BE */
 
 void doPoW(uint64_t target, unsigned char initialHash[64], uint64_t* trialValue, uint64_t* nonce, unsigned int poolSize) {
-	sha512_context ctx;
+	struct sha512_ctx ctx;
 	unsigned char tmp[72];
 
 	*trialValue = target + 1;
 
-	sha512_init(&ctx);
 	while (*trialValue > target) {
 		*nonce += poolSize;
 
 		PUT_UINT64_BE(*nonce, tmp, 0);
 		memcpy(&(tmp[8]), initialHash, 64);
 			
-		sha512_starts(&ctx, 0);
-		sha512_update(&ctx, tmp, 72);
-		sha512_finish(&ctx, tmp);
+		sha512_init_ctx(&ctx);
+		sha512_process_bytes(tmp, 72, &ctx);
+		sha512_finish_ctx(&ctx, tmp);
 
-		sha512_starts(&ctx, 0);
-		sha512_update(&ctx, tmp, 64);
-		sha512_finish(&ctx, tmp);
+		sha512_init_ctx(&ctx);
+		sha512_process_bytes(tmp, 64, &ctx);
+		sha512_finish_ctx(&ctx, tmp);
 
 		GET_UINT64_BE(*trialValue, tmp, 0);
 	}
-
-	sha512_free(&ctx);
 }
 
 #ifdef TEST

--- a/src/c/proofofwork.c
+++ b/src/c/proofofwork.c
@@ -1,0 +1,89 @@
+#include "sha512.h"
+#include <inttypes.h>
+
+/*
+ * 64-bit integer manipulation macros (big endian)
+ */
+#ifndef GET_UINT64_BE
+#define GET_UINT64_BE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint64_t) (b)[(i)    ] << 56 )       \
+        | ( (uint64_t) (b)[(i) + 1] << 48 )       \
+        | ( (uint64_t) (b)[(i) + 2] << 40 )       \
+        | ( (uint64_t) (b)[(i) + 3] << 32 )       \
+        | ( (uint64_t) (b)[(i) + 4] << 24 )       \
+        | ( (uint64_t) (b)[(i) + 5] << 16 )       \
+        | ( (uint64_t) (b)[(i) + 6] <<  8 )       \
+        | ( (uint64_t) (b)[(i) + 7]       );      \
+}
+#endif /* GET_UINT64_BE */
+
+#ifndef PUT_UINT64_BE
+#define PUT_UINT64_BE(n,b,i)                            \
+{                                                       \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 40 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 32 );       \
+    (b)[(i) + 4] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 5] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 7] = (unsigned char) ( (n)       );       \
+}
+#endif /* PUT_UINT64_BE */
+
+void doPoW(uint64_t target, unsigned char initialHash[64], uint64_t* trialValue, uint64_t* nonce, unsigned int poolSize) {
+	sha512_context ctx;
+	unsigned char tmp[72];
+
+	*trialValue = target + 1;
+
+	sha512_init(&ctx);
+	while (*trialValue > target) {
+		*nonce += poolSize;
+
+		PUT_UINT64_BE(*nonce, tmp, 0);
+		memcpy(&(tmp[8]), initialHash, 64);
+			
+		sha512_starts(&ctx, 0);
+		sha512_update(&ctx, tmp, 72);
+		sha512_finish(&ctx, tmp);
+
+		sha512_starts(&ctx, 0);
+		sha512_update(&ctx, tmp, 64);
+		sha512_finish(&ctx, tmp);
+
+		GET_UINT64_BE(*trialValue, tmp, 0);
+	}
+
+	sha512_free(&ctx);
+}
+
+#ifdef TEST
+
+#include <stdio.h>
+
+int main() {
+	uint64_t trialValue;
+	uint64_t nonce = 0;
+	unsigned char initialHash[64] = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+		0x00, 0x00, 0x00, 0x00 };
+	uint64_t target = 9999999999999;
+
+	doPoW(target, initialHash, &trialValue, &nonce, 1);
+	if (nonce == 4284919Lu && trialValue == 6694291384049Lu) {
+		printf("Test passed!\n");
+	} else {
+		printf("Test failed!\n");
+		printf("Nonce == %lu\n", nonce);
+		printf("trialValue == %lu\n", trialValue);
+	}
+	return 0;
+}
+#endif //TEST

--- a/src/c/sha512.c
+++ b/src/c/sha512.c
@@ -1,747 +1,417 @@
-/*
- *  FIPS-180-2 compliant SHA-384/512 implementation
- *
- *  Copyright (C) 2006-2014, Brainspark B.V.
- *
- *  This file is part of PolarSSL (http://www.polarssl.org)
- *  Lead Maintainer: Paul Bakker <polarssl_maintainer at polarssl.org>
- *
- *  All rights reserved.
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
-/*
- *  The SHA-512 Secure Hash Standard was published by NIST in 2002.
- *
- *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
- */
+/* Taken from SHA512-based Unix crypt implementation.
+   Released into the Public Domain by Ulrich Drepper <drepper@redhat.com>.  */
 
 #include "sha512.h"
 
-#if defined(POLARSSL_SELF_TEST)
-#include <stdio.h>
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+# define SWAP(n) \
+  (((n) << 56)					\
+   | (((n) & 0xff00) << 40)			\
+   | (((n) & 0xff0000) << 24)			\
+   | (((n) & 0xff000000) << 8)			\
+   | (((n) >> 8) & 0xff000000)			\
+   | (((n) >> 24) & 0xff0000)			\
+   | (((n) >> 40) & 0xff00)			\
+   | ((n) >> 56))
+#else
+# define SWAP(n) (n)
 #endif
 
-/* Implementation that should never be optimized out by the compiler */
-static void polarssl_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
-}
 
-/*
- * 64-bit integer manipulation macros (big endian)
- */
-#ifndef GET_UINT64_BE
-#define GET_UINT64_BE(n,b,i)                            \
-{                                                       \
-    (n) = ( (uint64_t) (b)[(i)    ] << 56 )       \
-        | ( (uint64_t) (b)[(i) + 1] << 48 )       \
-        | ( (uint64_t) (b)[(i) + 2] << 40 )       \
-        | ( (uint64_t) (b)[(i) + 3] << 32 )       \
-        | ( (uint64_t) (b)[(i) + 4] << 24 )       \
-        | ( (uint64_t) (b)[(i) + 5] << 16 )       \
-        | ( (uint64_t) (b)[(i) + 6] <<  8 )       \
-        | ( (uint64_t) (b)[(i) + 7]       );      \
-}
-#endif /* GET_UINT64_BE */
+/* This array contains the bytes used to pad the buffer to the next
+   64-byte boundary.  (FIPS 180-2:5.1.2)  */
+static const unsigned char fillbuf[128] = { 0x80, 0 /* , 0, 0, ...  */ };
 
-#ifndef PUT_UINT64_BE
-#define PUT_UINT64_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >> 40 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n) >> 32 );       \
-    (b)[(i) + 4] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 5] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 7] = (unsigned char) ( (n)       );       \
-}
-#endif /* PUT_UINT64_BE */
 
-/*
- * Round constants
- */
+/* Constants for SHA512 from FIPS 180-2:4.2.3.  */
 static const uint64_t K[80] =
+  {
+    UINT64_C (0x428a2f98d728ae22), UINT64_C (0x7137449123ef65cd),
+    UINT64_C (0xb5c0fbcfec4d3b2f), UINT64_C (0xe9b5dba58189dbbc),
+    UINT64_C (0x3956c25bf348b538), UINT64_C (0x59f111f1b605d019),
+    UINT64_C (0x923f82a4af194f9b), UINT64_C (0xab1c5ed5da6d8118),
+    UINT64_C (0xd807aa98a3030242), UINT64_C (0x12835b0145706fbe),
+    UINT64_C (0x243185be4ee4b28c), UINT64_C (0x550c7dc3d5ffb4e2),
+    UINT64_C (0x72be5d74f27b896f), UINT64_C (0x80deb1fe3b1696b1),
+    UINT64_C (0x9bdc06a725c71235), UINT64_C (0xc19bf174cf692694),
+    UINT64_C (0xe49b69c19ef14ad2), UINT64_C (0xefbe4786384f25e3),
+    UINT64_C (0x0fc19dc68b8cd5b5), UINT64_C (0x240ca1cc77ac9c65),
+    UINT64_C (0x2de92c6f592b0275), UINT64_C (0x4a7484aa6ea6e483),
+    UINT64_C (0x5cb0a9dcbd41fbd4), UINT64_C (0x76f988da831153b5),
+    UINT64_C (0x983e5152ee66dfab), UINT64_C (0xa831c66d2db43210),
+    UINT64_C (0xb00327c898fb213f), UINT64_C (0xbf597fc7beef0ee4),
+    UINT64_C (0xc6e00bf33da88fc2), UINT64_C (0xd5a79147930aa725),
+    UINT64_C (0x06ca6351e003826f), UINT64_C (0x142929670a0e6e70),
+    UINT64_C (0x27b70a8546d22ffc), UINT64_C (0x2e1b21385c26c926),
+    UINT64_C (0x4d2c6dfc5ac42aed), UINT64_C (0x53380d139d95b3df),
+    UINT64_C (0x650a73548baf63de), UINT64_C (0x766a0abb3c77b2a8),
+    UINT64_C (0x81c2c92e47edaee6), UINT64_C (0x92722c851482353b),
+    UINT64_C (0xa2bfe8a14cf10364), UINT64_C (0xa81a664bbc423001),
+    UINT64_C (0xc24b8b70d0f89791), UINT64_C (0xc76c51a30654be30),
+    UINT64_C (0xd192e819d6ef5218), UINT64_C (0xd69906245565a910),
+    UINT64_C (0xf40e35855771202a), UINT64_C (0x106aa07032bbd1b8),
+    UINT64_C (0x19a4c116b8d2d0c8), UINT64_C (0x1e376c085141ab53),
+    UINT64_C (0x2748774cdf8eeb99), UINT64_C (0x34b0bcb5e19b48a8),
+    UINT64_C (0x391c0cb3c5c95a63), UINT64_C (0x4ed8aa4ae3418acb),
+    UINT64_C (0x5b9cca4f7763e373), UINT64_C (0x682e6ff3d6b2b8a3),
+    UINT64_C (0x748f82ee5defb2fc), UINT64_C (0x78a5636f43172f60),
+    UINT64_C (0x84c87814a1f0ab72), UINT64_C (0x8cc702081a6439ec),
+    UINT64_C (0x90befffa23631e28), UINT64_C (0xa4506cebde82bde9),
+    UINT64_C (0xbef9a3f7b2c67915), UINT64_C (0xc67178f2e372532b),
+    UINT64_C (0xca273eceea26619c), UINT64_C (0xd186b8c721c0c207),
+    UINT64_C (0xeada7dd6cde0eb1e), UINT64_C (0xf57d4f7fee6ed178),
+    UINT64_C (0x06f067aa72176fba), UINT64_C (0x0a637dc5a2c898a6),
+    UINT64_C (0x113f9804bef90dae), UINT64_C (0x1b710b35131c471b),
+    UINT64_C (0x28db77f523047d84), UINT64_C (0x32caab7b40c72493),
+    UINT64_C (0x3c9ebe0a15c9bebc), UINT64_C (0x431d67c49c100d4c),
+    UINT64_C (0x4cc5d4becb3e42b6), UINT64_C (0x597f299cfc657e2a),
+    UINT64_C (0x5fcb6fab3ad6faec), UINT64_C (0x6c44198c4a475817)
+  };
+
+
+/* Process LEN bytes of BUFFER, accumulating context into CTX.
+   It is assumed that LEN % 128 == 0.  */
+static void
+sha512_process_block (const void *buffer, size_t len, struct sha512_ctx *ctx)
 {
-    UL64(0x428A2F98D728AE22),  UL64(0x7137449123EF65CD),
-    UL64(0xB5C0FBCFEC4D3B2F),  UL64(0xE9B5DBA58189DBBC),
-    UL64(0x3956C25BF348B538),  UL64(0x59F111F1B605D019),
-    UL64(0x923F82A4AF194F9B),  UL64(0xAB1C5ED5DA6D8118),
-    UL64(0xD807AA98A3030242),  UL64(0x12835B0145706FBE),
-    UL64(0x243185BE4EE4B28C),  UL64(0x550C7DC3D5FFB4E2),
-    UL64(0x72BE5D74F27B896F),  UL64(0x80DEB1FE3B1696B1),
-    UL64(0x9BDC06A725C71235),  UL64(0xC19BF174CF692694),
-    UL64(0xE49B69C19EF14AD2),  UL64(0xEFBE4786384F25E3),
-    UL64(0x0FC19DC68B8CD5B5),  UL64(0x240CA1CC77AC9C65),
-    UL64(0x2DE92C6F592B0275),  UL64(0x4A7484AA6EA6E483),
-    UL64(0x5CB0A9DCBD41FBD4),  UL64(0x76F988DA831153B5),
-    UL64(0x983E5152EE66DFAB),  UL64(0xA831C66D2DB43210),
-    UL64(0xB00327C898FB213F),  UL64(0xBF597FC7BEEF0EE4),
-    UL64(0xC6E00BF33DA88FC2),  UL64(0xD5A79147930AA725),
-    UL64(0x06CA6351E003826F),  UL64(0x142929670A0E6E70),
-    UL64(0x27B70A8546D22FFC),  UL64(0x2E1B21385C26C926),
-    UL64(0x4D2C6DFC5AC42AED),  UL64(0x53380D139D95B3DF),
-    UL64(0x650A73548BAF63DE),  UL64(0x766A0ABB3C77B2A8),
-    UL64(0x81C2C92E47EDAEE6),  UL64(0x92722C851482353B),
-    UL64(0xA2BFE8A14CF10364),  UL64(0xA81A664BBC423001),
-    UL64(0xC24B8B70D0F89791),  UL64(0xC76C51A30654BE30),
-    UL64(0xD192E819D6EF5218),  UL64(0xD69906245565A910),
-    UL64(0xF40E35855771202A),  UL64(0x106AA07032BBD1B8),
-    UL64(0x19A4C116B8D2D0C8),  UL64(0x1E376C085141AB53),
-    UL64(0x2748774CDF8EEB99),  UL64(0x34B0BCB5E19B48A8),
-    UL64(0x391C0CB3C5C95A63),  UL64(0x4ED8AA4AE3418ACB),
-    UL64(0x5B9CCA4F7763E373),  UL64(0x682E6FF3D6B2B8A3),
-    UL64(0x748F82EE5DEFB2FC),  UL64(0x78A5636F43172F60),
-    UL64(0x84C87814A1F0AB72),  UL64(0x8CC702081A6439EC),
-    UL64(0x90BEFFFA23631E28),  UL64(0xA4506CEBDE82BDE9),
-    UL64(0xBEF9A3F7B2C67915),  UL64(0xC67178F2E372532B),
-    UL64(0xCA273ECEEA26619C),  UL64(0xD186B8C721C0C207),
-    UL64(0xEADA7DD6CDE0EB1E),  UL64(0xF57D4F7FEE6ED178),
-    UL64(0x06F067AA72176FBA),  UL64(0x0A637DC5A2C898A6),
-    UL64(0x113F9804BEF90DAE),  UL64(0x1B710B35131C471B),
-    UL64(0x28DB77F523047D84),  UL64(0x32CAAB7B40C72493),
-    UL64(0x3C9EBE0A15C9BEBC),  UL64(0x431D67C49C100D4C),
-    UL64(0x4CC5D4BECB3E42B6),  UL64(0x597F299CFC657E2A),
-    UL64(0x5FCB6FAB3AD6FAEC),  UL64(0x6C44198C4A475817)
-};
+  const uint64_t *words = buffer;
+  size_t nwords = len / sizeof (uint64_t);
+  uint64_t a = ctx->H[0];
+  uint64_t b = ctx->H[1];
+  uint64_t c = ctx->H[2];
+  uint64_t d = ctx->H[3];
+  uint64_t e = ctx->H[4];
+  uint64_t f = ctx->H[5];
+  uint64_t g = ctx->H[6];
+  uint64_t h = ctx->H[7];
 
-void sha512_init( sha512_context *ctx )
-{
-    memset( ctx, 0, sizeof( sha512_context ) );
-}
+  /* First increment the byte count.  FIPS 180-2 specifies the possible
+     length of the file up to 2^128 bits.  Here we only compute the
+     number of bytes.  Do a double word increment.  */
+  ctx->total[0] += len;
+  if (ctx->total[0] < len)
+    ++ctx->total[1];
 
-void sha512_free( sha512_context *ctx )
-{
-    if( ctx == NULL )
-        return;
-
-    polarssl_zeroize( ctx, sizeof( sha512_context ) );
-}
-
-/*
- * SHA-512 context setup
- */
-void sha512_starts( sha512_context *ctx, int is384 )
-{
-    ctx->total[0] = 0;
-    ctx->total[1] = 0;
-
-    if( is384 == 0 )
+  /* Process all bytes in the buffer with 128 bytes in each round of
+     the loop.  */
+  while (nwords > 0)
     {
-        /* SHA-512 */
-        ctx->state[0] = UL64(0x6A09E667F3BCC908);
-        ctx->state[1] = UL64(0xBB67AE8584CAA73B);
-        ctx->state[2] = UL64(0x3C6EF372FE94F82B);
-        ctx->state[3] = UL64(0xA54FF53A5F1D36F1);
-        ctx->state[4] = UL64(0x510E527FADE682D1);
-        ctx->state[5] = UL64(0x9B05688C2B3E6C1F);
-        ctx->state[6] = UL64(0x1F83D9ABFB41BD6B);
-        ctx->state[7] = UL64(0x5BE0CD19137E2179);
-    }
-    else
-    {
-        /* SHA-384 */
-        ctx->state[0] = UL64(0xCBBB9D5DC1059ED8);
-        ctx->state[1] = UL64(0x629A292A367CD507);
-        ctx->state[2] = UL64(0x9159015A3070DD17);
-        ctx->state[3] = UL64(0x152FECD8F70E5939);
-        ctx->state[4] = UL64(0x67332667FFC00B31);
-        ctx->state[5] = UL64(0x8EB44A8768581511);
-        ctx->state[6] = UL64(0xDB0C2E0D64F98FA7);
-        ctx->state[7] = UL64(0x47B5481DBEFA4FA4);
-    }
+      uint64_t W[80];
+      uint64_t a_save = a;
+      uint64_t b_save = b;
+      uint64_t c_save = c;
+      uint64_t d_save = d;
+      uint64_t e_save = e;
+      uint64_t f_save = f;
+      uint64_t g_save = g;
+      uint64_t h_save = h;
 
-    ctx->is384 = is384;
-}
+      /* Operators defined in FIPS 180-2:4.1.2.  */
+#define Ch(x, y, z) ((x & y) ^ (~x & z))
+#define Maj(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
+#define S0(x) (CYCLIC (x, 28) ^ CYCLIC (x, 34) ^ CYCLIC (x, 39))
+#define S1(x) (CYCLIC (x, 14) ^ CYCLIC (x, 18) ^ CYCLIC (x, 41))
+#define R0(x) (CYCLIC (x, 1) ^ CYCLIC (x, 8) ^ (x >> 7))
+#define R1(x) (CYCLIC (x, 19) ^ CYCLIC (x, 61) ^ (x >> 6))
 
-void sha512_process( sha512_context *ctx, const unsigned char data[128] )
-{
-    int i;
-    uint64_t temp1, temp2, W[80];
-    uint64_t A, B, C, D, E, F, G, H;
+      /* It is unfortunate that C does not provide an operator for
+	 cyclic rotation.  Hope the C compiler is smart enough.  */
+#define CYCLIC(w, s) ((w >> s) | (w << (64 - s)))
 
-#define  SHR(x,n) (x >> n)
-#define ROTR(x,n) (SHR(x,n) | (x << (64 - n)))
+      /* Compute the message schedule according to FIPS 180-2:6.3.2 step 2.  */
+      for (unsigned int t = 0; t < 16; ++t)
+	{
+	  W[t] = SWAP (*words);
+	  ++words;
+	}
+      for (unsigned int t = 16; t < 80; ++t)
+	W[t] = R1 (W[t - 2]) + W[t - 7] + R0 (W[t - 15]) + W[t - 16];
 
-#define S0(x) (ROTR(x, 1) ^ ROTR(x, 8) ^  SHR(x, 7))
-#define S1(x) (ROTR(x,19) ^ ROTR(x,61) ^  SHR(x, 6))
+      /* The actual computation according to FIPS 180-2:6.3.2 step 3.  */
+      for (unsigned int t = 0; t < 80; ++t)
+	{
+	  uint64_t T1 = h + S1 (e) + Ch (e, f, g) + K[t] + W[t];
+	  uint64_t T2 = S0 (a) + Maj (a, b, c);
+	  h = g;
+	  g = f;
+	  f = e;
+	  e = d + T1;
+	  d = c;
+	  c = b;
+	  b = a;
+	  a = T1 + T2;
+	}
 
-#define S2(x) (ROTR(x,28) ^ ROTR(x,34) ^ ROTR(x,39))
-#define S3(x) (ROTR(x,14) ^ ROTR(x,18) ^ ROTR(x,41))
+      /* Add the starting values of the context according to FIPS 180-2:6.3.2
+	 step 4.  */
+      a += a_save;
+      b += b_save;
+      c += c_save;
+      d += d_save;
+      e += e_save;
+      f += f_save;
+      g += g_save;
+      h += h_save;
 
-#define F0(x,y,z) ((x & y) | (z & (x | y)))
-#define F1(x,y,z) (z ^ (x & (y ^ z)))
-
-#define P(a,b,c,d,e,f,g,h,x,K)                  \
-{                                               \
-    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
-    temp2 = S2(a) + F0(a,b,c);                  \
-    d += temp1; h = temp1 + temp2;              \
-}
-
-    for( i = 0; i < 16; i++ )
-    {
-        GET_UINT64_BE( W[i], data, i << 3 );
-    }
-
-    for( ; i < 80; i++ )
-    {
-        W[i] = S1(W[i -  2]) + W[i -  7] +
-               S0(W[i - 15]) + W[i - 16];
-    }
-
-    A = ctx->state[0];
-    B = ctx->state[1];
-    C = ctx->state[2];
-    D = ctx->state[3];
-    E = ctx->state[4];
-    F = ctx->state[5];
-    G = ctx->state[6];
-    H = ctx->state[7];
-    i = 0;
-
-    do
-    {
-        P( A, B, C, D, E, F, G, H, W[i], K[i] ); i++;
-        P( H, A, B, C, D, E, F, G, W[i], K[i] ); i++;
-        P( G, H, A, B, C, D, E, F, W[i], K[i] ); i++;
-        P( F, G, H, A, B, C, D, E, W[i], K[i] ); i++;
-        P( E, F, G, H, A, B, C, D, W[i], K[i] ); i++;
-        P( D, E, F, G, H, A, B, C, W[i], K[i] ); i++;
-        P( C, D, E, F, G, H, A, B, W[i], K[i] ); i++;
-        P( B, C, D, E, F, G, H, A, W[i], K[i] ); i++;
-    }
-    while( i < 80 );
-
-    ctx->state[0] += A;
-    ctx->state[1] += B;
-    ctx->state[2] += C;
-    ctx->state[3] += D;
-    ctx->state[4] += E;
-    ctx->state[5] += F;
-    ctx->state[6] += G;
-    ctx->state[7] += H;
-}
-
-/*
- * SHA-512 process buffer
- */
-void sha512_update( sha512_context *ctx, const unsigned char *input,
-                    size_t ilen )
-{
-    size_t fill;
-    unsigned int left;
-
-    if( ilen == 0 )
-        return;
-
-    left = (unsigned int) (ctx->total[0] & 0x7F);
-    fill = 128 - left;
-
-    ctx->total[0] += (uint64_t) ilen;
-
-    if( ctx->total[0] < (uint64_t) ilen )
-        ctx->total[1]++;
-
-    if( left && ilen >= fill )
-    {
-        memcpy( (void *) (ctx->buffer + left), input, fill );
-        sha512_process( ctx, ctx->buffer );
-        input += fill;
-        ilen  -= fill;
-        left = 0;
+      /* Prepare for the next round.  */
+      nwords -= 16;
     }
 
-    while( ilen >= 128 )
+  /* Put checksum in context given as argument.  */
+  ctx->H[0] = a;
+  ctx->H[1] = b;
+  ctx->H[2] = c;
+  ctx->H[3] = d;
+  ctx->H[4] = e;
+  ctx->H[5] = f;
+  ctx->H[6] = g;
+  ctx->H[7] = h;
+}
+
+
+/* Initialize structure containing state of computation.
+   (FIPS 180-2:5.3.3)  */
+void
+sha512_init_ctx (struct sha512_ctx *ctx)
+{
+  ctx->H[0] = UINT64_C (0x6a09e667f3bcc908);
+  ctx->H[1] = UINT64_C (0xbb67ae8584caa73b);
+  ctx->H[2] = UINT64_C (0x3c6ef372fe94f82b);
+  ctx->H[3] = UINT64_C (0xa54ff53a5f1d36f1);
+  ctx->H[4] = UINT64_C (0x510e527fade682d1);
+  ctx->H[5] = UINT64_C (0x9b05688c2b3e6c1f);
+  ctx->H[6] = UINT64_C (0x1f83d9abfb41bd6b);
+  ctx->H[7] = UINT64_C (0x5be0cd19137e2179);
+
+  ctx->total[0] = ctx->total[1] = 0;
+  ctx->buflen = 0;
+}
+
+
+/* Process the remaining bytes in the internal buffer and the usual
+   prolog according to the standard and write the result to RESBUF.
+
+   IMPORTANT: On some systems it is required that RESBUF is correctly
+   aligned for a 32 bits value.  */
+void *
+sha512_finish_ctx (struct sha512_ctx *ctx, void *resbuf)
+{
+  /* Take yet unprocessed bytes into account.  */
+  uint64_t bytes = ctx->buflen;
+  size_t pad;
+
+  /* Now count remaining bytes.  */
+  ctx->total[0] += bytes;
+  if (ctx->total[0] < bytes)
+    ++ctx->total[1];
+
+  pad = bytes >= 112 ? 128 + 112 - bytes : 112 - bytes;
+  memcpy (&ctx->buffer[bytes], fillbuf, pad);
+
+  /* Put the 128-bit file length in *bits* at the end of the buffer.  */
+  *(uint64_t *) &ctx->buffer[bytes + pad + 8] = SWAP (ctx->total[0] << 3);
+  *(uint64_t *) &ctx->buffer[bytes + pad] = SWAP ((ctx->total[1] << 3) |
+						  (ctx->total[0] >> 61));
+
+  /* Process last bytes.  */
+  sha512_process_block (ctx->buffer, bytes + pad + 16, ctx);
+
+  /* Put result from CTX in first 64 bytes following RESBUF.  */
+  for (unsigned int i = 0; i < 8; ++i)
+    ((uint64_t *) resbuf)[i] = SWAP (ctx->H[i]);
+
+  return resbuf;
+}
+
+
+void
+sha512_process_bytes (const void *buffer, size_t len, struct sha512_ctx *ctx)
+{
+  /* When we already have some bits in our internal buffer concatenate
+     both inputs first.  */
+  if (ctx->buflen != 0)
     {
-        sha512_process( ctx, input );
-        input += 128;
-        ilen  -= 128;
+      size_t left_over = ctx->buflen;
+      size_t add = 256 - left_over > len ? len : 256 - left_over;
+
+      memcpy (&ctx->buffer[left_over], buffer, add);
+      ctx->buflen += add;
+
+      if (ctx->buflen > 128)
+	{
+	  sha512_process_block (ctx->buffer, ctx->buflen & ~127, ctx);
+
+	  ctx->buflen &= 127;
+	  /* The regions in the following copy operation cannot overlap.  */
+	  memcpy (ctx->buffer, &ctx->buffer[(left_over + add) & ~127],
+		  ctx->buflen);
+	}
+
+      buffer = (const char *) buffer + add;
+      len -= add;
     }
 
-    if( ilen > 0 )
-        memcpy( (void *) (ctx->buffer + left), input, ilen );
-}
-
-static const unsigned char sha512_padding[128] =
-{
- 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-};
-
-/*
- * SHA-512 final digest
- */
-void sha512_finish( sha512_context *ctx, unsigned char output[64] )
-{
-    size_t last, padn;
-    uint64_t high, low;
-    unsigned char msglen[16];
-
-    high = ( ctx->total[0] >> 61 )
-         | ( ctx->total[1] <<  3 );
-    low  = ( ctx->total[0] <<  3 );
-
-    PUT_UINT64_BE( high, msglen, 0 );
-    PUT_UINT64_BE( low,  msglen, 8 );
-
-    last = (size_t)( ctx->total[0] & 0x7F );
-    padn = ( last < 112 ) ? ( 112 - last ) : ( 240 - last );
-
-    sha512_update( ctx, sha512_padding, padn );
-    sha512_update( ctx, msglen, 16 );
-
-    PUT_UINT64_BE( ctx->state[0], output,  0 );
-    PUT_UINT64_BE( ctx->state[1], output,  8 );
-    PUT_UINT64_BE( ctx->state[2], output, 16 );
-    PUT_UINT64_BE( ctx->state[3], output, 24 );
-    PUT_UINT64_BE( ctx->state[4], output, 32 );
-    PUT_UINT64_BE( ctx->state[5], output, 40 );
-
-    if( ctx->is384 == 0 )
+  /* Process available complete blocks.  */
+  if (len >= 128)
     {
-        PUT_UINT64_BE( ctx->state[6], output, 48 );
-        PUT_UINT64_BE( ctx->state[7], output, 56 );
+#if !_STRING_ARCH_unaligned
+/* To check alignment gcc has an appropriate operator.  Other
+   compilers don't.  */
+# if __GNUC__ >= 2
+#  define UNALIGNED_P(p) (((uintptr_t) p) % __alignof__ (uint64_t) != 0)
+# else
+#  define UNALIGNED_P(p) (((uintptr_t) p) % sizeof (uint64_t) != 0)
+# endif
+      if (UNALIGNED_P (buffer))
+	while (len > 128)
+	  {
+	    sha512_process_block (memcpy (ctx->buffer, buffer, 128), 128,
+				    ctx);
+	    buffer = (const char *) buffer + 128;
+	    len -= 128;
+	  }
+      else
+#endif
+	{
+	  sha512_process_block (buffer, len & ~127, ctx);
+	  buffer = (const char *) buffer + (len & ~127);
+	  len &= 127;
+	}
+    }
+
+  /* Move remaining bytes into internal buffer.  */
+  if (len > 0)
+    {
+      size_t left_over = ctx->buflen;
+
+      memcpy (&ctx->buffer[left_over], buffer, len);
+      left_over += len;
+      if (left_over >= 128)
+	{
+	  sha512_process_block (ctx->buffer, 128, ctx);
+	  left_over -= 128;
+	  memcpy (ctx->buffer, &ctx->buffer[128], left_over);
+	}
+      ctx->buflen = left_over;
     }
 }
 
-/*
- * output = SHA-512( input buffer )
- */
-void sha512( const unsigned char *input, size_t ilen,
-             unsigned char output[64], int is384 )
+#ifdef TEST
+
+#include <stdio.h>
+
+static const struct
 {
-    sha512_context ctx;
-
-    sha512_init( &ctx );
-    sha512_starts( &ctx, is384 );
-    sha512_update( &ctx, input, ilen );
-    sha512_finish( &ctx, output );
-    sha512_free( &ctx );
-}
-
-/*
- * SHA-512 HMAC context setup
- */
-void sha512_hmac_starts( sha512_context *ctx, const unsigned char *key,
-                         size_t keylen, int is384 )
-{
-    size_t i;
-    unsigned char sum[64];
-
-    if( keylen > 128 )
-    {
-        sha512( key, keylen, sum, is384 );
-        keylen = ( is384 ) ? 48 : 64;
-        key = sum;
-    }
-
-    memset( ctx->ipad, 0x36, 128 );
-    memset( ctx->opad, 0x5C, 128 );
-
-    for( i = 0; i < keylen; i++ )
-    {
-        ctx->ipad[i] = (unsigned char)( ctx->ipad[i] ^ key[i] );
-        ctx->opad[i] = (unsigned char)( ctx->opad[i] ^ key[i] );
-    }
-
-    sha512_starts( ctx, is384 );
-    sha512_update( ctx, ctx->ipad, 128 );
-
-    polarssl_zeroize( sum, sizeof( sum ) );
-}
-
-/*
- * SHA-512 HMAC process buffer
- */
-void sha512_hmac_update( sha512_context  *ctx,
-                         const unsigned char *input, size_t ilen )
-{
-    sha512_update( ctx, input, ilen );
-}
-
-/*
- * SHA-512 HMAC final digest
- */
-void sha512_hmac_finish( sha512_context *ctx, unsigned char output[64] )
-{
-    int is384, hlen;
-    unsigned char tmpbuf[64];
-
-    is384 = ctx->is384;
-    hlen = ( is384 == 0 ) ? 64 : 48;
-
-    sha512_finish( ctx, tmpbuf );
-    sha512_starts( ctx, is384 );
-    sha512_update( ctx, ctx->opad, 128 );
-    sha512_update( ctx, tmpbuf, hlen );
-    sha512_finish( ctx, output );
-
-    polarssl_zeroize( tmpbuf, sizeof( tmpbuf ) );
-}
-
-/*
- * SHA-512 HMAC context reset
- */
-void sha512_hmac_reset( sha512_context *ctx )
-{
-    sha512_starts( ctx, ctx->is384 );
-    sha512_update( ctx, ctx->ipad, 128 );
-}
-
-/*
- * output = HMAC-SHA-512( hmac key, input buffer )
- */
-void sha512_hmac( const unsigned char *key, size_t keylen,
-                const unsigned char *input, size_t ilen,
-                unsigned char output[64], int is384 )
-{
-    sha512_context ctx;
-
-    sha512_init( &ctx );
-    sha512_hmac_starts( &ctx, key, keylen, is384 );
-    sha512_hmac_update( &ctx, input, ilen );
-    sha512_hmac_finish( &ctx, output );
-    sha512_free( &ctx );
-}
-
-#if defined(POLARSSL_SELF_TEST) 
-
-/*
- * FIPS-180-2 test vectors
- */
-static unsigned char sha512_test_buf[3][113] =
-{
-    { "abc" },
+  const char *input;
+  const char result[64];
+} tests[] =
+  {
+    /* Test vectors from FIPS 180-2: appendix C.1.  */
+    { "abc",
+      "\xdd\xaf\x35\xa1\x93\x61\x7a\xba\xcc\x41\x73\x49\xae\x20\x41\x31"
+      "\x12\xe6\xfa\x4e\x89\xa9\x7e\xa2\x0a\x9e\xee\xe6\x4b\x55\xd3\x9a"
+      "\x21\x92\x99\x2a\x27\x4f\xc1\xa8\x36\xba\x3c\x23\xa3\xfe\xeb\xbd"
+      "\x45\x4d\x44\x23\x64\x3c\xe8\x0e\x2a\x9a\xc9\x4f\xa5\x4c\xa4\x9f" },
+    /* Test vectors from FIPS 180-2: appendix C.2.  */
     { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
-      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
-    { "" }
-};
+      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+      "\x8e\x95\x9b\x75\xda\xe3\x13\xda\x8c\xf4\xf7\x28\x14\xfc\x14\x3f"
+      "\x8f\x77\x79\xc6\xeb\x9f\x7f\xa1\x72\x99\xae\xad\xb6\x88\x90\x18"
+      "\x50\x1d\x28\x9e\x49\x00\xf7\xe4\x33\x1b\x99\xde\xc4\xb5\x43\x3a"
+      "\xc7\xd3\x29\xee\xb6\xdd\x26\x54\x5e\x96\xe5\x5b\x87\x4b\xe9\x09" },
+    /* Test vectors from the NESSIE project.  */
+    { "",
+      "\xcf\x83\xe1\x35\x7e\xef\xb8\xbd\xf1\x54\x28\x50\xd6\x6d\x80\x07"
+      "\xd6\x20\xe4\x05\x0b\x57\x15\xdc\x83\xf4\xa9\x21\xd3\x6c\xe9\xce"
+      "\x47\xd0\xd1\x3c\x5d\x85\xf2\xb0\xff\x83\x18\xd2\x87\x7e\xec\x2f"
+      "\x63\xb9\x31\xbd\x47\x41\x7a\x81\xa5\x38\x32\x7a\xf9\x27\xda\x3e" },
+    { "a",
+      "\x1f\x40\xfc\x92\xda\x24\x16\x94\x75\x09\x79\xee\x6c\xf5\x82\xf2"
+      "\xd5\xd7\xd2\x8e\x18\x33\x5d\xe0\x5a\xbc\x54\xd0\x56\x0e\x0f\x53"
+      "\x02\x86\x0c\x65\x2b\xf0\x8d\x56\x02\x52\xaa\x5e\x74\x21\x05\x46"
+      "\xf3\x69\xfb\xbb\xce\x8c\x12\xcf\xc7\x95\x7b\x26\x52\xfe\x9a\x75" },
+    { "message digest",
+      "\x10\x7d\xbf\x38\x9d\x9e\x9f\x71\xa3\xa9\x5f\x6c\x05\x5b\x92\x51"
+      "\xbc\x52\x68\xc2\xbe\x16\xd6\xc1\x34\x92\xea\x45\xb0\x19\x9f\x33"
+      "\x09\xe1\x64\x55\xab\x1e\x96\x11\x8e\x8a\x90\x5d\x55\x97\xb7\x20"
+      "\x38\xdd\xb3\x72\xa8\x98\x26\x04\x6d\xe6\x66\x87\xbb\x42\x0e\x7c" },
+    { "abcdefghijklmnopqrstuvwxyz",
+      "\x4d\xbf\xf8\x6c\xc2\xca\x1b\xae\x1e\x16\x46\x8a\x05\xcb\x98\x81"
+      "\xc9\x7f\x17\x53\xbc\xe3\x61\x90\x34\x89\x8f\xaa\x1a\xab\xe4\x29"
+      "\x95\x5a\x1b\xf8\xec\x48\x3d\x74\x21\xfe\x3c\x16\x46\x61\x3a\x59"
+      "\xed\x54\x41\xfb\x0f\x32\x13\x89\xf7\x7f\x48\xa8\x79\xc7\xb1\xf1" },
+    { "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+      "\x20\x4a\x8f\xc6\xdd\xa8\x2f\x0a\x0c\xed\x7b\xeb\x8e\x08\xa4\x16"
+      "\x57\xc1\x6e\xf4\x68\xb2\x28\xa8\x27\x9b\xe3\x31\xa7\x03\xc3\x35"
+      "\x96\xfd\x15\xc1\x3b\x1b\x07\xf9\xaa\x1d\x3b\xea\x57\x78\x9c\xa0"
+      "\x31\xad\x85\xc7\xa7\x1d\xd7\x03\x54\xec\x63\x12\x38\xca\x34\x45" },
+    { "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+      "\x1e\x07\xbe\x23\xc2\x6a\x86\xea\x37\xea\x81\x0c\x8e\xc7\x80\x93"
+      "\x52\x51\x5a\x97\x0e\x92\x53\xc2\x6f\x53\x6c\xfc\x7a\x99\x96\xc4"
+      "\x5c\x83\x70\x58\x3e\x0a\x78\xfa\x4a\x90\x04\x1d\x71\xa4\xce\xab"
+      "\x74\x23\xf1\x9c\x71\xb9\xd5\xa3\xe0\x12\x49\xf0\xbe\xbd\x58\x94" },
+    { "123456789012345678901234567890123456789012345678901234567890"
+      "12345678901234567890",
+      "\x72\xec\x1e\xf1\x12\x4a\x45\xb0\x47\xe8\xb7\xc7\x5a\x93\x21\x95"
+      "\x13\x5b\xb6\x1d\xe2\x4e\xc0\xd1\x91\x40\x42\x24\x6e\x0a\xec\x3a"
+      "\x23\x54\xe0\x93\xd7\x6f\x30\x48\xb4\x56\x76\x43\x46\x90\x0c\xb1"
+      "\x30\xd2\xa4\xfd\x5d\xd1\x6a\xbb\x5e\x30\xbc\xb8\x50\xde\xe8\x43" }
+  };
+#define ntests (sizeof (tests) / sizeof (tests[0]))
 
-static const int sha512_test_buflen[3] =
+
+int
+main (void)
 {
-    3, 112, 1000
-};
+  struct sha512_ctx ctx;
+  char sum[64];
+  int result = 0;
+  int cnt;
 
-static const unsigned char sha512_test_sum[6][64] =
-{
-    /*
-     * SHA-384 test vectors
-     */
-    { 0xCB, 0x00, 0x75, 0x3F, 0x45, 0xA3, 0x5E, 0x8B,
-      0xB5, 0xA0, 0x3D, 0x69, 0x9A, 0xC6, 0x50, 0x07,
-      0x27, 0x2C, 0x32, 0xAB, 0x0E, 0xDE, 0xD1, 0x63,
-      0x1A, 0x8B, 0x60, 0x5A, 0x43, 0xFF, 0x5B, 0xED,
-      0x80, 0x86, 0x07, 0x2B, 0xA1, 0xE7, 0xCC, 0x23,
-      0x58, 0xBA, 0xEC, 0xA1, 0x34, 0xC8, 0x25, 0xA7 },
-    { 0x09, 0x33, 0x0C, 0x33, 0xF7, 0x11, 0x47, 0xE8,
-      0x3D, 0x19, 0x2F, 0xC7, 0x82, 0xCD, 0x1B, 0x47,
-      0x53, 0x11, 0x1B, 0x17, 0x3B, 0x3B, 0x05, 0xD2,
-      0x2F, 0xA0, 0x80, 0x86, 0xE3, 0xB0, 0xF7, 0x12,
-      0xFC, 0xC7, 0xC7, 0x1A, 0x55, 0x7E, 0x2D, 0xB9,
-      0x66, 0xC3, 0xE9, 0xFA, 0x91, 0x74, 0x60, 0x39 },
-    { 0x9D, 0x0E, 0x18, 0x09, 0x71, 0x64, 0x74, 0xCB,
-      0x08, 0x6E, 0x83, 0x4E, 0x31, 0x0A, 0x4A, 0x1C,
-      0xED, 0x14, 0x9E, 0x9C, 0x00, 0xF2, 0x48, 0x52,
-      0x79, 0x72, 0xCE, 0xC5, 0x70, 0x4C, 0x2A, 0x5B,
-      0x07, 0xB8, 0xB3, 0xDC, 0x38, 0xEC, 0xC4, 0xEB,
-      0xAE, 0x97, 0xDD, 0xD8, 0x7F, 0x3D, 0x89, 0x85 },
-
-    /*
-     * SHA-512 test vectors
-     */
-    { 0xDD, 0xAF, 0x35, 0xA1, 0x93, 0x61, 0x7A, 0xBA,
-      0xCC, 0x41, 0x73, 0x49, 0xAE, 0x20, 0x41, 0x31,
-      0x12, 0xE6, 0xFA, 0x4E, 0x89, 0xA9, 0x7E, 0xA2,
-      0x0A, 0x9E, 0xEE, 0xE6, 0x4B, 0x55, 0xD3, 0x9A,
-      0x21, 0x92, 0x99, 0x2A, 0x27, 0x4F, 0xC1, 0xA8,
-      0x36, 0xBA, 0x3C, 0x23, 0xA3, 0xFE, 0xEB, 0xBD,
-      0x45, 0x4D, 0x44, 0x23, 0x64, 0x3C, 0xE8, 0x0E,
-      0x2A, 0x9A, 0xC9, 0x4F, 0xA5, 0x4C, 0xA4, 0x9F },
-    { 0x8E, 0x95, 0x9B, 0x75, 0xDA, 0xE3, 0x13, 0xDA,
-      0x8C, 0xF4, 0xF7, 0x28, 0x14, 0xFC, 0x14, 0x3F,
-      0x8F, 0x77, 0x79, 0xC6, 0xEB, 0x9F, 0x7F, 0xA1,
-      0x72, 0x99, 0xAE, 0xAD, 0xB6, 0x88, 0x90, 0x18,
-      0x50, 0x1D, 0x28, 0x9E, 0x49, 0x00, 0xF7, 0xE4,
-      0x33, 0x1B, 0x99, 0xDE, 0xC4, 0xB5, 0x43, 0x3A,
-      0xC7, 0xD3, 0x29, 0xEE, 0xB6, 0xDD, 0x26, 0x54,
-      0x5E, 0x96, 0xE5, 0x5B, 0x87, 0x4B, 0xE9, 0x09 },
-    { 0xE7, 0x18, 0x48, 0x3D, 0x0C, 0xE7, 0x69, 0x64,
-      0x4E, 0x2E, 0x42, 0xC7, 0xBC, 0x15, 0xB4, 0x63,
-      0x8E, 0x1F, 0x98, 0xB1, 0x3B, 0x20, 0x44, 0x28,
-      0x56, 0x32, 0xA8, 0x03, 0xAF, 0xA9, 0x73, 0xEB,
-      0xDE, 0x0F, 0xF2, 0x44, 0x87, 0x7E, 0xA6, 0x0A,
-      0x4C, 0xB0, 0x43, 0x2C, 0xE5, 0x77, 0xC3, 0x1B,
-      0xEB, 0x00, 0x9C, 0x5C, 0x2C, 0x49, 0xAA, 0x2E,
-      0x4E, 0xAD, 0xB2, 0x17, 0xAD, 0x8C, 0xC0, 0x9B }
-};
-
-/*
- * RFC 4231 test vectors
- */
-static unsigned char sha512_hmac_test_key[7][26] =
-{
-    { "\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B"
-      "\x0B\x0B\x0B\x0B" },
-    { "Jefe" },
-    { "\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA"
-      "\xAA\xAA\xAA\xAA" },
-    { "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10"
-      "\x11\x12\x13\x14\x15\x16\x17\x18\x19" },
-    { "\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C"
-      "\x0C\x0C\x0C\x0C" },
-    { "" }, /* 0xAA 131 times */
-    { "" }
-};
-
-static const int sha512_hmac_test_keylen[7] =
-{
-    20, 4, 20, 25, 20, 131, 131
-};
-
-static unsigned char sha512_hmac_test_buf[7][153] =
-{
-    { "Hi There" },
-    { "what do ya want for nothing?" },
-    { "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
-      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
-      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
-      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
-      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD" },
-    { "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
-      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
-      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
-      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
-      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD" },
-    { "Test With Truncation" },
-    { "Test Using Larger Than Block-Size Key - Hash Key First" },
-    { "This is a test using a larger than block-size key "
-      "and a larger than block-size data. The key needs to "
-      "be hashed before being used by the HMAC algorithm." }
-};
-
-static const int sha512_hmac_test_buflen[7] =
-{
-    8, 28, 50, 50, 20, 54, 152
-};
-
-static const unsigned char sha512_hmac_test_sum[14][64] =
-{
-    /*
-     * HMAC-SHA-384 test vectors
-     */
-    { 0xAF, 0xD0, 0x39, 0x44, 0xD8, 0x48, 0x95, 0x62,
-      0x6B, 0x08, 0x25, 0xF4, 0xAB, 0x46, 0x90, 0x7F,
-      0x15, 0xF9, 0xDA, 0xDB, 0xE4, 0x10, 0x1E, 0xC6,
-      0x82, 0xAA, 0x03, 0x4C, 0x7C, 0xEB, 0xC5, 0x9C,
-      0xFA, 0xEA, 0x9E, 0xA9, 0x07, 0x6E, 0xDE, 0x7F,
-      0x4A, 0xF1, 0x52, 0xE8, 0xB2, 0xFA, 0x9C, 0xB6 },
-    { 0xAF, 0x45, 0xD2, 0xE3, 0x76, 0x48, 0x40, 0x31,
-      0x61, 0x7F, 0x78, 0xD2, 0xB5, 0x8A, 0x6B, 0x1B,
-      0x9C, 0x7E, 0xF4, 0x64, 0xF5, 0xA0, 0x1B, 0x47,
-      0xE4, 0x2E, 0xC3, 0x73, 0x63, 0x22, 0x44, 0x5E,
-      0x8E, 0x22, 0x40, 0xCA, 0x5E, 0x69, 0xE2, 0xC7,
-      0x8B, 0x32, 0x39, 0xEC, 0xFA, 0xB2, 0x16, 0x49 },
-    { 0x88, 0x06, 0x26, 0x08, 0xD3, 0xE6, 0xAD, 0x8A,
-      0x0A, 0xA2, 0xAC, 0xE0, 0x14, 0xC8, 0xA8, 0x6F,
-      0x0A, 0xA6, 0x35, 0xD9, 0x47, 0xAC, 0x9F, 0xEB,
-      0xE8, 0x3E, 0xF4, 0xE5, 0x59, 0x66, 0x14, 0x4B,
-      0x2A, 0x5A, 0xB3, 0x9D, 0xC1, 0x38, 0x14, 0xB9,
-      0x4E, 0x3A, 0xB6, 0xE1, 0x01, 0xA3, 0x4F, 0x27 },
-    { 0x3E, 0x8A, 0x69, 0xB7, 0x78, 0x3C, 0x25, 0x85,
-      0x19, 0x33, 0xAB, 0x62, 0x90, 0xAF, 0x6C, 0xA7,
-      0x7A, 0x99, 0x81, 0x48, 0x08, 0x50, 0x00, 0x9C,
-      0xC5, 0x57, 0x7C, 0x6E, 0x1F, 0x57, 0x3B, 0x4E,
-      0x68, 0x01, 0xDD, 0x23, 0xC4, 0xA7, 0xD6, 0x79,
-      0xCC, 0xF8, 0xA3, 0x86, 0xC6, 0x74, 0xCF, 0xFB },
-    { 0x3A, 0xBF, 0x34, 0xC3, 0x50, 0x3B, 0x2A, 0x23,
-      0xA4, 0x6E, 0xFC, 0x61, 0x9B, 0xAE, 0xF8, 0x97 },
-    { 0x4E, 0xCE, 0x08, 0x44, 0x85, 0x81, 0x3E, 0x90,
-      0x88, 0xD2, 0xC6, 0x3A, 0x04, 0x1B, 0xC5, 0xB4,
-      0x4F, 0x9E, 0xF1, 0x01, 0x2A, 0x2B, 0x58, 0x8F,
-      0x3C, 0xD1, 0x1F, 0x05, 0x03, 0x3A, 0xC4, 0xC6,
-      0x0C, 0x2E, 0xF6, 0xAB, 0x40, 0x30, 0xFE, 0x82,
-      0x96, 0x24, 0x8D, 0xF1, 0x63, 0xF4, 0x49, 0x52 },
-    { 0x66, 0x17, 0x17, 0x8E, 0x94, 0x1F, 0x02, 0x0D,
-      0x35, 0x1E, 0x2F, 0x25, 0x4E, 0x8F, 0xD3, 0x2C,
-      0x60, 0x24, 0x20, 0xFE, 0xB0, 0xB8, 0xFB, 0x9A,
-      0xDC, 0xCE, 0xBB, 0x82, 0x46, 0x1E, 0x99, 0xC5,
-      0xA6, 0x78, 0xCC, 0x31, 0xE7, 0x99, 0x17, 0x6D,
-      0x38, 0x60, 0xE6, 0x11, 0x0C, 0x46, 0x52, 0x3E },
-
-    /*
-     * HMAC-SHA-512 test vectors
-     */
-    { 0x87, 0xAA, 0x7C, 0xDE, 0xA5, 0xEF, 0x61, 0x9D,
-      0x4F, 0xF0, 0xB4, 0x24, 0x1A, 0x1D, 0x6C, 0xB0,
-      0x23, 0x79, 0xF4, 0xE2, 0xCE, 0x4E, 0xC2, 0x78,
-      0x7A, 0xD0, 0xB3, 0x05, 0x45, 0xE1, 0x7C, 0xDE,
-      0xDA, 0xA8, 0x33, 0xB7, 0xD6, 0xB8, 0xA7, 0x02,
-      0x03, 0x8B, 0x27, 0x4E, 0xAE, 0xA3, 0xF4, 0xE4,
-      0xBE, 0x9D, 0x91, 0x4E, 0xEB, 0x61, 0xF1, 0x70,
-      0x2E, 0x69, 0x6C, 0x20, 0x3A, 0x12, 0x68, 0x54 },
-    { 0x16, 0x4B, 0x7A, 0x7B, 0xFC, 0xF8, 0x19, 0xE2,
-      0xE3, 0x95, 0xFB, 0xE7, 0x3B, 0x56, 0xE0, 0xA3,
-      0x87, 0xBD, 0x64, 0x22, 0x2E, 0x83, 0x1F, 0xD6,
-      0x10, 0x27, 0x0C, 0xD7, 0xEA, 0x25, 0x05, 0x54,
-      0x97, 0x58, 0xBF, 0x75, 0xC0, 0x5A, 0x99, 0x4A,
-      0x6D, 0x03, 0x4F, 0x65, 0xF8, 0xF0, 0xE6, 0xFD,
-      0xCA, 0xEA, 0xB1, 0xA3, 0x4D, 0x4A, 0x6B, 0x4B,
-      0x63, 0x6E, 0x07, 0x0A, 0x38, 0xBC, 0xE7, 0x37 },
-    { 0xFA, 0x73, 0xB0, 0x08, 0x9D, 0x56, 0xA2, 0x84,
-      0xEF, 0xB0, 0xF0, 0x75, 0x6C, 0x89, 0x0B, 0xE9,
-      0xB1, 0xB5, 0xDB, 0xDD, 0x8E, 0xE8, 0x1A, 0x36,
-      0x55, 0xF8, 0x3E, 0x33, 0xB2, 0x27, 0x9D, 0x39,
-      0xBF, 0x3E, 0x84, 0x82, 0x79, 0xA7, 0x22, 0xC8,
-      0x06, 0xB4, 0x85, 0xA4, 0x7E, 0x67, 0xC8, 0x07,
-      0xB9, 0x46, 0xA3, 0x37, 0xBE, 0xE8, 0x94, 0x26,
-      0x74, 0x27, 0x88, 0x59, 0xE1, 0x32, 0x92, 0xFB },
-    { 0xB0, 0xBA, 0x46, 0x56, 0x37, 0x45, 0x8C, 0x69,
-      0x90, 0xE5, 0xA8, 0xC5, 0xF6, 0x1D, 0x4A, 0xF7,
-      0xE5, 0x76, 0xD9, 0x7F, 0xF9, 0x4B, 0x87, 0x2D,
-      0xE7, 0x6F, 0x80, 0x50, 0x36, 0x1E, 0xE3, 0xDB,
-      0xA9, 0x1C, 0xA5, 0xC1, 0x1A, 0xA2, 0x5E, 0xB4,
-      0xD6, 0x79, 0x27, 0x5C, 0xC5, 0x78, 0x80, 0x63,
-      0xA5, 0xF1, 0x97, 0x41, 0x12, 0x0C, 0x4F, 0x2D,
-      0xE2, 0xAD, 0xEB, 0xEB, 0x10, 0xA2, 0x98, 0xDD },
-    { 0x41, 0x5F, 0xAD, 0x62, 0x71, 0x58, 0x0A, 0x53,
-      0x1D, 0x41, 0x79, 0xBC, 0x89, 0x1D, 0x87, 0xA6 },
-    { 0x80, 0xB2, 0x42, 0x63, 0xC7, 0xC1, 0xA3, 0xEB,
-      0xB7, 0x14, 0x93, 0xC1, 0xDD, 0x7B, 0xE8, 0xB4,
-      0x9B, 0x46, 0xD1, 0xF4, 0x1B, 0x4A, 0xEE, 0xC1,
-      0x12, 0x1B, 0x01, 0x37, 0x83, 0xF8, 0xF3, 0x52,
-      0x6B, 0x56, 0xD0, 0x37, 0xE0, 0x5F, 0x25, 0x98,
-      0xBD, 0x0F, 0xD2, 0x21, 0x5D, 0x6A, 0x1E, 0x52,
-      0x95, 0xE6, 0x4F, 0x73, 0xF6, 0x3F, 0x0A, 0xEC,
-      0x8B, 0x91, 0x5A, 0x98, 0x5D, 0x78, 0x65, 0x98 },
-    { 0xE3, 0x7B, 0x6A, 0x77, 0x5D, 0xC8, 0x7D, 0xBA,
-      0xA4, 0xDF, 0xA9, 0xF9, 0x6E, 0x5E, 0x3F, 0xFD,
-      0xDE, 0xBD, 0x71, 0xF8, 0x86, 0x72, 0x89, 0x86,
-      0x5D, 0xF5, 0xA3, 0x2D, 0x20, 0xCD, 0xC9, 0x44,
-      0xB6, 0x02, 0x2C, 0xAC, 0x3C, 0x49, 0x82, 0xB1,
-      0x0D, 0x5E, 0xEB, 0x55, 0xC3, 0xE4, 0xDE, 0x15,
-      0x13, 0x46, 0x76, 0xFB, 0x6D, 0xE0, 0x44, 0x60,
-      0x65, 0xC9, 0x74, 0x40, 0xFA, 0x8C, 0x6A, 0x58 }
-};
-
-/*
- * Checkup routine
- */
-int sha512_self_test( int verbose )
-{
-    int i, j, k, buflen, ret = 0;
-    unsigned char buf[1024];
-    unsigned char sha512sum[64];
-    sha512_context ctx;
-
-    sha512_init( &ctx );
-
-    for( i = 0; i < 6; i++ )
+  for (cnt = 0; cnt < (int) ntests; ++cnt)
     {
-        j = i % 3;
-        k = i < 3;
+      sha512_init_ctx (&ctx);
+      sha512_process_bytes (tests[cnt].input, strlen (tests[cnt].input), &ctx);
+      sha512_finish_ctx (&ctx, sum);
+      if (memcmp (tests[cnt].result, sum, 64) != 0)
+	{
+	  printf ("test %d run %d failed\n", cnt, 1);
+	  result = 1;
+	}
 
-        if( verbose != 0 )
-            printf( "  SHA-%d test #%d: ", 512 - k * 128, j + 1 );
-
-        sha512_starts( &ctx, k );
-
-        if( j == 2 )
-        {
-            memset( buf, 'a', buflen = 1000 );
-
-            for( j = 0; j < 1000; j++ )
-                sha512_update( &ctx, buf, buflen );
-        }
-        else
-            sha512_update( &ctx, sha512_test_buf[j],
-                                 sha512_test_buflen[j] );
-
-        sha512_finish( &ctx, sha512sum );
-
-        if( memcmp( sha512sum, sha512_test_sum[i], 64 - k * 16 ) != 0 )
-        {
-            if( verbose != 0 )
-                printf( "failed\n" );
-
-            ret = 1;
-            goto exit;
-        }
-
-        if( verbose != 0 )
-            printf( "passed\n" );
+      sha512_init_ctx (&ctx);
+      for (int i = 0; tests[cnt].input[i] != '\0'; ++i)
+	sha512_process_bytes (&tests[cnt].input[i], 1, &ctx);
+      sha512_finish_ctx (&ctx, sum);
+      if (memcmp (tests[cnt].result, sum, 64) != 0)
+	{
+	  printf ("test %d run %d failed\n", cnt, 2);
+	  result = 1;
+	}
     }
 
-    if( verbose != 0 )
-        printf( "\n" );
-
-    for( i = 0; i < 14; i++ )
+  /* Test vector from FIPS 180-2: appendix C.3.  */
+  char buf[1000];
+  memset (buf, 'a', sizeof (buf));
+  sha512_init_ctx (&ctx);
+  for (int i = 0; i < 1000; ++i)
+    sha512_process_bytes (buf, sizeof (buf), &ctx);
+  sha512_finish_ctx (&ctx, sum);
+  static const char expected[64] =
+    "\xe7\x18\x48\x3d\x0c\xe7\x69\x64\x4e\x2e\x42\xc7\xbc\x15\xb4\x63"
+    "\x8e\x1f\x98\xb1\x3b\x20\x44\x28\x56\x32\xa8\x03\xaf\xa9\x73\xeb"
+    "\xde\x0f\xf2\x44\x87\x7e\xa6\x0a\x4c\xb0\x43\x2c\xe5\x77\xc3\x1b"
+    "\xeb\x00\x9c\x5c\x2c\x49\xaa\x2e\x4e\xad\xb2\x17\xad\x8c\xc0\x9b";
+  if (memcmp (expected, sum, 64) != 0)
     {
-        j = i % 7;
-        k = i < 7;
-
-        if( verbose != 0 )
-            printf( "  HMAC-SHA-%d test #%d: ", 512 - k * 128, j + 1 );
-
-        if( j == 5 || j == 6 )
-        {
-            memset( buf, '\xAA', buflen = 131 );
-            sha512_hmac_starts( &ctx, buf, buflen, k );
-        }
-        else
-            sha512_hmac_starts( &ctx, sha512_hmac_test_key[j],
-                                      sha512_hmac_test_keylen[j], k );
-
-        sha512_hmac_update( &ctx, sha512_hmac_test_buf[j],
-                                  sha512_hmac_test_buflen[j] );
-
-        sha512_hmac_finish( &ctx, sha512sum );
-
-        buflen = ( j == 4 ) ? 16 : 64 - k * 16;
-
-        if( memcmp( sha512sum, sha512_hmac_test_sum[i], buflen ) != 0 )
-        {
-            if( verbose != 0 )
-                printf( "failed\n" );
-
-            ret = 1;
-            goto exit;
-        }
-
-        if( verbose != 0 )
-            printf( "passed\n" );
+      printf ("test %d failed\n", cnt);
+      result = 1;
     }
 
-    if( verbose != 0 )
-        printf( "\n" );
+  if (result == 0)
+    puts ("all tests OK");
 
-exit:
-    sha512_free( &ctx );
-
-    return( ret );
+  return result;
 }
-
-int main() {
-	return sha512_self_test(1);
-}	
-
-#endif /* POLARSSL_SELF_TEST */
-
+#endif

--- a/src/c/sha512.c
+++ b/src/c/sha512.c
@@ -1,0 +1,747 @@
+/*
+ *  FIPS-180-2 compliant SHA-384/512 implementation
+ *
+ *  Copyright (C) 2006-2014, Brainspark B.V.
+ *
+ *  This file is part of PolarSSL (http://www.polarssl.org)
+ *  Lead Maintainer: Paul Bakker <polarssl_maintainer at polarssl.org>
+ *
+ *  All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/*
+ *  The SHA-512 Secure Hash Standard was published by NIST in 2002.
+ *
+ *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
+ */
+
+#include "sha512.h"
+
+#if defined(POLARSSL_SELF_TEST)
+#include <stdio.h>
+#endif
+
+/* Implementation that should never be optimized out by the compiler */
+static void polarssl_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = v; while( n-- ) *p++ = 0;
+}
+
+/*
+ * 64-bit integer manipulation macros (big endian)
+ */
+#ifndef GET_UINT64_BE
+#define GET_UINT64_BE(n,b,i)                            \
+{                                                       \
+    (n) = ( (uint64_t) (b)[(i)    ] << 56 )       \
+        | ( (uint64_t) (b)[(i) + 1] << 48 )       \
+        | ( (uint64_t) (b)[(i) + 2] << 40 )       \
+        | ( (uint64_t) (b)[(i) + 3] << 32 )       \
+        | ( (uint64_t) (b)[(i) + 4] << 24 )       \
+        | ( (uint64_t) (b)[(i) + 5] << 16 )       \
+        | ( (uint64_t) (b)[(i) + 6] <<  8 )       \
+        | ( (uint64_t) (b)[(i) + 7]       );      \
+}
+#endif /* GET_UINT64_BE */
+
+#ifndef PUT_UINT64_BE
+#define PUT_UINT64_BE(n,b,i)                            \
+{                                                       \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 40 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 32 );       \
+    (b)[(i) + 4] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 5] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 7] = (unsigned char) ( (n)       );       \
+}
+#endif /* PUT_UINT64_BE */
+
+/*
+ * Round constants
+ */
+static const uint64_t K[80] =
+{
+    UL64(0x428A2F98D728AE22),  UL64(0x7137449123EF65CD),
+    UL64(0xB5C0FBCFEC4D3B2F),  UL64(0xE9B5DBA58189DBBC),
+    UL64(0x3956C25BF348B538),  UL64(0x59F111F1B605D019),
+    UL64(0x923F82A4AF194F9B),  UL64(0xAB1C5ED5DA6D8118),
+    UL64(0xD807AA98A3030242),  UL64(0x12835B0145706FBE),
+    UL64(0x243185BE4EE4B28C),  UL64(0x550C7DC3D5FFB4E2),
+    UL64(0x72BE5D74F27B896F),  UL64(0x80DEB1FE3B1696B1),
+    UL64(0x9BDC06A725C71235),  UL64(0xC19BF174CF692694),
+    UL64(0xE49B69C19EF14AD2),  UL64(0xEFBE4786384F25E3),
+    UL64(0x0FC19DC68B8CD5B5),  UL64(0x240CA1CC77AC9C65),
+    UL64(0x2DE92C6F592B0275),  UL64(0x4A7484AA6EA6E483),
+    UL64(0x5CB0A9DCBD41FBD4),  UL64(0x76F988DA831153B5),
+    UL64(0x983E5152EE66DFAB),  UL64(0xA831C66D2DB43210),
+    UL64(0xB00327C898FB213F),  UL64(0xBF597FC7BEEF0EE4),
+    UL64(0xC6E00BF33DA88FC2),  UL64(0xD5A79147930AA725),
+    UL64(0x06CA6351E003826F),  UL64(0x142929670A0E6E70),
+    UL64(0x27B70A8546D22FFC),  UL64(0x2E1B21385C26C926),
+    UL64(0x4D2C6DFC5AC42AED),  UL64(0x53380D139D95B3DF),
+    UL64(0x650A73548BAF63DE),  UL64(0x766A0ABB3C77B2A8),
+    UL64(0x81C2C92E47EDAEE6),  UL64(0x92722C851482353B),
+    UL64(0xA2BFE8A14CF10364),  UL64(0xA81A664BBC423001),
+    UL64(0xC24B8B70D0F89791),  UL64(0xC76C51A30654BE30),
+    UL64(0xD192E819D6EF5218),  UL64(0xD69906245565A910),
+    UL64(0xF40E35855771202A),  UL64(0x106AA07032BBD1B8),
+    UL64(0x19A4C116B8D2D0C8),  UL64(0x1E376C085141AB53),
+    UL64(0x2748774CDF8EEB99),  UL64(0x34B0BCB5E19B48A8),
+    UL64(0x391C0CB3C5C95A63),  UL64(0x4ED8AA4AE3418ACB),
+    UL64(0x5B9CCA4F7763E373),  UL64(0x682E6FF3D6B2B8A3),
+    UL64(0x748F82EE5DEFB2FC),  UL64(0x78A5636F43172F60),
+    UL64(0x84C87814A1F0AB72),  UL64(0x8CC702081A6439EC),
+    UL64(0x90BEFFFA23631E28),  UL64(0xA4506CEBDE82BDE9),
+    UL64(0xBEF9A3F7B2C67915),  UL64(0xC67178F2E372532B),
+    UL64(0xCA273ECEEA26619C),  UL64(0xD186B8C721C0C207),
+    UL64(0xEADA7DD6CDE0EB1E),  UL64(0xF57D4F7FEE6ED178),
+    UL64(0x06F067AA72176FBA),  UL64(0x0A637DC5A2C898A6),
+    UL64(0x113F9804BEF90DAE),  UL64(0x1B710B35131C471B),
+    UL64(0x28DB77F523047D84),  UL64(0x32CAAB7B40C72493),
+    UL64(0x3C9EBE0A15C9BEBC),  UL64(0x431D67C49C100D4C),
+    UL64(0x4CC5D4BECB3E42B6),  UL64(0x597F299CFC657E2A),
+    UL64(0x5FCB6FAB3AD6FAEC),  UL64(0x6C44198C4A475817)
+};
+
+void sha512_init( sha512_context *ctx )
+{
+    memset( ctx, 0, sizeof( sha512_context ) );
+}
+
+void sha512_free( sha512_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    polarssl_zeroize( ctx, sizeof( sha512_context ) );
+}
+
+/*
+ * SHA-512 context setup
+ */
+void sha512_starts( sha512_context *ctx, int is384 )
+{
+    ctx->total[0] = 0;
+    ctx->total[1] = 0;
+
+    if( is384 == 0 )
+    {
+        /* SHA-512 */
+        ctx->state[0] = UL64(0x6A09E667F3BCC908);
+        ctx->state[1] = UL64(0xBB67AE8584CAA73B);
+        ctx->state[2] = UL64(0x3C6EF372FE94F82B);
+        ctx->state[3] = UL64(0xA54FF53A5F1D36F1);
+        ctx->state[4] = UL64(0x510E527FADE682D1);
+        ctx->state[5] = UL64(0x9B05688C2B3E6C1F);
+        ctx->state[6] = UL64(0x1F83D9ABFB41BD6B);
+        ctx->state[7] = UL64(0x5BE0CD19137E2179);
+    }
+    else
+    {
+        /* SHA-384 */
+        ctx->state[0] = UL64(0xCBBB9D5DC1059ED8);
+        ctx->state[1] = UL64(0x629A292A367CD507);
+        ctx->state[2] = UL64(0x9159015A3070DD17);
+        ctx->state[3] = UL64(0x152FECD8F70E5939);
+        ctx->state[4] = UL64(0x67332667FFC00B31);
+        ctx->state[5] = UL64(0x8EB44A8768581511);
+        ctx->state[6] = UL64(0xDB0C2E0D64F98FA7);
+        ctx->state[7] = UL64(0x47B5481DBEFA4FA4);
+    }
+
+    ctx->is384 = is384;
+}
+
+void sha512_process( sha512_context *ctx, const unsigned char data[128] )
+{
+    int i;
+    uint64_t temp1, temp2, W[80];
+    uint64_t A, B, C, D, E, F, G, H;
+
+#define  SHR(x,n) (x >> n)
+#define ROTR(x,n) (SHR(x,n) | (x << (64 - n)))
+
+#define S0(x) (ROTR(x, 1) ^ ROTR(x, 8) ^  SHR(x, 7))
+#define S1(x) (ROTR(x,19) ^ ROTR(x,61) ^  SHR(x, 6))
+
+#define S2(x) (ROTR(x,28) ^ ROTR(x,34) ^ ROTR(x,39))
+#define S3(x) (ROTR(x,14) ^ ROTR(x,18) ^ ROTR(x,41))
+
+#define F0(x,y,z) ((x & y) | (z & (x | y)))
+#define F1(x,y,z) (z ^ (x & (y ^ z)))
+
+#define P(a,b,c,d,e,f,g,h,x,K)                  \
+{                                               \
+    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
+    temp2 = S2(a) + F0(a,b,c);                  \
+    d += temp1; h = temp1 + temp2;              \
+}
+
+    for( i = 0; i < 16; i++ )
+    {
+        GET_UINT64_BE( W[i], data, i << 3 );
+    }
+
+    for( ; i < 80; i++ )
+    {
+        W[i] = S1(W[i -  2]) + W[i -  7] +
+               S0(W[i - 15]) + W[i - 16];
+    }
+
+    A = ctx->state[0];
+    B = ctx->state[1];
+    C = ctx->state[2];
+    D = ctx->state[3];
+    E = ctx->state[4];
+    F = ctx->state[5];
+    G = ctx->state[6];
+    H = ctx->state[7];
+    i = 0;
+
+    do
+    {
+        P( A, B, C, D, E, F, G, H, W[i], K[i] ); i++;
+        P( H, A, B, C, D, E, F, G, W[i], K[i] ); i++;
+        P( G, H, A, B, C, D, E, F, W[i], K[i] ); i++;
+        P( F, G, H, A, B, C, D, E, W[i], K[i] ); i++;
+        P( E, F, G, H, A, B, C, D, W[i], K[i] ); i++;
+        P( D, E, F, G, H, A, B, C, W[i], K[i] ); i++;
+        P( C, D, E, F, G, H, A, B, W[i], K[i] ); i++;
+        P( B, C, D, E, F, G, H, A, W[i], K[i] ); i++;
+    }
+    while( i < 80 );
+
+    ctx->state[0] += A;
+    ctx->state[1] += B;
+    ctx->state[2] += C;
+    ctx->state[3] += D;
+    ctx->state[4] += E;
+    ctx->state[5] += F;
+    ctx->state[6] += G;
+    ctx->state[7] += H;
+}
+
+/*
+ * SHA-512 process buffer
+ */
+void sha512_update( sha512_context *ctx, const unsigned char *input,
+                    size_t ilen )
+{
+    size_t fill;
+    unsigned int left;
+
+    if( ilen == 0 )
+        return;
+
+    left = (unsigned int) (ctx->total[0] & 0x7F);
+    fill = 128 - left;
+
+    ctx->total[0] += (uint64_t) ilen;
+
+    if( ctx->total[0] < (uint64_t) ilen )
+        ctx->total[1]++;
+
+    if( left && ilen >= fill )
+    {
+        memcpy( (void *) (ctx->buffer + left), input, fill );
+        sha512_process( ctx, ctx->buffer );
+        input += fill;
+        ilen  -= fill;
+        left = 0;
+    }
+
+    while( ilen >= 128 )
+    {
+        sha512_process( ctx, input );
+        input += 128;
+        ilen  -= 128;
+    }
+
+    if( ilen > 0 )
+        memcpy( (void *) (ctx->buffer + left), input, ilen );
+}
+
+static const unsigned char sha512_padding[128] =
+{
+ 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/*
+ * SHA-512 final digest
+ */
+void sha512_finish( sha512_context *ctx, unsigned char output[64] )
+{
+    size_t last, padn;
+    uint64_t high, low;
+    unsigned char msglen[16];
+
+    high = ( ctx->total[0] >> 61 )
+         | ( ctx->total[1] <<  3 );
+    low  = ( ctx->total[0] <<  3 );
+
+    PUT_UINT64_BE( high, msglen, 0 );
+    PUT_UINT64_BE( low,  msglen, 8 );
+
+    last = (size_t)( ctx->total[0] & 0x7F );
+    padn = ( last < 112 ) ? ( 112 - last ) : ( 240 - last );
+
+    sha512_update( ctx, sha512_padding, padn );
+    sha512_update( ctx, msglen, 16 );
+
+    PUT_UINT64_BE( ctx->state[0], output,  0 );
+    PUT_UINT64_BE( ctx->state[1], output,  8 );
+    PUT_UINT64_BE( ctx->state[2], output, 16 );
+    PUT_UINT64_BE( ctx->state[3], output, 24 );
+    PUT_UINT64_BE( ctx->state[4], output, 32 );
+    PUT_UINT64_BE( ctx->state[5], output, 40 );
+
+    if( ctx->is384 == 0 )
+    {
+        PUT_UINT64_BE( ctx->state[6], output, 48 );
+        PUT_UINT64_BE( ctx->state[7], output, 56 );
+    }
+}
+
+/*
+ * output = SHA-512( input buffer )
+ */
+void sha512( const unsigned char *input, size_t ilen,
+             unsigned char output[64], int is384 )
+{
+    sha512_context ctx;
+
+    sha512_init( &ctx );
+    sha512_starts( &ctx, is384 );
+    sha512_update( &ctx, input, ilen );
+    sha512_finish( &ctx, output );
+    sha512_free( &ctx );
+}
+
+/*
+ * SHA-512 HMAC context setup
+ */
+void sha512_hmac_starts( sha512_context *ctx, const unsigned char *key,
+                         size_t keylen, int is384 )
+{
+    size_t i;
+    unsigned char sum[64];
+
+    if( keylen > 128 )
+    {
+        sha512( key, keylen, sum, is384 );
+        keylen = ( is384 ) ? 48 : 64;
+        key = sum;
+    }
+
+    memset( ctx->ipad, 0x36, 128 );
+    memset( ctx->opad, 0x5C, 128 );
+
+    for( i = 0; i < keylen; i++ )
+    {
+        ctx->ipad[i] = (unsigned char)( ctx->ipad[i] ^ key[i] );
+        ctx->opad[i] = (unsigned char)( ctx->opad[i] ^ key[i] );
+    }
+
+    sha512_starts( ctx, is384 );
+    sha512_update( ctx, ctx->ipad, 128 );
+
+    polarssl_zeroize( sum, sizeof( sum ) );
+}
+
+/*
+ * SHA-512 HMAC process buffer
+ */
+void sha512_hmac_update( sha512_context  *ctx,
+                         const unsigned char *input, size_t ilen )
+{
+    sha512_update( ctx, input, ilen );
+}
+
+/*
+ * SHA-512 HMAC final digest
+ */
+void sha512_hmac_finish( sha512_context *ctx, unsigned char output[64] )
+{
+    int is384, hlen;
+    unsigned char tmpbuf[64];
+
+    is384 = ctx->is384;
+    hlen = ( is384 == 0 ) ? 64 : 48;
+
+    sha512_finish( ctx, tmpbuf );
+    sha512_starts( ctx, is384 );
+    sha512_update( ctx, ctx->opad, 128 );
+    sha512_update( ctx, tmpbuf, hlen );
+    sha512_finish( ctx, output );
+
+    polarssl_zeroize( tmpbuf, sizeof( tmpbuf ) );
+}
+
+/*
+ * SHA-512 HMAC context reset
+ */
+void sha512_hmac_reset( sha512_context *ctx )
+{
+    sha512_starts( ctx, ctx->is384 );
+    sha512_update( ctx, ctx->ipad, 128 );
+}
+
+/*
+ * output = HMAC-SHA-512( hmac key, input buffer )
+ */
+void sha512_hmac( const unsigned char *key, size_t keylen,
+                const unsigned char *input, size_t ilen,
+                unsigned char output[64], int is384 )
+{
+    sha512_context ctx;
+
+    sha512_init( &ctx );
+    sha512_hmac_starts( &ctx, key, keylen, is384 );
+    sha512_hmac_update( &ctx, input, ilen );
+    sha512_hmac_finish( &ctx, output );
+    sha512_free( &ctx );
+}
+
+#if defined(POLARSSL_SELF_TEST) 
+
+/*
+ * FIPS-180-2 test vectors
+ */
+static unsigned char sha512_test_buf[3][113] =
+{
+    { "abc" },
+    { "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+      "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu" },
+    { "" }
+};
+
+static const int sha512_test_buflen[3] =
+{
+    3, 112, 1000
+};
+
+static const unsigned char sha512_test_sum[6][64] =
+{
+    /*
+     * SHA-384 test vectors
+     */
+    { 0xCB, 0x00, 0x75, 0x3F, 0x45, 0xA3, 0x5E, 0x8B,
+      0xB5, 0xA0, 0x3D, 0x69, 0x9A, 0xC6, 0x50, 0x07,
+      0x27, 0x2C, 0x32, 0xAB, 0x0E, 0xDE, 0xD1, 0x63,
+      0x1A, 0x8B, 0x60, 0x5A, 0x43, 0xFF, 0x5B, 0xED,
+      0x80, 0x86, 0x07, 0x2B, 0xA1, 0xE7, 0xCC, 0x23,
+      0x58, 0xBA, 0xEC, 0xA1, 0x34, 0xC8, 0x25, 0xA7 },
+    { 0x09, 0x33, 0x0C, 0x33, 0xF7, 0x11, 0x47, 0xE8,
+      0x3D, 0x19, 0x2F, 0xC7, 0x82, 0xCD, 0x1B, 0x47,
+      0x53, 0x11, 0x1B, 0x17, 0x3B, 0x3B, 0x05, 0xD2,
+      0x2F, 0xA0, 0x80, 0x86, 0xE3, 0xB0, 0xF7, 0x12,
+      0xFC, 0xC7, 0xC7, 0x1A, 0x55, 0x7E, 0x2D, 0xB9,
+      0x66, 0xC3, 0xE9, 0xFA, 0x91, 0x74, 0x60, 0x39 },
+    { 0x9D, 0x0E, 0x18, 0x09, 0x71, 0x64, 0x74, 0xCB,
+      0x08, 0x6E, 0x83, 0x4E, 0x31, 0x0A, 0x4A, 0x1C,
+      0xED, 0x14, 0x9E, 0x9C, 0x00, 0xF2, 0x48, 0x52,
+      0x79, 0x72, 0xCE, 0xC5, 0x70, 0x4C, 0x2A, 0x5B,
+      0x07, 0xB8, 0xB3, 0xDC, 0x38, 0xEC, 0xC4, 0xEB,
+      0xAE, 0x97, 0xDD, 0xD8, 0x7F, 0x3D, 0x89, 0x85 },
+
+    /*
+     * SHA-512 test vectors
+     */
+    { 0xDD, 0xAF, 0x35, 0xA1, 0x93, 0x61, 0x7A, 0xBA,
+      0xCC, 0x41, 0x73, 0x49, 0xAE, 0x20, 0x41, 0x31,
+      0x12, 0xE6, 0xFA, 0x4E, 0x89, 0xA9, 0x7E, 0xA2,
+      0x0A, 0x9E, 0xEE, 0xE6, 0x4B, 0x55, 0xD3, 0x9A,
+      0x21, 0x92, 0x99, 0x2A, 0x27, 0x4F, 0xC1, 0xA8,
+      0x36, 0xBA, 0x3C, 0x23, 0xA3, 0xFE, 0xEB, 0xBD,
+      0x45, 0x4D, 0x44, 0x23, 0x64, 0x3C, 0xE8, 0x0E,
+      0x2A, 0x9A, 0xC9, 0x4F, 0xA5, 0x4C, 0xA4, 0x9F },
+    { 0x8E, 0x95, 0x9B, 0x75, 0xDA, 0xE3, 0x13, 0xDA,
+      0x8C, 0xF4, 0xF7, 0x28, 0x14, 0xFC, 0x14, 0x3F,
+      0x8F, 0x77, 0x79, 0xC6, 0xEB, 0x9F, 0x7F, 0xA1,
+      0x72, 0x99, 0xAE, 0xAD, 0xB6, 0x88, 0x90, 0x18,
+      0x50, 0x1D, 0x28, 0x9E, 0x49, 0x00, 0xF7, 0xE4,
+      0x33, 0x1B, 0x99, 0xDE, 0xC4, 0xB5, 0x43, 0x3A,
+      0xC7, 0xD3, 0x29, 0xEE, 0xB6, 0xDD, 0x26, 0x54,
+      0x5E, 0x96, 0xE5, 0x5B, 0x87, 0x4B, 0xE9, 0x09 },
+    { 0xE7, 0x18, 0x48, 0x3D, 0x0C, 0xE7, 0x69, 0x64,
+      0x4E, 0x2E, 0x42, 0xC7, 0xBC, 0x15, 0xB4, 0x63,
+      0x8E, 0x1F, 0x98, 0xB1, 0x3B, 0x20, 0x44, 0x28,
+      0x56, 0x32, 0xA8, 0x03, 0xAF, 0xA9, 0x73, 0xEB,
+      0xDE, 0x0F, 0xF2, 0x44, 0x87, 0x7E, 0xA6, 0x0A,
+      0x4C, 0xB0, 0x43, 0x2C, 0xE5, 0x77, 0xC3, 0x1B,
+      0xEB, 0x00, 0x9C, 0x5C, 0x2C, 0x49, 0xAA, 0x2E,
+      0x4E, 0xAD, 0xB2, 0x17, 0xAD, 0x8C, 0xC0, 0x9B }
+};
+
+/*
+ * RFC 4231 test vectors
+ */
+static unsigned char sha512_hmac_test_key[7][26] =
+{
+    { "\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B\x0B"
+      "\x0B\x0B\x0B\x0B" },
+    { "Jefe" },
+    { "\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA\xAA"
+      "\xAA\xAA\xAA\xAA" },
+    { "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F\x10"
+      "\x11\x12\x13\x14\x15\x16\x17\x18\x19" },
+    { "\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C"
+      "\x0C\x0C\x0C\x0C" },
+    { "" }, /* 0xAA 131 times */
+    { "" }
+};
+
+static const int sha512_hmac_test_keylen[7] =
+{
+    20, 4, 20, 25, 20, 131, 131
+};
+
+static unsigned char sha512_hmac_test_buf[7][153] =
+{
+    { "Hi There" },
+    { "what do ya want for nothing?" },
+    { "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
+      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
+      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
+      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD"
+      "\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD\xDD" },
+    { "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD"
+      "\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD\xCD" },
+    { "Test With Truncation" },
+    { "Test Using Larger Than Block-Size Key - Hash Key First" },
+    { "This is a test using a larger than block-size key "
+      "and a larger than block-size data. The key needs to "
+      "be hashed before being used by the HMAC algorithm." }
+};
+
+static const int sha512_hmac_test_buflen[7] =
+{
+    8, 28, 50, 50, 20, 54, 152
+};
+
+static const unsigned char sha512_hmac_test_sum[14][64] =
+{
+    /*
+     * HMAC-SHA-384 test vectors
+     */
+    { 0xAF, 0xD0, 0x39, 0x44, 0xD8, 0x48, 0x95, 0x62,
+      0x6B, 0x08, 0x25, 0xF4, 0xAB, 0x46, 0x90, 0x7F,
+      0x15, 0xF9, 0xDA, 0xDB, 0xE4, 0x10, 0x1E, 0xC6,
+      0x82, 0xAA, 0x03, 0x4C, 0x7C, 0xEB, 0xC5, 0x9C,
+      0xFA, 0xEA, 0x9E, 0xA9, 0x07, 0x6E, 0xDE, 0x7F,
+      0x4A, 0xF1, 0x52, 0xE8, 0xB2, 0xFA, 0x9C, 0xB6 },
+    { 0xAF, 0x45, 0xD2, 0xE3, 0x76, 0x48, 0x40, 0x31,
+      0x61, 0x7F, 0x78, 0xD2, 0xB5, 0x8A, 0x6B, 0x1B,
+      0x9C, 0x7E, 0xF4, 0x64, 0xF5, 0xA0, 0x1B, 0x47,
+      0xE4, 0x2E, 0xC3, 0x73, 0x63, 0x22, 0x44, 0x5E,
+      0x8E, 0x22, 0x40, 0xCA, 0x5E, 0x69, 0xE2, 0xC7,
+      0x8B, 0x32, 0x39, 0xEC, 0xFA, 0xB2, 0x16, 0x49 },
+    { 0x88, 0x06, 0x26, 0x08, 0xD3, 0xE6, 0xAD, 0x8A,
+      0x0A, 0xA2, 0xAC, 0xE0, 0x14, 0xC8, 0xA8, 0x6F,
+      0x0A, 0xA6, 0x35, 0xD9, 0x47, 0xAC, 0x9F, 0xEB,
+      0xE8, 0x3E, 0xF4, 0xE5, 0x59, 0x66, 0x14, 0x4B,
+      0x2A, 0x5A, 0xB3, 0x9D, 0xC1, 0x38, 0x14, 0xB9,
+      0x4E, 0x3A, 0xB6, 0xE1, 0x01, 0xA3, 0x4F, 0x27 },
+    { 0x3E, 0x8A, 0x69, 0xB7, 0x78, 0x3C, 0x25, 0x85,
+      0x19, 0x33, 0xAB, 0x62, 0x90, 0xAF, 0x6C, 0xA7,
+      0x7A, 0x99, 0x81, 0x48, 0x08, 0x50, 0x00, 0x9C,
+      0xC5, 0x57, 0x7C, 0x6E, 0x1F, 0x57, 0x3B, 0x4E,
+      0x68, 0x01, 0xDD, 0x23, 0xC4, 0xA7, 0xD6, 0x79,
+      0xCC, 0xF8, 0xA3, 0x86, 0xC6, 0x74, 0xCF, 0xFB },
+    { 0x3A, 0xBF, 0x34, 0xC3, 0x50, 0x3B, 0x2A, 0x23,
+      0xA4, 0x6E, 0xFC, 0x61, 0x9B, 0xAE, 0xF8, 0x97 },
+    { 0x4E, 0xCE, 0x08, 0x44, 0x85, 0x81, 0x3E, 0x90,
+      0x88, 0xD2, 0xC6, 0x3A, 0x04, 0x1B, 0xC5, 0xB4,
+      0x4F, 0x9E, 0xF1, 0x01, 0x2A, 0x2B, 0x58, 0x8F,
+      0x3C, 0xD1, 0x1F, 0x05, 0x03, 0x3A, 0xC4, 0xC6,
+      0x0C, 0x2E, 0xF6, 0xAB, 0x40, 0x30, 0xFE, 0x82,
+      0x96, 0x24, 0x8D, 0xF1, 0x63, 0xF4, 0x49, 0x52 },
+    { 0x66, 0x17, 0x17, 0x8E, 0x94, 0x1F, 0x02, 0x0D,
+      0x35, 0x1E, 0x2F, 0x25, 0x4E, 0x8F, 0xD3, 0x2C,
+      0x60, 0x24, 0x20, 0xFE, 0xB0, 0xB8, 0xFB, 0x9A,
+      0xDC, 0xCE, 0xBB, 0x82, 0x46, 0x1E, 0x99, 0xC5,
+      0xA6, 0x78, 0xCC, 0x31, 0xE7, 0x99, 0x17, 0x6D,
+      0x38, 0x60, 0xE6, 0x11, 0x0C, 0x46, 0x52, 0x3E },
+
+    /*
+     * HMAC-SHA-512 test vectors
+     */
+    { 0x87, 0xAA, 0x7C, 0xDE, 0xA5, 0xEF, 0x61, 0x9D,
+      0x4F, 0xF0, 0xB4, 0x24, 0x1A, 0x1D, 0x6C, 0xB0,
+      0x23, 0x79, 0xF4, 0xE2, 0xCE, 0x4E, 0xC2, 0x78,
+      0x7A, 0xD0, 0xB3, 0x05, 0x45, 0xE1, 0x7C, 0xDE,
+      0xDA, 0xA8, 0x33, 0xB7, 0xD6, 0xB8, 0xA7, 0x02,
+      0x03, 0x8B, 0x27, 0x4E, 0xAE, 0xA3, 0xF4, 0xE4,
+      0xBE, 0x9D, 0x91, 0x4E, 0xEB, 0x61, 0xF1, 0x70,
+      0x2E, 0x69, 0x6C, 0x20, 0x3A, 0x12, 0x68, 0x54 },
+    { 0x16, 0x4B, 0x7A, 0x7B, 0xFC, 0xF8, 0x19, 0xE2,
+      0xE3, 0x95, 0xFB, 0xE7, 0x3B, 0x56, 0xE0, 0xA3,
+      0x87, 0xBD, 0x64, 0x22, 0x2E, 0x83, 0x1F, 0xD6,
+      0x10, 0x27, 0x0C, 0xD7, 0xEA, 0x25, 0x05, 0x54,
+      0x97, 0x58, 0xBF, 0x75, 0xC0, 0x5A, 0x99, 0x4A,
+      0x6D, 0x03, 0x4F, 0x65, 0xF8, 0xF0, 0xE6, 0xFD,
+      0xCA, 0xEA, 0xB1, 0xA3, 0x4D, 0x4A, 0x6B, 0x4B,
+      0x63, 0x6E, 0x07, 0x0A, 0x38, 0xBC, 0xE7, 0x37 },
+    { 0xFA, 0x73, 0xB0, 0x08, 0x9D, 0x56, 0xA2, 0x84,
+      0xEF, 0xB0, 0xF0, 0x75, 0x6C, 0x89, 0x0B, 0xE9,
+      0xB1, 0xB5, 0xDB, 0xDD, 0x8E, 0xE8, 0x1A, 0x36,
+      0x55, 0xF8, 0x3E, 0x33, 0xB2, 0x27, 0x9D, 0x39,
+      0xBF, 0x3E, 0x84, 0x82, 0x79, 0xA7, 0x22, 0xC8,
+      0x06, 0xB4, 0x85, 0xA4, 0x7E, 0x67, 0xC8, 0x07,
+      0xB9, 0x46, 0xA3, 0x37, 0xBE, 0xE8, 0x94, 0x26,
+      0x74, 0x27, 0x88, 0x59, 0xE1, 0x32, 0x92, 0xFB },
+    { 0xB0, 0xBA, 0x46, 0x56, 0x37, 0x45, 0x8C, 0x69,
+      0x90, 0xE5, 0xA8, 0xC5, 0xF6, 0x1D, 0x4A, 0xF7,
+      0xE5, 0x76, 0xD9, 0x7F, 0xF9, 0x4B, 0x87, 0x2D,
+      0xE7, 0x6F, 0x80, 0x50, 0x36, 0x1E, 0xE3, 0xDB,
+      0xA9, 0x1C, 0xA5, 0xC1, 0x1A, 0xA2, 0x5E, 0xB4,
+      0xD6, 0x79, 0x27, 0x5C, 0xC5, 0x78, 0x80, 0x63,
+      0xA5, 0xF1, 0x97, 0x41, 0x12, 0x0C, 0x4F, 0x2D,
+      0xE2, 0xAD, 0xEB, 0xEB, 0x10, 0xA2, 0x98, 0xDD },
+    { 0x41, 0x5F, 0xAD, 0x62, 0x71, 0x58, 0x0A, 0x53,
+      0x1D, 0x41, 0x79, 0xBC, 0x89, 0x1D, 0x87, 0xA6 },
+    { 0x80, 0xB2, 0x42, 0x63, 0xC7, 0xC1, 0xA3, 0xEB,
+      0xB7, 0x14, 0x93, 0xC1, 0xDD, 0x7B, 0xE8, 0xB4,
+      0x9B, 0x46, 0xD1, 0xF4, 0x1B, 0x4A, 0xEE, 0xC1,
+      0x12, 0x1B, 0x01, 0x37, 0x83, 0xF8, 0xF3, 0x52,
+      0x6B, 0x56, 0xD0, 0x37, 0xE0, 0x5F, 0x25, 0x98,
+      0xBD, 0x0F, 0xD2, 0x21, 0x5D, 0x6A, 0x1E, 0x52,
+      0x95, 0xE6, 0x4F, 0x73, 0xF6, 0x3F, 0x0A, 0xEC,
+      0x8B, 0x91, 0x5A, 0x98, 0x5D, 0x78, 0x65, 0x98 },
+    { 0xE3, 0x7B, 0x6A, 0x77, 0x5D, 0xC8, 0x7D, 0xBA,
+      0xA4, 0xDF, 0xA9, 0xF9, 0x6E, 0x5E, 0x3F, 0xFD,
+      0xDE, 0xBD, 0x71, 0xF8, 0x86, 0x72, 0x89, 0x86,
+      0x5D, 0xF5, 0xA3, 0x2D, 0x20, 0xCD, 0xC9, 0x44,
+      0xB6, 0x02, 0x2C, 0xAC, 0x3C, 0x49, 0x82, 0xB1,
+      0x0D, 0x5E, 0xEB, 0x55, 0xC3, 0xE4, 0xDE, 0x15,
+      0x13, 0x46, 0x76, 0xFB, 0x6D, 0xE0, 0x44, 0x60,
+      0x65, 0xC9, 0x74, 0x40, 0xFA, 0x8C, 0x6A, 0x58 }
+};
+
+/*
+ * Checkup routine
+ */
+int sha512_self_test( int verbose )
+{
+    int i, j, k, buflen, ret = 0;
+    unsigned char buf[1024];
+    unsigned char sha512sum[64];
+    sha512_context ctx;
+
+    sha512_init( &ctx );
+
+    for( i = 0; i < 6; i++ )
+    {
+        j = i % 3;
+        k = i < 3;
+
+        if( verbose != 0 )
+            printf( "  SHA-%d test #%d: ", 512 - k * 128, j + 1 );
+
+        sha512_starts( &ctx, k );
+
+        if( j == 2 )
+        {
+            memset( buf, 'a', buflen = 1000 );
+
+            for( j = 0; j < 1000; j++ )
+                sha512_update( &ctx, buf, buflen );
+        }
+        else
+            sha512_update( &ctx, sha512_test_buf[j],
+                                 sha512_test_buflen[j] );
+
+        sha512_finish( &ctx, sha512sum );
+
+        if( memcmp( sha512sum, sha512_test_sum[i], 64 - k * 16 ) != 0 )
+        {
+            if( verbose != 0 )
+                printf( "failed\n" );
+
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        printf( "\n" );
+
+    for( i = 0; i < 14; i++ )
+    {
+        j = i % 7;
+        k = i < 7;
+
+        if( verbose != 0 )
+            printf( "  HMAC-SHA-%d test #%d: ", 512 - k * 128, j + 1 );
+
+        if( j == 5 || j == 6 )
+        {
+            memset( buf, '\xAA', buflen = 131 );
+            sha512_hmac_starts( &ctx, buf, buflen, k );
+        }
+        else
+            sha512_hmac_starts( &ctx, sha512_hmac_test_key[j],
+                                      sha512_hmac_test_keylen[j], k );
+
+        sha512_hmac_update( &ctx, sha512_hmac_test_buf[j],
+                                  sha512_hmac_test_buflen[j] );
+
+        sha512_hmac_finish( &ctx, sha512sum );
+
+        buflen = ( j == 4 ) ? 16 : 64 - k * 16;
+
+        if( memcmp( sha512sum, sha512_hmac_test_sum[i], buflen ) != 0 )
+        {
+            if( verbose != 0 )
+                printf( "failed\n" );
+
+            ret = 1;
+            goto exit;
+        }
+
+        if( verbose != 0 )
+            printf( "passed\n" );
+    }
+
+    if( verbose != 0 )
+        printf( "\n" );
+
+exit:
+    sha512_free( &ctx );
+
+    return( ret );
+}
+
+int main() {
+	return sha512_self_test(1);
+}	
+
+#endif /* POLARSSL_SELF_TEST */
+

--- a/src/c/sha512.h
+++ b/src/c/sha512.h
@@ -1,0 +1,169 @@
+/**
+ * \file sha512.h
+ *
+ * \brief SHA-384 and SHA-512 cryptographic hash function
+ *
+ *  Copyright (C) 2006-2014, Brainspark B.V.
+ *
+ *  This file is part of PolarSSL (http://www.polarssl.org)
+ *  Lead Maintainer: Paul Bakker <polarssl_maintainer at polarssl.org>
+ *
+ *  All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef POLARSSL_SHA512_H
+#define POLARSSL_SHA512_H
+
+#include <string.h>
+
+#if defined(_MSC_VER) || defined(__WATCOMC__)
+  #define UL64(x) x##ui64
+  typedef unsigned __int64 uint64_t;
+#else
+  #include <inttypes.h>
+  #define UL64(x) x##ULL
+#endif
+
+// Regular implementation
+//
+
+/**
+ * \brief          SHA-512 context structure
+ */
+typedef struct
+{
+    uint64_t total[2];          /*!< number of bytes processed  */
+    uint64_t state[8];          /*!< intermediate digest state  */
+    unsigned char buffer[128];  /*!< data block being processed */
+
+    unsigned char ipad[128];    /*!< HMAC: inner padding        */
+    unsigned char opad[128];    /*!< HMAC: outer padding        */
+    int is384;                  /*!< 0 => SHA-512, else SHA-384 */
+}
+sha512_context;
+
+/**
+ * \brief          Initialize SHA-512 context
+ *
+ * \param ctx      SHA-512 context to be initialized
+ */
+void sha512_init( sha512_context *ctx );
+
+/**
+ * \brief          Clear SHA-512 context
+ *
+ * \param ctx      SHA-512 context to be cleared
+ */
+void sha512_free( sha512_context *ctx );
+
+/**
+ * \brief          SHA-512 context setup
+ *
+ * \param ctx      context to be initialized
+ * \param is384    0 = use SHA512, 1 = use SHA384
+ */
+void sha512_starts( sha512_context *ctx, int is384 );
+
+/**
+ * \brief          SHA-512 process buffer
+ *
+ * \param ctx      SHA-512 context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+void sha512_update( sha512_context *ctx, const unsigned char *input,
+                    size_t ilen );
+
+/**
+ * \brief          SHA-512 final digest
+ *
+ * \param ctx      SHA-512 context
+ * \param output   SHA-384/512 checksum result
+ */
+void sha512_finish( sha512_context *ctx, unsigned char output[64] );
+
+/**
+ * \brief          Output = SHA-512( input buffer )
+ *
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   SHA-384/512 checksum result
+ * \param is384    0 = use SHA512, 1 = use SHA384
+ */
+void sha512( const unsigned char *input, size_t ilen,
+             unsigned char output[64], int is384 );
+
+/**
+ * \brief          SHA-512 HMAC context setup
+ *
+ * \param ctx      HMAC context to be initialized
+ * \param is384    0 = use SHA512, 1 = use SHA384
+ * \param key      HMAC secret key
+ * \param keylen   length of the HMAC key
+ */
+void sha512_hmac_starts( sha512_context *ctx, const unsigned char *key,
+                         size_t keylen, int is384 );
+
+/**
+ * \brief          SHA-512 HMAC process buffer
+ *
+ * \param ctx      HMAC context
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ */
+void sha512_hmac_update( sha512_context *ctx, const unsigned char *input,
+                         size_t ilen );
+
+/**
+ * \brief          SHA-512 HMAC final digest
+ *
+ * \param ctx      HMAC context
+ * \param output   SHA-384/512 HMAC checksum result
+ */
+void sha512_hmac_finish( sha512_context *ctx, unsigned char output[64] );
+
+/**
+ * \brief          SHA-512 HMAC context reset
+ *
+ * \param ctx      HMAC context to be reset
+ */
+void sha512_hmac_reset( sha512_context *ctx );
+
+/**
+ * \brief          Output = HMAC-SHA-512( hmac key, input buffer )
+ *
+ * \param key      HMAC secret key
+ * \param keylen   length of the HMAC key
+ * \param input    buffer holding the  data
+ * \param ilen     length of the input data
+ * \param output   HMAC-SHA-384/512 result
+ * \param is384    0 = use SHA512, 1 = use SHA384
+ */
+void sha512_hmac( const unsigned char *key, size_t keylen,
+                const unsigned char *input, size_t ilen,
+                unsigned char output[64], int is384 );
+
+/**
+ * \brief          Checkup routine
+ *
+ * \return         0 if successful, or 1 if the test failed
+ */
+int sha512_self_test( int verbose );
+
+/* Internal use */
+void sha512_process( sha512_context *ctx, const unsigned char data[128] );
+
+#endif /* sha512.h */

--- a/src/c/sha512.h
+++ b/src/c/sha512.h
@@ -1,169 +1,31 @@
-/**
- * \file sha512.h
- *
- * \brief SHA-384 and SHA-512 cryptographic hash function
- *
- *  Copyright (C) 2006-2014, Brainspark B.V.
- *
- *  This file is part of PolarSSL (http://www.polarssl.org)
- *  Lead Maintainer: Paul Bakker <polarssl_maintainer at polarssl.org>
- *
- *  All rights reserved.
- *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
-#ifndef POLARSSL_SHA512_H
-#define POLARSSL_SHA512_H
+/* Taken from SHA512-based Unix crypt implementation.
+   Released into the Public Domain by Ulrich Drepper <drepper@redhat.com>.  */
 
+#include <stdint.h>
 #include <string.h>
 
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-  #define UL64(x) x##ui64
-  typedef unsigned __int64 uint64_t;
-#else
-  #include <inttypes.h>
-  #define UL64(x) x##ULL
-#endif
-
-// Regular implementation
-//
-
-/**
- * \brief          SHA-512 context structure
- */
-typedef struct
+/* Structure to save state of computation between the single steps.  */
+struct sha512_ctx
 {
-    uint64_t total[2];          /*!< number of bytes processed  */
-    uint64_t state[8];          /*!< intermediate digest state  */
-    unsigned char buffer[128];  /*!< data block being processed */
+  uint64_t H[8];
 
-    unsigned char ipad[128];    /*!< HMAC: inner padding        */
-    unsigned char opad[128];    /*!< HMAC: outer padding        */
-    int is384;                  /*!< 0 => SHA-512, else SHA-384 */
-}
-sha512_context;
+  uint64_t total[2];
+  uint64_t buflen;
+  char buffer[256];	/* NB: always correctly aligned for uint64_t.  */
+};
 
-/**
- * \brief          Initialize SHA-512 context
- *
- * \param ctx      SHA-512 context to be initialized
- */
-void sha512_init( sha512_context *ctx );
+/* Initialize structure containing state of computation.
+   (FIPS 180-2:5.3.3)  */
+void
+sha512_init_ctx (struct sha512_ctx *ctx);
 
-/**
- * \brief          Clear SHA-512 context
- *
- * \param ctx      SHA-512 context to be cleared
- */
-void sha512_free( sha512_context *ctx );
+/* Process the remaining bytes in the internal buffer and the usual
+   prolog according to the standard and write the result to RESBUF.
 
-/**
- * \brief          SHA-512 context setup
- *
- * \param ctx      context to be initialized
- * \param is384    0 = use SHA512, 1 = use SHA384
- */
-void sha512_starts( sha512_context *ctx, int is384 );
+   IMPORTANT: On some systems it is required that RESBUF is correctly
+   aligned for a 32 bits value.  */
+void *
+sha512_finish_ctx (struct sha512_ctx *ctx, void *resbuf);
 
-/**
- * \brief          SHA-512 process buffer
- *
- * \param ctx      SHA-512 context
- * \param input    buffer holding the  data
- * \param ilen     length of the input data
- */
-void sha512_update( sha512_context *ctx, const unsigned char *input,
-                    size_t ilen );
-
-/**
- * \brief          SHA-512 final digest
- *
- * \param ctx      SHA-512 context
- * \param output   SHA-384/512 checksum result
- */
-void sha512_finish( sha512_context *ctx, unsigned char output[64] );
-
-/**
- * \brief          Output = SHA-512( input buffer )
- *
- * \param input    buffer holding the  data
- * \param ilen     length of the input data
- * \param output   SHA-384/512 checksum result
- * \param is384    0 = use SHA512, 1 = use SHA384
- */
-void sha512( const unsigned char *input, size_t ilen,
-             unsigned char output[64], int is384 );
-
-/**
- * \brief          SHA-512 HMAC context setup
- *
- * \param ctx      HMAC context to be initialized
- * \param is384    0 = use SHA512, 1 = use SHA384
- * \param key      HMAC secret key
- * \param keylen   length of the HMAC key
- */
-void sha512_hmac_starts( sha512_context *ctx, const unsigned char *key,
-                         size_t keylen, int is384 );
-
-/**
- * \brief          SHA-512 HMAC process buffer
- *
- * \param ctx      HMAC context
- * \param input    buffer holding the  data
- * \param ilen     length of the input data
- */
-void sha512_hmac_update( sha512_context *ctx, const unsigned char *input,
-                         size_t ilen );
-
-/**
- * \brief          SHA-512 HMAC final digest
- *
- * \param ctx      HMAC context
- * \param output   SHA-384/512 HMAC checksum result
- */
-void sha512_hmac_finish( sha512_context *ctx, unsigned char output[64] );
-
-/**
- * \brief          SHA-512 HMAC context reset
- *
- * \param ctx      HMAC context to be reset
- */
-void sha512_hmac_reset( sha512_context *ctx );
-
-/**
- * \brief          Output = HMAC-SHA-512( hmac key, input buffer )
- *
- * \param key      HMAC secret key
- * \param keylen   length of the HMAC key
- * \param input    buffer holding the  data
- * \param ilen     length of the input data
- * \param output   HMAC-SHA-384/512 result
- * \param is384    0 = use SHA512, 1 = use SHA384
- */
-void sha512_hmac( const unsigned char *key, size_t keylen,
-                const unsigned char *input, size_t ilen,
-                unsigned char output[64], int is384 );
-
-/**
- * \brief          Checkup routine
- *
- * \return         0 if successful, or 1 if the test failed
- */
-int sha512_self_test( int verbose );
-
-/* Internal use */
-void sha512_process( sha512_context *ctx, const unsigned char data[128] );
-
-#endif /* sha512.h */
+void
+sha512_process_bytes (const void *buffer, size_t len, struct sha512_ctx *ctx);

--- a/src/c/test.c
+++ b/src/c/test.c
@@ -1,0 +1,60 @@
+#include <inttypes.h>
+
+//Raise this here and in cwrapper.py when making incompatible changes in the lib
+#define LIBRARYVERSION 1
+
+//Decrease this here and in cwrapper.py after porting the lib to a now architecture
+#define UNSUPPORTED -1 
+
+#ifndef PUT_UINT64_BE
+#define PUT_UINT64_BE(n,b,i)                            \
+{                                                       \
+    (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
+    (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
+    (b)[(i) + 2] = (unsigned char) ( (n) >> 40 );       \
+    (b)[(i) + 3] = (unsigned char) ( (n) >> 32 );       \
+    (b)[(i) + 4] = (unsigned char) ( (n) >> 24 );       \
+    (b)[(i) + 5] = (unsigned char) ( (n) >> 16 );       \
+    (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
+    (b)[(i) + 7] = (unsigned char) ( (n)       );       \
+}
+#endif /* PUT_UINT64_BE */
+
+int test() {
+	/* Test if we are on a big endian machine 
+	 * since others are not supported at the moment. 
+	 * If that's the case, n should be  
+	 * {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07} 
+	 * after PUT_UINT64_BE(). */
+
+	uint64_t i = 283686952306183Lu;
+	unsigned char x[8];
+	
+	PUT_UINT64_BE(i, x, 0);
+
+	int n;
+	for (n=0;n<8;++n) {
+		if (x[n] != n) return UNSUPPORTED;
+	}
+
+	return LIBRARYVERSION;
+}
+
+#ifdef TEST
+
+#include <stdio.h>
+
+int main() {
+	switch(test()) {
+		case LIBRARYVERSION:
+			printf("Test passed if you are on a BIG ENDIAN ENGINE\n");
+			break;
+		case UNSUPPORTED:
+			printf("Test passed of you are NOT on a BIG ENDIAN ENGINE!\n");
+		default:
+			printf("Test failed!\n");
+			break;
+	}
+	return 0;
+}
+#endif //TEST

--- a/src/c/test.c
+++ b/src/c/test.c
@@ -1,4 +1,4 @@
-#include <inttypes.h>
+#include <stdint.h>
 
 //Raise this here and in cwrapper.py when making incompatible changes in the lib
 #define LIBRARYVERSION 1

--- a/src/cwrapper.py
+++ b/src/cwrapper.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import ctypes
+import os
+from debug import logger
+
+#Return values for test() from C library 
+LIBRARYVERSION = 1
+UNSUPPORTED = -1
+
+lib = None
+
+def openLib():
+    global lib
+    global LIBRARYVERSION
+    global UNSUPPORTED
+
+    if ('win' in os.sys.platform):
+        libPath = "pybitmessage.dll"
+    else:
+        libPath = "./pybitmessage.so"
+
+    if not os.access(libPath, os.F_OK):
+        return False
+
+    try:
+        lib = ctypes.CDLL(libPath)
+        return lib.test()
+    except:
+        lib = None
+        return False
+
+def buildLibUnix() :
+    logger.debug("Tring to build C library")
+    dirChanged = False
+    try:
+        os.chdir("./c")
+        dirChanged = True
+        os.system("cc -c -fpic proofofwork.c sha512.c test.c")
+        os.system("cc -shared -o pybitmessage.so proofofwork.o sha512.o test.o")
+        os.rename("./pybitmessage.so", "./../pybitmessage.so")
+        os.chdir("./..")
+        logger.debug("Builded C library successfully")
+    except:
+        if dirChanged:
+            os.chdir("./..")
+        logger.debug("Faild to build C library")
+
+def init():
+    global lib
+    global LIBRARYVERSION
+    global UNSUPPORTED
+
+    test = openLib()
+    if (test == LIBRARYVERSION):
+        logger.debug("Using C library")
+        return True
+    elif (test == UNSUPPORTED):
+        logger.debug("No C library support for your platform")
+        return False
+    else:
+        if ('win' in os.sys.platform):
+            logger.debug("Can't build C library automatically on windows")
+            return False
+        else:
+            buildLibUnix()
+            if (openLib() == LIBRARYVERSION):
+                return True
+                logger.debug("Using C library")
+            else:
+                logger.debug("No C library support for your platform or failed to build it")
+                return False
+
+def doPoW(_target, _initialHash, _nonce, _poolSize):
+    global lib
+
+    #This is needed on windows, because for some reason the variables 
+    #are lost in the threads created in _doFastPow().
+    if not lib:
+        openLib()
+    
+    target = ctypes.c_uint64(_target)
+
+    chararray = ctypes.c_char * 64
+    initialHash = chararray()
+    for i in range(0, 63):
+        initialHash[i] = _initialHash[i]
+
+    trialValue = ctypes.c_uint64(0)
+    nonce = ctypes.c_uint64(_nonce)
+    poolSize = ctypes.c_uint(_poolSize)
+
+    lib.doPoW(target, ctypes.byref(initialHash), ctypes.byref(trialValue), ctypes.byref(nonce), poolSize)
+
+    return [trialValue.value, nonce.value]

--- a/src/cwrapper.py
+++ b/src/cwrapper.py
@@ -35,8 +35,8 @@ def buildLibUnix() :
     try:
         os.chdir("./c")
         dirChanged = True
-        os.system("cc -c -fpic proofofwork.c sha512.c test.c")
-        os.system("cc -shared -o pybitmessage.so proofofwork.o sha512.o test.o")
+        os.system("cc -c -fpic -std=c99 proofofwork.c sha512.c test.c")
+        os.system("cc -shared -o pybitmessage.so -std=c99 proofofwork.o sha512.o test.o")
         os.rename("./pybitmessage.so", "./../pybitmessage.so")
         os.chdir("./..")
         logger.debug("Builded C library successfully")

--- a/src/shared.py
+++ b/src/shared.py
@@ -72,6 +72,7 @@ numberOfBroadcastsProcessed = 0
 numberOfPubkeysProcessed = 0
 numberOfInventoryLookupsPerformed = 0
 daemon = False
+clibAvaible = False
 inventorySets = {} # key = streamNumer, value = a set which holds the inventory object hashes that we are aware of. This is used whenever we receive an inv message from a peer to check to see what items are new to us. We don't delete things out of it; instead, the singleCleaner thread clears and refills it every couple hours.
 needToWriteKnownNodesToDisk = False # If True, the singleCleaner will write it to disk eventually.
 maximumLengthOfTimeToBotherResendingMessages = 0


### PR DESCRIPTION
I added a C library to the client in order to speed up cpu intensive tasks. At the moment it only implements the PoW, but other functions can be added easily.

On Unix, the client will try to build the library on startup. Windows user must compile it by themselves and place it under "src/pybitmessage.dll", or you can distribute precompiled binarys.
It should also work on Mac, but I haven't one to test with.

However, it will fall back to the python implemention if the library can't be used or is disabled with "disableclib = True" in keys.dat.

The sha512 implementation is taken from polarSSL. If there are license issues, it's no problem to pick another one.

I don't know if you accept this kind of patch at all, so feel free to reject it ;)