### PR TITLE
Implemented getVersion API call #729

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -156,6 +156,8 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
         elif method == 'add':
             (a, b) = params
             return a + b
+        elif method == 'getVersion':
+            return shared.softwareVersion
         elif method == 'statusBar':
             message, = params
             shared.UISignalQueue.put(('updateStatusBar', message))


### PR DESCRIPTION
Implementation of feature request https://github.com/Bitmessage/PyBitmessage/issues/729: API to get current pybitmessage version number.

command: getVersion
parameters: n/a
description: Returns the version string.

The `getVersion` call is important, as it allows API users to determine which operations are available.

Example usage

``` python
import xmlrpclib
import json
import time

api = xmlrpclib.ServerProxy("http://user:pass@127.0.0.1:8442/")
print api.getVersion()
```

Note: Upon merging this commit, the [API reference documentation](https://bitmessage.org/wiki/API_Reference) should also be updated. 
