### PR TITLE
Removed obsolete Protocol v2 code

### DIFF
--- a/src/pyelliptic/hash.py
+++ b/src/pyelliptic/hash.py
@@ -7,6 +7,32 @@
 from pyelliptic.openssl import OpenSSL
 
 
+# For python3
+def _equals_bytes(a, b):
+    if len(a) != len(b):
+        return False
+    result = 0
+    for x, y in zip(a, b):
+        result |= x ^ y
+    return result == 0
+
+
+def _equals_str(a, b):
+    if len(a) != len(b):
+        return False
+    result = 0
+    for x, y in zip(a, b):
+        result |= ord(x) ^ ord(y)
+    return result == 0
+
+
+def equals(a, b):
+    if isinstance(a, str):
+        return _equals_str(a, b)
+    else:
+        return _equals_bytes(a, b)
+
+
 def hmac_sha256(k, m):
     """
     Compute the key and the message with HMAC SHA5256


### PR DESCRIPTION
This also standardized the format of the data held in the transmitdata field in the pubkeys table. On start, Bitmessage will clear out everything from the pubkeys table and all of the pubkey objects from the inventory table. They will be redownloaded and inserted into the pubkeys table in the standard format.
