### PR TITLE
Blacklist API

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -763,9 +763,9 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             # black-/white-list.
             queryreturn = sqlQuery('''select * from '''+table+''' where address=?''', address)
             if queryreturn != []:
-                raise APIError(16, 'You have already black-/white-listed that address.')
+                raise APIError(28, 'You have already black-/white-listed that address.')
             sqlExecute('''INSERT INTO '''+table+''' VALUES (?,?,?)''',label, address, True)
-            shared.UISignalQueue.put(('rerenderBlacklist', ''))
+            shared.UISignalQueue.put(('rerenderBlackWhiteList', ''))
             return 'Added black-/white-list entry.'
 
         elif method == 'removeAddressFromBlackWhiteList':
@@ -780,8 +780,14 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             else:
                 table = 'whitelist'
 
-            sqlExecute('''DELETE FROM blacklist WHERE address=?''', address)
-            shared.UISignalQueue.put(('rerenderBlacklist', ''))
+            # First we must check to see if the address is already in the
+            # black-/white-list.
+            queryreturn = sqlQuery('''select * from '''+table+''' where address=?''', address)
+            if queryreturn == []:
+                raise APIError(29, 'That entry does not exist in the black-/white-list.')
+
+            sqlExecute('''DELETE FROM '''+table+''' WHERE address=?''', address)
+            shared.UISignalQueue.put(('rerenderBlackWhiteList', ''))
             return 'Deleted black-/white-list entry if it existed.'
 
         elif method == 'deleteSubscription':


### PR DESCRIPTION
Addresses #496.

This PR adds two new API commands: `addAddressToBlackWhiteList` and `removeAddressFromBlackWhiteList`, which add and remove black-/white-list entries (respectively) depending on which of `(blacklist|whitelist)` the user has set.

Two new API codes (28 and 29) are added for alerting API clients of when an entry already exists or does not exist (also respectively).

In `bitmessageqt/__init__.py` `loadBlackWhiteList` is refactored into `rerenderBlackWhiteList` to be more consistent with the rest of the rerender methods. Finally, it also accepts a new UI signal to refresh the black-/white-list UI pane.

There was no testing suite to speak of, but I did test the breadth of the functionality manually as thoroughly as I could.
