### PR TITLE
Minor setup.py fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,9 @@ if __name__ == "__main__":
             },
             scripts=['src/pybitmessage']
         )
-    except SystemExit:
+    except SystemExit as err:
+        print err.message
+    except:
         print "It looks like building the package failed.\n" \
             "You may be missing a C++ compiler and the OpenSSL headers."
         compilerToPackages()


### PR DESCRIPTION
If you run `python setup.py` with no arguments on Ubuntu, you'll get:

```
It looks like building the package failed.
You may be missing a C++ compiler and the OpenSSL headers.
You can install the requirements by running, as root:
apt-get install build-essential libssl-dev
```

This change prints the exception message instead of using the above. New result:

```
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: no commands supplied
```
