### PR TITLE
set log level from config file

### DIFF
--- a/src/debug.py
+++ b/src/debug.py
@@ -24,7 +24,9 @@ import helper_startup
 helper_startup.loadConfig()
 
 # TODO(xj9): Get from a config file.
-log_level = 'DEBUG'
+possible_log_levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+config_log_level = shared.config.get('bitmessagesettings', 'loglevel').upper()
+log_level = config_log_level if config_log_level in possible_log_levels else 'DEBUG'
 
 def configureLogging():
     logging.config.dictConfig({

--- a/src/shared.py
+++ b/src/shared.py
@@ -34,7 +34,9 @@ import shared
 from helper_sql import *
 
 
-config = ConfigParser.SafeConfigParser()
+config = ConfigParser.SafeConfigParser(
+    defaults={'loglevel':'DEBUG'
+    })
 myECCryptorObjects = {}
 MyECSubscriptionCryptorObjects = {}
 myAddressesByHash = {} #The key in this dictionary is the RIPE hash which is encoded in an address and value is the address itself.


### PR DESCRIPTION
Read the log level settings from the "loglevel" value in the
"bitmessagesettings" section of the config file. The possible
values map directly to the ones allowed by the logger module:
DEBUG, INFO, WARNING, ERROR, CRITICAL
Only allow these values, and cast to upper case to be more easy
going in the settings.