### PR TITLE
Fix isOurOperatingSystemLimitedToHavingVeryFewHalfOpenConnections on BSD

### DIFF
--- a/src/helper_startup.py
+++ b/src/helper_startup.py
@@ -140,8 +140,11 @@ def loadConfig():
 
 def isOurOperatingSystemLimitedToHavingVeryFewHalfOpenConnections():
     try:
-        VER_THIS=StrictVersion(platform.version())
         if sys.platform[0:3]=="win":
+            # This check won't work on BSD platforms, replacing it with
+            # platform.release() still won't be portable, as e.g. FreeBSD might
+            # return '11.0-CURRENT'. Leave the version check for Windows only.
+            VER_THIS=StrictVersion(platform.version())
             return StrictVersion("5.1.2600")<=VER_THIS and StrictVersion("6.0.6000")>=VER_THIS
         return False
     except Exception as err:


### PR DESCRIPTION
Examples:

NetBSD:
>>> print platform.version()
NetBSD 7.99.21 (GENERIC) #1: Sun Sep 13 01:23:14 CEST 2015  root@chieftec:/tmp/netbsd-tmp/sys/arch/amd64/compile/GENERIC
>>> print platform.release()
7.99.21

OpenBSD:
>>> print platform.version()
GENERIC#738
>>> print platform.release()
5.7

FreeBSD:
>>> print platform.version()
FreeBSD 11.0-CURRENT #0 r285794: Thu Jul 23 00:39:41 UTC 2015     root@releng2.nyi.freebsd.org:/usr/obj/arm.armv6/usr/src/sys/RPI2
>>> print platform.release()
11.0-CURRENT

Supersedes #811 