### PR TITLE
New packages not listed in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -242,6 +242,9 @@ if __name__ == "__main__":
                 'pybitmessage.network',
                 'pybitmessage.pyelliptic',
                 'pybitmessage.socks',
+                'pybitmessage.storage',
+                'pybitmessage.fallback',
+                'pybitmessage.fallback.umsgpack',
                 'pybitmessage.plugins'
             ],
             package_data={'': [

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ class InstallCmd(install):
             print "Press Return to continue"
             try:
                 raw_input()
-            except EOFError, NameError:
+            except (EOFError, NameError):
                 pass
 
         return install.run(self)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,22 @@ packageName = {
         "openSUSE": "python-msgpack-python",
         "Fedora": "python2-msgpack",
         "Guix": "python2-msgpack",
-        "Gentoo": "dev-python/msgpack"
+        "Gentoo": "dev-python/msgpack",
+        "optional": True,
+        "description": "python-msgpack is recommended for messages coding"
+    },
+    "umsgpack": {
+        "FreeBSD": "",
+        "OpenBSD": "",
+        "Fedora": "",
+        "openSUSE": "",
+        "Guix": "",
+        "Ubuntu 12": "",
+        "Debian": "python-u-msgpack",
+        "Ubuntu": "python-u-msgpack",
+        "Gentoo": "dev-python/u-msgpack",
+        "optional": True,
+        "description": "umsgpack can be used instead of msgpack"
     },
     "pyopencl": {
         "FreeBSD": "py27-pyopencl",
@@ -202,9 +217,25 @@ if __name__ == "__main__":
     )
 
     installRequires = []
-    # this will silently accept alternative providers of msgpack if they are already installed
+    packages = [
+        'pybitmessage',
+        'pybitmessage.bitmessageqt',
+        'pybitmessage.bitmessagecurses',
+        'pybitmessage.messagetypes',
+        'pybitmessage.network',
+        'pybitmessage.pyelliptic',
+        'pybitmessage.socks',
+        'pybitmessage.storage',
+        'pybitmessage.plugins'
+    ]
+    # this will silently accept alternative providers of msgpack
+    # if they are already installed
     if "msgpack" in detectPrereqs():
         installRequires.append("msgpack-python")
+    elif "umsgpack" in detectPrereqs():
+        installRequires.append("umsgpack")
+    else:
+        packages += ['pybitmessage.fallback', 'pybitmessage.fallback.umsgpack']
 
     try:
         dist = setup(
@@ -234,19 +265,7 @@ if __name__ == "__main__":
                 "Topic :: Software Development :: Libraries :: Python Modules",
             ],
             package_dir={'pybitmessage': 'src'},
-            packages=[
-                'pybitmessage',
-                'pybitmessage.bitmessageqt',
-                'pybitmessage.bitmessagecurses',
-                'pybitmessage.messagetypes',
-                'pybitmessage.network',
-                'pybitmessage.pyelliptic',
-                'pybitmessage.socks',
-                'pybitmessage.storage',
-                'pybitmessage.fallback',
-                'pybitmessage.fallback.umsgpack',
-                'pybitmessage.plugins'
-            ],
+            packages=packages,
             package_data={'': [
                 'bitmessageqt/*.ui', 'bitmsghash/*.cl', 'sslkeys/*.pem',
                 'translations/*.ts', 'translations/*.qm',

--- a/src/depends.py
+++ b/src/depends.py
@@ -204,7 +204,9 @@ def check_msgpack():
     try:
         import msgpack
     except ImportError:
-        logger.error('The msgpack package is not available. PyBitmessage requires msgpack.')
+        logger.error(
+            'The msgpack package is not available.'
+            'It is highly recommended for messages coding.')
         if sys.platform.startswith('openbsd'):
             logger.error('On OpenBSD, try running "pkg_add py-msgpack" as root.')
         elif sys.platform.startswith('freebsd'):
@@ -224,7 +226,6 @@ def check_msgpack():
                         else:
                             logger.error('If your package manager does not have this package, try running "pip install msgpack-python".')
 
-        return False
     return True
 
 def check_dependencies(verbose = False, optional = False):

--- a/src/helper_msgcoding.py
+++ b/src/helper_msgcoding.py
@@ -3,12 +3,14 @@
 try:
     import msgpack
 except ImportError:
-    import fallback.umsgpack.umsgpack as msgpack
+    try:
+        import umsgpack as msgpack
+    except ImportError:
+        import fallback.umsgpack.umsgpack as msgpack
 import string
 import zlib
 
 from bmconfigparser import BMConfigParser
-import shared
 from debug import logger
 import messagetypes
 from tr import _translate
@@ -17,6 +19,7 @@ BITMESSAGE_ENCODING_IGNORE = 0
 BITMESSAGE_ENCODING_TRIVIAL = 1
 BITMESSAGE_ENCODING_SIMPLE = 2
 BITMESSAGE_ENCODING_EXTENDED = 3
+
 
 class DecompressionSizeException(Exception):
     def __init__(self, size):


### PR DESCRIPTION
Hello!

I noticed you added some new packages in recent code. Particularly `fallback.umsgpack` which should make dependency on python-msgpack optional. I made several changes to make it possible to install pybitmessage with `umsgpack` or without any msgpack implementation (to use `fallback` package).

First commit is sufficient to fix setup failure in case you don't like other changes.