### PR TITLE
Support for transparent terminals in curses mode

### DIFF
--- a/src/bitmessagecurses/__init__.py
+++ b/src/bitmessagecurses/__init__.py
@@ -961,7 +961,7 @@ def loadBlackWhiteList():
         blacklist.append([label, address, enabled])
     blacklist.reverse()
 
-def runwrapper():
+def runwrapper(transparent):
     sys.stdout = printlog
     #sys.stderr = errlog
     
@@ -981,30 +981,37 @@ def runwrapper():
     curses.curs_set(0)
     stdscr.timeout(1000)
     
-    curses.wrapper(run)
+    if (transparent):
+        curses.wrapper(run_transparent)
+    else:
+        curses.wrapper(run)
     shutdown()
 
-def run(stdscr):
+def run_transparent(stdscr):
+    curses.use_default_colors()
+    run(stdscr, -1)
+
+def run(stdscr,bgcolor=curses.COLOR_BLACK):
     # Schedule inventory lookup data
     resetlookups()
     
     # Init color pairs
     if curses.has_colors():
-        curses.init_pair(1, curses.COLOR_RED, curses.COLOR_BLACK) # red
-        curses.init_pair(2, curses.COLOR_GREEN, curses.COLOR_BLACK) # green
-        curses.init_pair(3, curses.COLOR_YELLOW, curses.COLOR_BLACK) # yellow
-        curses.init_pair(4, curses.COLOR_BLUE, curses.COLOR_BLACK) # blue
-        curses.init_pair(5, curses.COLOR_MAGENTA, curses.COLOR_BLACK) # magenta
-        curses.init_pair(6, curses.COLOR_CYAN, curses.COLOR_BLACK) # cyan
-        curses.init_pair(7, curses.COLOR_WHITE, curses.COLOR_BLACK) # white
+        curses.init_pair(1, curses.COLOR_RED, bgcolor) # red
+        curses.init_pair(2, curses.COLOR_GREEN, bgcolor) # green
+        curses.init_pair(3, curses.COLOR_YELLOW, bgcolor) # yellow
+        curses.init_pair(4, curses.COLOR_BLUE, bgcolor) # blue
+        curses.init_pair(5, curses.COLOR_MAGENTA, bgcolor) # magenta
+        curses.init_pair(6, curses.COLOR_CYAN, bgcolor) # cyan
+        curses.init_pair(7, curses.COLOR_WHITE, bgcolor) # white
         if curses.can_change_color():
             curses.init_color(8, 500, 500, 500) # gray
-            curses.init_pair(8, 8, 0)
+            curses.init_pair(8, 8, bgcolor)
             curses.init_color(9, 844, 465, 0) # orange
-            curses.init_pair(9, 9, 0)
+            curses.init_pair(9, 9, bgcolor)
         else:
-            curses.init_pair(8, curses.COLOR_WHITE, curses.COLOR_BLACK) # grayish
-            curses.init_pair(9, curses.COLOR_YELLOW, curses.COLOR_BLACK) # orangish
+            curses.init_pair(8, curses.COLOR_WHITE, bgcolor) # grayish
+            curses.init_pair(9, curses.COLOR_YELLOW, bgcolor) # orangish
     
     # Init list of address in 'Your Identities' tab
     configSections = shared.config.sections()

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -168,7 +168,11 @@ class Main:
 
         # get curses flag
         curses = False
-        if '-c' in sys.argv:
+        transparent = False
+        if '-ct' in sys.argv:
+            curses = True
+            transparent = True
+        elif '-c' in sys.argv:
             curses = True
 
         signal.signal(signal.SIGINT, helper_generic.signal_handler)
@@ -232,7 +236,7 @@ class Main:
                 except Exception as err:
                     print('PyBitmessage requires PyQt unless you want to run it as a daemon and interact with it using the API. You can download PyQt from http://www.riverbankcomputing.com/software/pyqt/download   or by searching Google for \'PyQt Download\'. If you want to run in daemon mode, see https://bitmessage.org/wiki/Daemon')
                     print('Error message:', err)
-                    print('You can also run PyBitmessage with the new curses interface by providing \'-c\' as a commandline argument.')
+                    print('You can also run PyBitmessage with the new curses interface by providing \'-c\' as a commandline argument. For transparent curses mode, \'-ct\' may be used.')
                     os._exit(0)
 
                 import bitmessageqt
@@ -240,7 +244,7 @@ class Main:
             else:
                 print('Running with curses')
                 import bitmessagecurses
-                bitmessagecurses.runwrapper()
+                bitmessagecurses.runwrapper(transparent)
         else:
             shared.config.remove_option('bitmessagesettings', 'dontconnect')
 


### PR DESCRIPTION
When run in curses mode, a black background is displayed. My terminal emulator allows me to play videos in the background, which unfortunately gets covered up by pybitmessage's background. This patch adds the command line option '-ct', which has the same effect as '-c', but without setting a background color.
