### PR TITLE
Handle exceptions from python without ipv6 support

### DIFF
--- a/src/protocol.py
+++ b/src/protocol.py
@@ -100,7 +100,10 @@ def checkIPAddress(host, private=False):
             return False
         return hostStandardFormat
     else:
-        hostStandardFormat = socket.inet_ntop(socket.AF_INET6, host)
+        try:
+            hostStandardFormat = socket.inet_ntop(socket.AF_INET6, host)
+        except ValueError:
+            return False
         if hostStandardFormat == "":
             # This can happen on Windows systems which are not 64-bit compatible 
             # so let us drop the IPv6 address. 


### PR DESCRIPTION
Hello.

PyBitmessage shown many exceptions on my linux laptop because of python installed without ipv6 support. I tried to handle them all properly. The only question that remains is the log message "Peer host is None!" from line 53 in src/class_outgoingSynSender.py.