### PR TITLE
Fixed fetch of connected hosts number in bitmessageqt.support

### DIFF
--- a/src/bitmessageqt/support.py
+++ b/src/bitmessageqt/support.py
@@ -16,7 +16,7 @@ import paths
 import proofofwork
 from pyelliptic.openssl import OpenSSL
 import queues
-import shared
+import network.stats
 import state
 from version import softwareVersion
 
@@ -124,7 +124,7 @@ def createSupportMessage(myapp):
         upnp = BMConfigParser().get('bitmessagesettings', 'upnp')
     except:
         upnp = "N/A"
-    connectedhosts = len(shared.connectedHostsList)
+    connectedhosts = len(network.stats.connectedHostsList())
 
     myapp.ui.textEditMessage.setText(str(QtGui.QApplication.translate("Support", SUPPORT_MESSAGE)).format(version, os, architecture, pythonversion, opensslversion, frozen, portablemode, cpow, openclpow, locale, socks, upnp, connectedhosts))
 


### PR DESCRIPTION
In message composed by "Help -> Contact support" action the last line

> Connected hosts: 0

always