### PR TITLE
Some inconvenience during first run on Ubuntu (mainly)

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -1619,7 +1619,8 @@ class MyForm(settingsmixin.SMainWindow):
         self.connectDialogInstance = connectDialog(self)
         if self.connectDialogInstance.exec_():
             if self.connectDialogInstance.ui.radioButtonConnectNow.isChecked():
-                BMConfigParser().remove_option('bitmessagesettings', 'dontconnect')
+                BMConfigParser().remove_option(
+                    'bitmessagesettings', 'dontconnect')
                 BMConfigParser().save()
             else:
                 self.click_actionSettings()
@@ -2349,7 +2350,12 @@ class MyForm(settingsmixin.SMainWindow):
 
     def click_actionSettings(self):
         self.settingsDialogInstance = settingsDialog(self)
+        if self._firstrun:
+            self.settingsDialogInstance.ui.tabWidgetSettings.setCurrentIndex(1)
         if self.settingsDialogInstance.exec_():
+            if self._firstrun:
+                BMConfigParser().remove_option(
+                    'bitmessagesettings', 'dontconnect')
             BMConfigParser().set('bitmessagesettings', 'startonlogon', str(
                 self.settingsDialogInstance.ui.checkBoxStartOnLogon.isChecked()))
             BMConfigParser().set('bitmessagesettings', 'minimizetotray', str(
@@ -4517,9 +4523,11 @@ def run():
     myapp.appIndicatorInit(app)
     myapp.ubuntuMessagingMenuInit()
     myapp.notifierInit()
-    if BMConfigParser().safeGetBoolean('bitmessagesettings', 'dontconnect'):
-        myapp.showConnectDialog() # ask the user if we may connect
-    
+    myapp._firstrun = BMConfigParser().safeGetBoolean(
+        'bitmessagesettings', 'dontconnect')
+    if myapp._firstrun:
+        myapp.showConnectDialog()  # ask the user if we may connect
+
 #    try:
 #        if BMConfigParser().get('bitmessagesettings', 'mailchuck') < 1:
 #            myapp.showMigrationWizard(BMConfigParser().get('bitmessagesettings', 'mailchuck'))

--- a/src/openclpow.py
+++ b/src/openclpow.py
@@ -26,7 +26,9 @@ except:
     libAvailable = False
 
 def initCL():
-    global ctx, queue, program, hash_dt
+    global ctx, queue, program, hash_dt, libAvailable
+    if libAvailable is False:
+        return
     del enabledGpus[:]
     del vendors[:]
     del gpus[:]
@@ -98,8 +100,7 @@ def do_opencl_pow(hash, target):
 #   logger.debug("Took %d tries.", progress)
     return output[0][0]
 
-if libAvailable:
-    initCL()
+initCL()
 
 if __name__ == "__main__":
     target = 54227212183L

--- a/src/proofofwork.py
+++ b/src/proofofwork.py
@@ -266,9 +266,18 @@ def init():
     else:
         try:
             bso = ctypes.CDLL(os.path.join(paths.codePath(), "bitmsghash", bitmsglib))
-            logger.info("Loaded C PoW DLL %s", bitmsglib)
+        except OSError:
+            import glob
+            try:
+                bso = ctypes.CDLL(glob.glob(os.path.join(
+                    paths.codePath(), "bitmsghash", "bitmsghash*.so"
+                ))[0])
+            except (OSError, IndexError):
+                bso = None
         except:
             bso = None
+        else:
+            logger.info("Loaded C PoW DLL %s", bitmsglib)
     if bso:
         try:
             bmpow = bso.BitmessagePOW


### PR DESCRIPTION
Hello!

When I run fresh installed PyBitmessage on Ubuntu there is some inconvenience:

1. the messages in console
```
make: Entering directory '/usr/lib/python2.7/dist-packages/pybitmessage/bitmsghash'
make: *** No targets specified and no makefile found.  Stop.
make: Leaving directory '/usr/lib/python2.7/dist-packages/pybitmessage/bitmsghash'
2017-03-28 16:42:21,281 - ERROR - OpenCL fail: 
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pybitmessage/openclpow.py", line 35, in initCL
    hash_dt = numpy.dtype([('target', numpy.uint64), ('v', numpy.str_, 73)])
NameError: global name 'numpy' is not defined
```
2. if I choose "Let me configure special network settings first" in Connect dialog the Settings dialog opened with "User Interface" tab active
3. when I finished network configuration PyBitmessage still not connects and Connect dialog open again during the next startup.
