### PR TITLE
Update pybitmessage.desktop with more search friendly GenericName

### DIFF
--- a/desktop/pybitmessage.desktop
+++ b/desktop/pybitmessage.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=PyBitmessage
-GenericName=PyBitmessage
+GenericName=Bitmessage Client
 Comment=Send encrypted messages
 Exec=pybitmessage %F
 Icon=pybitmessage


### PR DESCRIPTION
Often when I search for PyBitmessage in Gnome 3 nothing comes up because "Bitmessage" is not a word in the `.desktop` file. Changing the `GenericName` to include the word "Bitmessage" should fix this and it is in fact a generic name for PyBitmessage.