### PR TITLE
Total setup.py cleanup and simple script installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ src/**/*.o
 src/**/*.so
 build/lib.*
 build/temp.*
+dist
+*.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include COPYING
+include README.md
+recursive-include desktop *

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -9,17 +9,22 @@
 
 # The software version variable is now held in shared.py
 
+import os
+import sys
+
+app_dir = os.path.dirname(os.path.abspath(__file__))
+os.chdir(app_dir)
+sys.path.insert(0, app_dir)
+
 import depends
 depends.check_dependencies()
 
 import signal  # Used to capture a Ctrl-C keypress so that Bitmessage can shutdown gracefully.
 # The next 3 are used for the API
 from singleinstance import singleinstance
-import os
 import socket
 import ctypes
 from struct import pack
-import sys
 from subprocess import call
 import time
 
@@ -28,7 +33,6 @@ from helper_startup import isOurOperatingSystemLimitedToHavingVeryFewHalfOpenCon
 
 import defaults
 import shared
-from helper_sql import sqlQuery
 import knownnodes
 import state
 import shutdown
@@ -45,12 +49,12 @@ from class_addressGenerator import addressGenerator
 from class_smtpDeliver import smtpDeliver
 from class_smtpServer import smtpServer
 from bmconfigparser import BMConfigParser
-from debug import logger
 
 # Helper Functions
 import helper_bootstrap
 import helper_generic
 from helper_threading import *
+
 
 def connectToStream(streamNumber):
     state.streamsInWhichIAmParticipating.append(streamNumber)
@@ -309,9 +313,14 @@ class Main:
         port = BMConfigParser().getint('bitmessagesettings', 'apiport')
         return {'address':address,'port':port}
 
-if __name__ == "__main__":
+
+def main():
     mainprogram = Main()
-    mainprogram.start(BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon'))
+    mainprogram.start(
+        BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon'))
+
+if __name__ == "__main__":
+    main()
 
 
 # So far, the creation of and management of the Bitmessage protocol and this

--- a/src/pybitmessage
+++ b/src/pybitmessage
@@ -1,0 +1,11 @@
+#!/usr/bin/python2.7
+
+import os
+import pkg_resources
+
+dist = pkg_resources.get_distribution('pybitmessage')
+script_file = os.path.join(dist.location, dist.key, 'bitmessagemain.py')
+new_globals = globals()
+new_globals.update(__file__=script_file)
+
+execfile(script_file, new_globals)


### PR DESCRIPTION
Hello!

I made some changes to setuptools settings trying to make the it's operations more predictable, particularly:
 * the package `pybitmessage` installed into `pybitmessage` directory;
 * distutils-style script installation (a bit tricky): commented setuptools entry point could work if the program were able to run inside package, but currently it will lead to namespace problems and circular dependencies;
 * MANIFEST.in lists the files needed for `sdist` command (appended working files which may appear after it's invocation to `.gitignore` );

I also
 * made `setup.py` clean, readable and strict PEP8;
 * fixed typo in certificates location -> 'sslkeys/*.pem';
 * added the package manager and packages names for gentoo (Calculate is it's flavor).