### PR TITLE
Missed translations: namecoin and welcome message

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -659,14 +659,12 @@ class MyForm(settingsmixin.SMainWindow):
         self.rerenderTabTreeMessages()
 
         # Set welcome message
-        self.ui.textEditInboxMessage.setText(
-        """
+        self.ui.textEditInboxMessage.setText(_translate("MainWindow", """
         Welcome to easy and secure Bitmessage
             * send messages to other people
             * send broadcast messages like twitter or
             * discuss in chan(nel)s with other people
-        """
-        )
+        """))
 
         # Initialize the address book
         self.rerenderAddressBook()

--- a/src/translations/bitmessage.pro
+++ b/src/translations/bitmessage.pro
@@ -16,6 +16,7 @@ SOURCES	= 	../addresses.py\
 			../helper_msgcoding.py\
 			../helper_sent.py\
 			../helper_startup.py\
+                        ../namecoin.py\
 			../proofofwork.py\
 			../shared.py\
 			../upnp.py\


### PR DESCRIPTION
There is also a question about translations of MB, kB, etc. in [bitmessageqt/networkstatus.py](../tree/v0.6/src/bitmessageqt/networkstatus.py#L37) ...