### PR TITLE
Fix python shebangs from `#!/usr/bin/env python2.7*' to `#!/usr/bin/python2.7'.

### DIFF
--- a/src/bitmessagecli.py
+++ b/src/bitmessagecli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7.x
+#!/usr/bin/python2.7
 # Created by Adam Melton (.dok) referenceing https://bitmessage.org/wiki/API_Reference for API documentation
 # Distributed under the MIT/X11 software license. See http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python2.7
 # Copyright (c) 2012-2016 Jonathan Warren
 # Copyright (c) 2012-2016 The Bitmessage developers
 # Distributed under the MIT/X11 software license. See the accompanying


### PR DESCRIPTION
Fix python shebangs from `#!/usr/bin/env python2.7*' to `#!/usr/bin/python2.7'.

* src/bitmessagecli.py: fix it.
* src/bitmessagemain.py: same.

This fixes #887.