### PR TITLE
Revert "Fixed the path in shell executable when DESTDIR isn't empty"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ install:
 	install -m 644 desktop/can-icon.svg ${DESTDIR}${PREFIX}/share/icons/hicolor/scalable/apps/${APP}.svg
 	cp -rf src/* ${DESTDIR}${PREFIX}/share/${APP}
 	echo '#!/bin/sh' > ${DESTDIR}${PREFIX}/bin/${APP}
-	echo 'if [ -d ${DESTDIR}/usr/local/share/${APP} ]; then' >> ${DESTDIR}${PREFIX}/bin/${APP}
-	echo '  cd ${DESTDIR}/usr/local/share/${APP}' >> ${DESTDIR}${PREFIX}/bin/${APP}
+	echo 'if [ -d /usr/local/share/${APP} ]; then' >> ${DESTDIR}${PREFIX}/bin/${APP}
+	echo '  cd /usr/local/share/${APP}' >> ${DESTDIR}${PREFIX}/bin/${APP}
 	echo 'else' >> ${DESTDIR}${PREFIX}/bin/${APP}
-	echo '  cd ${DESTDIR}/usr/share/pybitmessage' >> ${DESTDIR}${PREFIX}/bin/${APP}
+	echo '  cd /usr/share/pybitmessage' >> ${DESTDIR}${PREFIX}/bin/${APP}
 	echo 'fi' >> ${DESTDIR}${PREFIX}/bin/${APP}
 	echo 'LD_LIBRARY_PATH="/opt/openssl-compat-bitcoin/lib/" exec python2 bitmessagemain.py' >> ${DESTDIR}${PREFIX}/bin/${APP}
 	chmod +x ${DESTDIR}${PREFIX}/bin/${APP}


### PR DESCRIPTION
I'm not sure what the original intention of this change was, but it breaks installation via debian packages. The `$DESTDIR` variable is [intended to facilitate staged installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html#DESTDIR), where the program is installed to a staging area before reaching its final destination. The staging area is not intended to stay around, and it will be deleted at some point after the files have been moved to their final destination.

Since the lines affected by this change are copied into the installation, this means that the staging path is left behind in the final shell script. The result is something like:

```
#!/bin/sh
if [ -d /tmp/tmp.TUTTv2xWvP/pybitmessage-0.4.4/debian/pybitmessage/usr/local/share/pybitmessage ]; then
  cd /tmp/tmp.TUTTv2xWvP/pybitmessage-0.4.4/debian/pybitmessage/usr/local/share/pybitmessage
else
  cd /tmp/tmp.TUTTv2xWvP/pybitmessage-0.4.4/debian/pybitmessage/usr/share/pybitmessage
fi
LD_LIBRARY_PATH="/opt/openssl-compat-bitcoin/lib/" exec python2 bitmessagemain.py
```

which means that the system-wide executable is actually launching the program from my temporary staging area and ignoring the files which were installed in the `/usr/share/` tree. This is not the intended effect; `$DESTDIR` should never be included anywhere in the files to be installed, by definition.
