### PR TITLE
change default debug output from stdout to stderr

### DIFF
--- a/src/debug.py
+++ b/src/debug.py
@@ -64,7 +64,7 @@ def configureLogging():
                 'class': 'logging.StreamHandler',
                 'formatter': 'default',
                 'level': log_level,
-                'stream': 'ext://sys.stdout'
+                'stream': 'ext://sys.stderr'
             },
             'file': {
                 'class': 'logging.handlers.RotatingFileHandler',


### PR DESCRIPTION
By default pyBitmessage sends debug output to sys.stdout. This is inconsistent with UNIX standard streams usage, specifically: 
- stdout The standard output stream, which is used for normal output from the program.
- stderr The standard error stream, which is used for error messages and diagnostics issued by the program.
(source: https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html )

This PR changes the default debug output destination from sys.stdout to sys.stderr.
