### PR TITLE
More fixes for l10n

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -1460,19 +1460,50 @@ class MyForm(settingsmixin.SMainWindow):
                 # may manage your keys by editing the keys.dat file stored in
                 # the same directory as this program. It is important that you
                 # back up this file.', QMessageBox.Ok)
-                reply = QtGui.QMessageBox.information(self, 'keys.dat?', _translate(
-                    "MainWindow", "You may manage your keys by editing the keys.dat file stored in the same directory as this program. It is important that you back up this file."), QtGui.QMessageBox.Ok)
-
+                reply = QtGui.QMessageBox.information(
+                    self, 'keys.dat?', _translate(
+                        "MainWindow",
+                        "You may manage your keys by editing the keys.dat"
+                        " file stored in the same directory as this program."
+                        " It is important that you back up this file."),
+                    QtGui.QMessageBox.Ok)
             else:
-                QtGui.QMessageBox.information(self, 'keys.dat?', _translate(
-                    "MainWindow", "You may manage your keys by editing the keys.dat file stored in\n %1 \nIt is important that you back up this file.").arg(state.appdata), QtGui.QMessageBox.Ok)
+                QtGui.QMessageBox.information(
+                    self, 'keys.dat?', _translate(
+                        "MainWindow",
+                        "You may manage your keys by editing the keys.dat"
+                        " file stored in\n %1 \n"
+                        "It is important that you back up this file."
+                    ).arg(state.appdata), QtGui.QMessageBox.Ok)
         elif sys.platform == 'win32' or sys.platform == 'win64':
+            _tr_open = _translate(
+                "MainWindow",
+                " Would you like to open the file now?"
+                " (Be sure to close Bitmessage before making"
+                " any changes.)",
+                "The second part of string begining with "
+                "\'You may manage your keys ...\' "
+                "Notice the leading space!"
+            )
             if state.appdata == '':
-                reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Open keys.dat?"), _translate(
-                    "MainWindow", "You may manage your keys by editing the keys.dat file stored in the same directory as this program. It is important that you back up this file. Would you like to open the file now? (Be sure to close Bitmessage before making any changes.)"), QtGui.QMessageBox.Yes, QtGui.QMessageBox.No)
+                reply = QtGui.QMessageBox.question(
+                    self, _translate("MainWindow", "Open keys.dat?"),
+                    _translate(
+                        "MainWindow",
+                        "You may manage your keys by editing the keys.dat"
+                        " file stored in the same directory as this program."
+                        " It is important that you back up this file."
+                    ) + _tr_open, QtGui.QMessageBox.Yes, QtGui.QMessageBox.No)
             else:
-                reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Open keys.dat?"), _translate(
-                    "MainWindow", "You may manage your keys by editing the keys.dat file stored in\n %1 \nIt is important that you back up this file. Would you like to open the file now? (Be sure to close Bitmessage before making any changes.)").arg(state.appdata), QtGui.QMessageBox.Yes, QtGui.QMessageBox.No)
+                reply = QtGui.QMessageBox.question(
+                    self, _translate("MainWindow", "Open keys.dat?"),
+                    _translate(
+                        "MainWindow",
+                        "You may manage your keys by editing the keys.dat"
+                        " file stored in\n %1 \n"
+                        "It is important that you back up this file."
+                    ).arg(state.appdata) + _tr_open,
+                    QtGui.QMessageBox.Yes, QtGui.QMessageBox.No)
             if reply == QtGui.QMessageBox.Yes:
                 shared.openKeysFile()
 
@@ -1960,24 +1991,32 @@ class MyForm(settingsmixin.SMainWindow):
                             pass
                         logger.error('Error: Could not decode recipient address ' + toAddress + ':' + status)
 
+                        _tr_wrong_soft = _translate(
+                            "MainWindow",
+                            "There might be something wrong with the software"
+                            " of your acquaintance.",
+                            "The second part of string begining with "
+                            "\'Error: Some data encoded in the "
+                            "recipient address...\'"
+                        )
                         if status == 'missingbm':
                             self.updateStatusBar(_translate(
                                 "MainWindow",
                                 "Error: Bitmessage addresses start with"
                                 " BM-   Please check the recipient address %1"
-                                ).arg(toAddress))
+                            ).arg(toAddress))
                         elif status == 'checksumfailed':
                             self.updateStatusBar(_translate(
                                 "MainWindow",
                                 "Error: The recipient address %1 is not"
                                 " typed or copied correctly. Please check it."
-                                ).arg(toAddress))
+                            ).arg(toAddress))
                         elif status == 'invalidcharacters':
                             self.updateStatusBar(_translate(
                                 "MainWindow",
                                 "Error: The recipient address %1 contains"
                                 " invalid characters. Please check it."
-                                ).arg(toAddress))
+                            ).arg(toAddress))
                         elif status == 'versiontoohigh':
                             self.updateStatusBar(_translate(
                                 "MainWindow",
@@ -1985,44 +2024,37 @@ class MyForm(settingsmixin.SMainWindow):
                                 " %1 is too high. Either you need to upgrade"
                                 " your Bitmessage software or your"
                                 " acquaintance is being clever."
-                                ).arg(toAddress))
+                            ).arg(toAddress))
                         elif status == 'ripetooshort':
                             self.updateStatusBar(_translate(
                                 "MainWindow",
                                 "Error: Some data encoded in the recipient"
-                                " address %1 is too short. There might be"
-                                " something wrong with the software of"
-                                " your acquaintance."
-                                ).arg(toAddress))
+                                " address %1 is too short. ").arg(toAddress) +
+                                _tr_wrong_soft)
                         elif status == 'ripetoolong':
                             self.updateStatusBar(_translate(
                                 "MainWindow",
                                 "Error: Some data encoded in the recipient"
-                                " address %1 is too long. There might be"
-                                " something wrong with the software of"
-                                " your acquaintance."
-                                ).arg(toAddress))
+                                " address %1 is too long. ").arg(toAddress) +
+                                _tr_wrong_soft)
                         elif status == 'varintmalformed':
                             self.updateStatusBar(_translate(
                                 "MainWindow",
                                 "Error: Some data encoded in the recipient"
-                                " address %1 is malformed. There might be"
-                                " something wrong with the software of"
-                                " your acquaintance."
-                                ).arg(toAddress))
+                                " address %1 is malformed. ").arg(toAddress) +
+                                _tr_wrong_soft)
                         else:
                             self.updateStatusBar(_translate(
                                 "MainWindow",
                                 "Error: Something is wrong with the"
                                 " recipient address %1."
-                                ).arg(toAddress))
+                            ).arg(toAddress))
                     elif fromAddress == '':
                         self.updateStatusBar(_translate(
                             "MainWindow",
                             "Error: You must specify a From address. If you"
                             " don\'t have one, go to the"
-                            " \'Your Identities\' tab.")
-                        )
+                            " \'Your Identities\' tab."))
                     else:
                         toAddress = addBMIfNotPresent(toAddress)
 
@@ -2743,10 +2775,27 @@ class MyForm(settingsmixin.SMainWindow):
             elif reply == QtGui.QMessageBox.Cancel:
                 return
 
+        _tr_if_quit = _translate(
+            "MainWindow",
+            " If you quit now, it may cause delivery delays."
+            " Wait until the synchronization finishes?",
+            "The second part of string begining with "
+            "\'Bitmessage hasn't synchronized (connected)...\' "
+            "Notice the leading space!"
+        )
         if PendingDownloadQueue.totalSize() > 0:
-            reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Synchronization pending"),
-                    _translate("MainWindow", "Bitmessage hasn't synchronized with the network, %n object(s) to be downloaded. If you quit now, it may cause delivery delays. Wait until the synchronization finishes?", None, _codec, PendingDownloadQueue.totalSize()),
-                    QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Cancel)
+            reply = QtGui.QMessageBox.question(
+                self,
+                _translate("MainWindow", "Synchronization pending"),
+                _translate(
+                    "MainWindow",
+                    "Bitmessage hasn't synchronized with the network,"
+                    " %n object(s) to be downloaded.",
+                    None, _codec, PendingDownloadQueue.totalSize()
+                ) + _tr_if_quit,
+                QtGui.QMessageBox.Yes | QtGui.QMessageBox.No |
+                QtGui.QMessageBox.Cancel,
+                QtGui.QMessageBox.Cancel)
             if reply == QtGui.QMessageBox.Yes:
                 waitForSync = True
             elif reply == QtGui.QMessageBox.Cancel:
@@ -2754,11 +2803,19 @@ class MyForm(settingsmixin.SMainWindow):
             else:
                 PendingDownloadQueue.stop()
 
-        if shared.statusIconColor == 'red' and not BMConfigParser().safeGetBoolean(
-                'bitmessagesettings', 'dontconnect'):
-            reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Not connected"),
-                    _translate("MainWindow", "Bitmessage isn't connected to the network. If you quit now, it may cause delivery delays. Wait until connected and the synchronization finishes?"),
-                    QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Cancel)
+        if shared.statusIconColor == 'red' \
+            and not BMConfigParser().safeGetBoolean(
+                    'bitmessagesettings', 'dontconnect'):
+            reply = QtGui.QMessageBox.question(
+                self,
+                _translate("MainWindow", "Not connected"),
+                _translate(
+                    "MainWindow",
+                    "Bitmessage isn't connected to the network."
+                ) + _tr_if_quit,
+                QtGui.QMessageBox.Yes | QtGui.QMessageBox.No |
+                QtGui.QMessageBox.Cancel,
+                QtGui.QMessageBox.Cancel)
             if reply == QtGui.QMessageBox.Yes:
                 waitForConnection = True
                 waitForSync = True

--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3976,20 +3976,20 @@ class MyForm(settingsmixin.SMainWindow):
                 self.popMenuInbox.addAction(self.actionAddSenderToAddressBook)
                 self.actionClipboardMessagelist = \
                     self.ui.inboxContextMenuToolbar.addAction(
-                        _translate(
-                            "MainWindow",
-                            "Copy subject to clipboard"
-                            if tableWidget.currentColumn() == 2
-                            else "Copy address to clipboard"),
+                        _translate("MainWindow", "Copy subject to clipboard")
+                        if tableWidget.currentColumn() == 2
+                        else _translate(
+                            "MainWindow", "Copy address to clipboard"),
                         self.on_action_ClipboardMessagelist
-                )
+                    )
                 self.popMenuInbox.addAction(self.actionClipboardMessagelist)
                 self.popMenuInbox.addSeparator()
                 self.popMenuInbox.addAction(self.actionAddSenderToBlackList)
                 self.popMenuInbox.addSeparator()
                 self.popMenuInbox.addAction(self.actionSaveMessageAs)
                 if currentFolder == "trash":
-                    self.popMenuInbox.addAction(self.actionUndeleteTrashedMessage)
+                    self.popMenuInbox.addAction(
+                        self.actionUndeleteTrashedMessage)
                 else:
                     self.popMenuInbox.addAction(self.actionTrashInboxMessage)
                 self.popMenuInbox.exec_(tableWidget.mapToGlobal(point))

--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -9,7 +9,7 @@ except Exception as err:
     logger.critical(logmsg, exc_info=True)
     sys.exit()
 
-from tr import _translate
+from tr import _translate, _codec
 from addresses import decodeAddress, addBMIfNotPresent
 import shared
 from bitmessageui import Ui_MainWindow
@@ -585,8 +585,10 @@ class MyForm(settingsmixin.SMainWindow):
                 addressInKeysFile)
             if addressVersionNumber == 1:
                 displayMsg = _translate(
-                    "MainWindow", "One of your addresses, %1, is an old version 1 address. Version 1 addresses are no longer supported. "
-                    + "May we delete it now?").arg(addressInKeysFile)
+                    "MainWindow",
+                    "One of your addresses, %1, is an old version 1 address."
+                    " Version 1 addresses are no longer supported."
+                    " May we delete it now?").arg(addressInKeysFile)
                 reply = QtGui.QMessageBox.question(
                     self, 'Message', displayMsg, QtGui.QMessageBox.Yes, QtGui.QMessageBox.No)
                 if reply == QtGui.QMessageBox.Yes:
@@ -816,16 +818,17 @@ class MyForm(settingsmixin.SMainWindow):
         stylesheet = ""
 
         if numberOfHours < 48:
-            self.ui.labelHumanFriendlyTTLDescription.setText(
-                _translate("MainWindow", "%n hour(s)", None, QtCore.QCoreApplication.CodecForTr, numberOfHours) +
-                ", " +
-                _translate("MainWindow", "not recommended for chans", None, QtCore.QCoreApplication.CodecForTr)
-                )
+            self.ui.labelHumanFriendlyTTLDescription.setText(_translate(
+                "MainWindow", "%n hour(s), not recommended for chans",
+                None, _codec, numberOfHours
+            ))
             stylesheet = "QLabel { color : red; }"
             font.setBold(True)
         else:
             numberOfDays = int(round(TTL / (24*60*60)))
-            self.ui.labelHumanFriendlyTTLDescription.setText(_translate("MainWindow", "%n day(s)", None, QtCore.QCoreApplication.CodecForTr, numberOfDays))
+            self.ui.labelHumanFriendlyTTLDescription.setText(_translate(
+                "MainWindow", "%n day(s)", None, _codec, numberOfDays
+            ))
             font.setBold(False)
         self.ui.labelHumanFriendlyTTLDescription.setStyleSheet(stylesheet)
         self.ui.labelHumanFriendlyTTLDescription.setFont(font)
@@ -1068,8 +1071,10 @@ class MyForm(settingsmixin.SMainWindow):
             statusText = _translate(
                 "MainWindow", "Forced difficulty override. Send should start soon.")
         else:
-            statusText = _translate("MainWindow", "Unknown status: %1 %2").arg(status).arg(
-                l10n.formatTimestamp(lastactiontime))
+            statusText = _translate(
+                "MainWindow", "Unknown status: %1 %2").arg(
+                    status, l10n.formatTimestamp(lastactiontime)
+                )
         newItem = myTableWidgetItem(statusText)
         newItem.setToolTip(statusText)
         newItem.setData(QtCore.Qt.UserRole, QtCore.QByteArray(ackdata))
@@ -1143,7 +1148,8 @@ class MyForm(settingsmixin.SMainWindow):
         tableWidget.horizontalHeader().setSortIndicator(
             3, QtCore.Qt.DescendingOrder)
         tableWidget.setSortingEnabled(True)
-        tableWidget.horizontalHeaderItem(3).setText(_translate("MainWindow", "Sent", None))
+        tableWidget.horizontalHeaderItem(3).setText(
+            _translate("MainWindow", "Sent"))
         tableWidget.setUpdatesEnabled(True)
 
     # Load messages from database file
@@ -1177,7 +1183,8 @@ class MyForm(settingsmixin.SMainWindow):
             3, QtCore.Qt.DescendingOrder)
         tableWidget.setSortingEnabled(True)
         tableWidget.selectRow(0)
-        tableWidget.horizontalHeaderItem(3).setText(_translate("MainWindow", "Received", None))
+        tableWidget.horizontalHeaderItem(3).setText(
+            _translate("MainWindow", "Received"))
         tableWidget.setUpdatesEnabled(True)
 
     # create application indicator
@@ -2020,12 +2027,28 @@ class MyForm(settingsmixin.SMainWindow):
                         toAddress = addBMIfNotPresent(toAddress)
 
                         if addressVersionNumber > 4 or addressVersionNumber <= 1:
-                            QtGui.QMessageBox.about(self, _translate("MainWindow", "Address version number"), _translate(
-                                "MainWindow", "Concerning the address %1, Bitmessage cannot understand address version numbers of %2. Perhaps upgrade Bitmessage to the latest version.").arg(toAddress).arg(str(addressVersionNumber)))
+                            QtGui.QMessageBox.about(
+                                self, _translate(
+                                    "MainWindow", "Address version number"),
+                                _translate(
+                                    "MainWindow",
+                                    "Concerning the address %1, Bitmessage"
+                                    " cannot understand address version"
+                                    " numbers of %2. Perhaps upgrade"
+                                    " Bitmessage to the latest version."
+                                ).arg(toAddress, str(addressVersionNumber)))
                             continue
                         if streamNumber > 1 or streamNumber == 0:
-                            QtGui.QMessageBox.about(self, _translate("MainWindow", "Stream number"), _translate(
-                                "MainWindow", "Concerning the address %1, Bitmessage cannot handle stream numbers of %2. Perhaps upgrade Bitmessage to the latest version.").arg(toAddress).arg(str(streamNumber)))
+                            QtGui.QMessageBox.about(
+                                self, _translate(
+                                    "MainWindow", "Stream number"),
+                                _translate(
+                                    "MainWindow",
+                                    "Concerning the address %1, Bitmessage"
+                                    " cannot handle stream numbers of %2."
+                                    " Perhaps upgrade Bitmessage to the"
+                                    " latest version."
+                                ).arg(toAddress, str(streamNumber)))
                             continue
                         self.statusbar.clearMessage()
                         if shared.statusIconColor == 'red':
@@ -2699,12 +2722,22 @@ class MyForm(settingsmixin.SMainWindow):
         waitForSync = False
 
         # C PoW currently doesn't support interrupting and OpenCL is untested
-        if getPowType() == "python" and (powQueueSize() > 0 or PendingUpload().len() > 0):
-            reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Proof of work pending"),
-                    _translate("MainWindow", "%n object(s) pending proof of work", None, QtCore.QCoreApplication.CodecForTr, powQueueSize()) + ", " +
-                    _translate("MainWindow", "%n object(s) waiting to be distributed", None, QtCore.QCoreApplication.CodecForTr, PendingUpload().len()) + "\n\n" + 
-                    _translate("MainWindow", "Wait until these tasks finish?"),
-                    QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Cancel)
+        if getPowType() == "python" and (
+                powQueueSize() > 0 or PendingUpload().len() > 0
+        ):
+            reply = QtGui.QMessageBox.question(
+                self, _translate("MainWindow", "Proof of work pending"),
+                _translate(
+                    "MainWindow", "%n object(s) pending proof of work",
+                    None, _codec, powQueueSize()) + ", " +
+                _translate(
+                    "MainWindow", "%n object(s) waiting to be distributed",
+                    None, _codec, PendingUpload().len()) + "\n\n" +
+                _translate("MainWindow", "Wait until these tasks finish?"),
+                QtGui.QMessageBox.Yes | QtGui.QMessageBox.No |
+                QtGui.QMessageBox.Cancel,
+                QtGui.QMessageBox.Cancel
+            )
             if reply == QtGui.QMessageBox.No:
                 waitForPow = False
             elif reply == QtGui.QMessageBox.Cancel:
@@ -2712,7 +2745,7 @@ class MyForm(settingsmixin.SMainWindow):
 
         if PendingDownloadQueue.totalSize() > 0:
             reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Synchronisation pending"),
-                    _translate("MainWindow", "Bitmessage hasn't synchronised with the network, %n object(s) to be downloaded. If you quit now, it may cause delivery delays. Wait until the synchronisation finishes?", None, QtCore.QCoreApplication.CodecForTr, PendingDownloadQueue.totalSize()),
+                    _translate("MainWindow", "Bitmessage hasn't synchronised with the network, %n object(s) to be downloaded. If you quit now, it may cause delivery delays. Wait until the synchronisation finishes?", None, _codec, PendingDownloadQueue.totalSize()),
                     QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Cancel)
             if reply == QtGui.QMessageBox.Yes:
                 waitForSync = True
@@ -3884,11 +3917,15 @@ class MyForm(settingsmixin.SMainWindow):
                     self.popMenuInbox.addAction(self.actionReplyChan)
                 self.popMenuInbox.addAction(self.actionReply)
                 self.popMenuInbox.addAction(self.actionAddSenderToAddressBook)
-                self.actionClipboardMessagelist = self.ui.inboxContextMenuToolbar.addAction(
-                    _translate("MainWindow",
-                        "Copy subject to clipboard" if tableWidget.currentColumn() == 2 else "Copy address to clipboard"
-                    ),
-                    self.on_action_ClipboardMessagelist)
+                self.actionClipboardMessagelist = \
+                    self.ui.inboxContextMenuToolbar.addAction(
+                        _translate(
+                            "MainWindow",
+                            "Copy subject to clipboard"
+                            if tableWidget.currentColumn() == 2
+                            else "Copy address to clipboard"),
+                        self.on_action_ClipboardMessagelist
+                )
                 self.popMenuInbox.addAction(self.actionClipboardMessagelist)
                 self.popMenuInbox.addSeparator()
                 self.popMenuInbox.addAction(self.actionAddSenderToBlackList)

--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -2744,8 +2744,8 @@ class MyForm(settingsmixin.SMainWindow):
                 return
 
         if PendingDownloadQueue.totalSize() > 0:
-            reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Synchronisation pending"),
-                    _translate("MainWindow", "Bitmessage hasn't synchronised with the network, %n object(s) to be downloaded. If you quit now, it may cause delivery delays. Wait until the synchronisation finishes?", None, _codec, PendingDownloadQueue.totalSize()),
+            reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Synchronization pending"),
+                    _translate("MainWindow", "Bitmessage hasn't synchronized with the network, %n object(s) to be downloaded. If you quit now, it may cause delivery delays. Wait until the synchronization finishes?", None, _codec, PendingDownloadQueue.totalSize()),
                     QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Cancel)
             if reply == QtGui.QMessageBox.Yes:
                 waitForSync = True
@@ -2757,7 +2757,7 @@ class MyForm(settingsmixin.SMainWindow):
         if shared.statusIconColor == 'red' and not BMConfigParser().safeGetBoolean(
                 'bitmessagesettings', 'dontconnect'):
             reply = QtGui.QMessageBox.question(self, _translate("MainWindow", "Not connected"),
-                    _translate("MainWindow", "Bitmessage isn't connected to the network. If you quit now, it may cause delivery delays. Wait until connected and the synchronisation finishes?"),
+                    _translate("MainWindow", "Bitmessage isn't connected to the network. If you quit now, it may cause delivery delays. Wait until connected and the synchronization finishes?"),
                     QtGui.QMessageBox.Yes|QtGui.QMessageBox.No|QtGui.QMessageBox.Cancel, QtGui.QMessageBox.Cancel)
             if reply == QtGui.QMessageBox.Yes:
                 waitForConnection = True
@@ -2782,7 +2782,7 @@ class MyForm(settingsmixin.SMainWindow):
         # this probably will not work correctly, because there is a delay between the status icon turning red and inventory exchange, but it's better than nothing.
         if waitForSync:
             self.updateStatusBar(_translate(
-                "MainWindow", "Waiting for finishing synchronisation..."))
+                "MainWindow", "Waiting for finishing synchronization..."))
             while PendingDownloadQueue.totalSize() > 0:
                 time.sleep(0.5)
                 QtCore.QCoreApplication.processEvents(

--- a/src/bitmessageqt/bitmessageui.py
+++ b/src/bitmessageqt/bitmessageui.py
@@ -755,7 +755,7 @@ class Ui_MainWindow(object):
         self.actionExit.setText(_translate("MainWindow", "Quit", None))
         self.actionExit.setShortcut(_translate("MainWindow", "Ctrl+Q", None))
         self.actionHelp.setText(_translate("MainWindow", "Help", None))
-        self.actionHelp.setShortcut(_translate("MainWindow", "F1", None))
+        self.actionHelp.setShortcut("F1")
         self.actionSupport.setText(_translate("MainWindow", "Contact support", None))
         self.actionAbout.setText(_translate("MainWindow", "About", None))
         self.actionSettings.setText(_translate("MainWindow", "Settings", None))

--- a/src/bitmessageqt/connect.ui
+++ b/src/bitmessageqt/connect.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Bitmessage</string>
+   <string notr="true">Bitmessage</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0" colspan="2">

--- a/src/bitmessageqt/emailgateway.ui
+++ b/src/bitmessageqt/emailgateway.ui
@@ -56,7 +56,7 @@
       <bool>true</bool>
      </property>
      <property name="text">
-      <string>@mailchuck.com</string>
+      <string notr="true">@mailchuck.com</string>
      </property>
      <property name="cursorPosition">
       <number>0</number>

--- a/src/bitmessageqt/help.ui
+++ b/src/bitmessageqt/help.ui
@@ -17,7 +17,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="labelHelpURI">
      <property name="text">
-      <string>&lt;a href=&quot;https://bitmessage.org/wiki/PyBitmessage_Help&quot;&gt;https://bitmessage.org/wiki/PyBitmessage_Help&lt;/a&gt;</string>
+      <string notr="true">&lt;a href=&quot;https://bitmessage.org/wiki/PyBitmessage_Help&quot;&gt;https://bitmessage.org/wiki/PyBitmessage_Help&lt;/a&gt;</string>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>

--- a/src/bitmessageqt/networkstatus.py
+++ b/src/bitmessageqt/networkstatus.py
@@ -1,8 +1,7 @@
 from PyQt4 import QtCore, QtGui
 import time
 import shared
-
-from tr import _translate
+from tr import _translate, _codec
 from inventory import Inventory, PendingDownloadQueue, PendingUpload
 import knownnodes
 import l10n
@@ -27,9 +26,10 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
             header.setSortIndicator(0, QtCore.Qt.AscendingOrder)
 
         self.startup = time.localtime()
-        self.labelStartupTime.setText(_translate("networkstatus", "Since startup on %1").arg(
-            l10n.formatTimestamp(self.startup)))
-        
+        self.labelStartupTime.setText(_translate(
+            "networkstatus", "Since startup on %1"
+            ).arg(l10n.formatTimestamp(self.startup)))
+
         self.UISignalThread = UISignaler.get()
         QtCore.QObject.connect(self.UISignalThread, QtCore.SIGNAL(
             "updateNumberOfMessagesProcessed()"), self.updateNumberOfMessagesProcessed)
@@ -54,33 +54,42 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
         self.timer.stop()
 
     def formatBytes(self, num):
-        for x in [_translate("networkstatus", "byte(s)", None, QtCore.QCoreApplication.CodecForTr, num), "kB", "MB", "GB"]:
+        for x in [_translate("networkstatus", "byte(s)", None, _codec, num),
+                  _translate("networkstatus", "kB"),
+                  _translate("networkstatus", "MB"),
+                  _translate("networkstatus", "GB")]:
             if num < 1000.0:
                 return "%3.0f %s" % (num, x)
             num /= 1000.0
-        return "%3.0f %s" % (num, 'TB')
+        return "%3.0f %s" % (num, _translate("networkstatus", "TB"))
 
     def formatByteRate(self, num):
         num /= 1000
-        return "%4.0f kB" % num
-        
+        return "%4.0f" % num
+
     def updateNumberOfObjectsToBeSynced(self):
-        self.labelSyncStatus.setText(_translate("networkstatus", "Object(s) to be synced: %n", None, QtCore.QCoreApplication.CodecForTr, network.stats.pendingDownload() + network.stats.pendingUpload()))
+        self.labelSyncStatus.setText(_translate(
+            "networkstatus", "Object(s) to be synced: %n", None, _codec,
+            network.stats.pendingDownload() + network.stats.pendingUpload()
+        ))
 
     def updateNumberOfMessagesProcessed(self):
         self.updateNumberOfObjectsToBeSynced()
         self.labelMessageCount.setText(_translate(
-            "networkstatus", "Processed %n person-to-person message(s).", None, QtCore.QCoreApplication.CodecForTr, shared.numberOfMessagesProcessed))
+            "networkstatus", "Processed %n person-to-person message(s).",
+            None, _codec, shared.numberOfMessagesProcessed))
 
     def updateNumberOfBroadcastsProcessed(self):
         self.updateNumberOfObjectsToBeSynced()
         self.labelBroadcastCount.setText(_translate(
-            "networkstatus", "Processed %n broadcast message(s).", None, QtCore.QCoreApplication.CodecForTr, shared.numberOfBroadcastsProcessed))
+            "networkstatus", "Processed %n broadcast message(s).",
+            None, _codec, shared.numberOfBroadcastsProcessed))
 
     def updateNumberOfPubkeysProcessed(self):
         self.updateNumberOfObjectsToBeSynced()
         self.labelPubkeyCount.setText(_translate(
-            "networkstatus", "Processed %n public key(s).", None, QtCore.QCoreApplication.CodecForTr, shared.numberOfPubkeysProcessed))
+            "networkstatus", "Processed %n public key(s).",
+            None, _codec, shared.numberOfPubkeysProcessed))
 
     def updateNumberOfBytes(self):
         """
@@ -88,9 +97,15 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
         sent and received by 2.
         """
         self.labelBytesRecvCount.setText(_translate(
-            "networkstatus", "Down: %1/s  Total: %2").arg(self.formatByteRate(network.stats.downloadSpeed()), self.formatBytes(network.stats.receivedBytes())))
+            "networkstatus", "Down: %1 kB/s  Total: %2").arg(
+                self.formatByteRate(network.stats.downloadSpeed()),
+                self.formatBytes(network.stats.receivedBytes()))
+        )
         self.labelBytesSentCount.setText(_translate(
-            "networkstatus", "Up: %1/s  Total: %2").arg(self.formatByteRate(network.stats.uploadSpeed()), self.formatBytes(network.stats.sentBytes())))
+            "networkstatus", "Up: %1 kB/s  Total: %2").arg(
+                self.formatByteRate(network.stats.uploadSpeed()),
+                self.formatBytes(network.stats.sentBytes()))
+        )
 
     def updateNetworkStatusTab(self, outbound, add, destination):
         if outbound:
@@ -151,8 +166,9 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
         self.tableWidgetConnectionCount.setUpdatesEnabled(True)
         self.tableWidgetConnectionCount.setSortingEnabled(True)
         self.labelTotalConnections.setText(_translate(
-            "networkstatus", "Total Connections: %1").arg(str(self.tableWidgetConnectionCount.rowCount())))
-       # FYI: The 'singlelistener' thread sets the icon color to green when it receives an incoming connection, meaning that the user's firewall is configured correctly.
+            "networkstatus", "Total Connections: %1"
+        ).arg(str(self.tableWidgetConnectionCount.rowCount())))
+        # FYI: The 'singlelistener' thread sets the icon color to green when it receives an incoming connection, meaning that the user's firewall is configured correctly.
         if self.tableWidgetConnectionCount.rowCount() and shared.statusIconColor == 'red':
             self.window().setStatusIcon('yellow')
         elif self.tableWidgetConnectionCount.rowCount() == 0 and shared.statusIconColor != "red":
@@ -161,12 +177,14 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
     # timer driven
     def runEveryTwoSeconds(self):
         self.labelLookupsPerSecond.setText(_translate(
-            "networkstatus", "Inventory lookups per second: %1").arg(str(Inventory().numberOfInventoryLookupsPerformed/2)))
+            "networkstatus", "Inventory lookups per second: %1"
+        ).arg(str(Inventory().numberOfInventoryLookupsPerformed/2)))
         Inventory().numberOfInventoryLookupsPerformed = 0
         self.updateNumberOfBytes()
         self.updateNumberOfObjectsToBeSynced()
 
     def retranslateUi(self):
         super(NetworkStatus, self).retranslateUi()
-        self.labelStartupTime.setText(_translate("networkstatus", "Since startup on %1").arg(
-            l10n.formatTimestamp(self.startup)))
+        self.labelStartupTime.setText(_translate(
+            "networkstatus", "Since startup on %1"
+        ).arg(l10n.formatTimestamp(self.startup)))

--- a/src/bitmessageqt/networkstatus.py
+++ b/src/bitmessageqt/networkstatus.py
@@ -26,9 +26,6 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
             header.setSortIndicator(0, QtCore.Qt.AscendingOrder)
 
         self.startup = time.localtime()
-        self.labelStartupTime.setText(_translate(
-            "networkstatus", "Since startup on %1"
-            ).arg(l10n.formatTimestamp(self.startup)))
 
         self.UISignalThread = UISignaler.get()
         QtCore.QObject.connect(self.UISignalThread, QtCore.SIGNAL(

--- a/src/bitmessageqt/networkstatus.ui
+++ b/src/bitmessageqt/networkstatus.ui
@@ -182,7 +182,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Since startup:</string>
+          <string notr="true">Since startup:</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/src/bitmessageqt/networkstatus.ui
+++ b/src/bitmessageqt/networkstatus.ui
@@ -141,7 +141,7 @@
          </column>
          <column>
           <property name="text">
-           <string>TLS</string>
+           <string notr="true">TLS</string>
           </property>
           <property name="toolTip">
            <string>Connection encryption</string>

--- a/src/bitmessageqt/regenerateaddresses.ui
+++ b/src/bitmessageqt/regenerateaddresses.ui
@@ -150,7 +150,7 @@
          </size>
         </property>
         <property name="text">
-         <string>1</string>
+         <string notr="true">1</string>
         </property>
        </widget>
       </item>

--- a/src/tr.py
+++ b/src/tr.py
@@ -1,39 +1,60 @@
 import os
+import textwrap
 
 import shared
 
-# This is used so that the translateText function can be used when we are in daemon mode and not using any QT functions.
+_codec = None
+
+
+# This is used so that the translateText function can be used
+# when we are in daemon mode and not using any Qt functions.
 class translateClass:
     def __init__(self, context, text):
-        self.context = context
         self.text = text
-    def arg(self,argument):
-        if '%' in self.text:
-            return translateClass(self.context, self.text.replace('%','',1)) # This doesn't actually do anything with the arguments because we don't have a UI in which to display this information anyway.
-        else:
-            return self.text
 
-def _translate(context, text, disambiguation = None, encoding = None, n = None):
-    return translateText(context, text, n)
+    def __str__(self):
+        return unicode(self.text)
 
-def translateText(context, text, n = None):
+    def arg(self, *args):
+        # if args and '%' in self.text:
+        #     try:
+        #         ''.join(args)
+        #     except TypeError:
+        #         args = None
+        #     self.text = self.text.replace('%', '', len(args) if args else 1)
+        # This doesn't actually do anything with the arguments because
+        # we don't have a UI in which to display this information anyway.
+        return self
+
+
+def _translate(context, text, disambiguation=None, encoding=None, n=None):
+    return translateText(context, text, disambiguation, n)
+
+
+def translateText(context, text, disambiguation=None, n=None):
     try:
         is_daemon = shared.thisapp.daemon
     except AttributeError:  # inside the plugin
         is_daemon = False
-    if not is_daemon:
-        try:
-            from PyQt4 import QtCore, QtGui
-        except Exception as err:
-            print 'PyBitmessage requires PyQt unless you want to run it as a daemon and interact with it using the API. You can download PyQt from http://www.riverbankcomputing.com/software/pyqt/download   or by searching Google for \'PyQt Download\'. If you want to run in daemon mode, see https://bitmessage.org/wiki/Daemon'
-            print 'Error message:', err
-            os._exit(0)
-        if n is None:
-            return QtGui.QApplication.translate(context, text)
-        else:
-            return QtGui.QApplication.translate(context, text, None, QtCore.QCoreApplication.CodecForTr, n)
-    else:
-        if '%' in text:
-            return translateClass(context, text.replace('%','',1))
-        else:
-            return text
+    if is_daemon:
+        return translateClass(context, text)
+
+    try:
+        from PyQt4 import QtCore, QtGui
+    except Exception as err:
+        print textwrap.dedent("""
+        PyBitmessage requires PyQt unless you want to run it as a daemon
+        and interact with it using the API. You can download PyQt from
+        http://www.riverbankcomputing.com/software/pyqt/download
+        or by searching Google for 'PyQt Download'.
+        If you want to run in daemon mode, see
+        https://bitmessage.org/wiki/Daemon
+        """)
+        print 'Error message:', err
+        os._exit(0)
+
+    return QtGui.QApplication.translate(
+        context, text, disambiguation,
+        QtCore.QCoreApplication.CodecForTr, n
+        ) if n is not None \
+        else QtGui.QApplication.translate(context, text, disambiguation)


### PR DESCRIPTION
When I was looking for the reason why pylupdate4 not includes the string "Show QR-code" into ts-files, I noticed that almost any widget module defines the `_translate()` function and calls it with many default values for the positional arguments. Fix me, I think `_translate` should be imported from `tr` where it's already defined for all cases and with the proper defaults. Here I edited only the modules `__init__` and `networkstatus` because it will not probably be generated from ui-files.

The disadvantage of this changeset is that pylupdate4 will mark all strings in that changed `_translate()` calls as "obsolete" and translators on transifex will be forced to copy suggestion into translation for each of it.