### PR TITLE
Fix #417 - bad relative path breaks translations

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3852,7 +3852,7 @@ def run():
     translator = QtCore.QTranslator()
     
     translationpath = os.path.join(
-        getattr(sys, '_MEIPASS', ''),
+        getattr(sys, '_MEIPASS', sys.path[0]),
         'translations',
         'bitmessage_' + l10n.getTranslationLanguage()
     )


### PR DESCRIPTION
Problem: Translations don't work when user launches bitmessagemain.py from another directory, like “src/bimessagmain.py”.

This problem was caused by incorrect fallback to an empty string when _MEIPASS is not present. This happens when bitmessage is not running from a onefile executable. In that case, PyInstaller's variable _MEIPASS is not defined, and because empty string is chosen as root path, the path to translations can only work by accident - if user happens to be in that directory.

Solution: if _MEIPASS is not present, fall back to sys.path[0](the location of bitmessagemain.py) so that it works in both modes.
