### PR TITLE
move config read inside main function

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -198,8 +198,10 @@ if shared.useVeryEasyProofOfWorkForTesting:
         defaults.networkDefaultPayloadLengthExtraBytes / 100)
 
 class Main:
-    def start(self, daemon=False):
+    def start(self):
         _fixSocket()
+
+        daemon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon')
 
         try:
             opts, args = getopt.getopt(sys.argv[1:], "hcd",
@@ -406,8 +408,7 @@ All parameters are optional.
 
 def main():
     mainprogram = Main()
-    mainprogram.start(
-        BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon'))
+    mainprogram.start()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In bitmessagemain.py, the "daemon" configuration option is read before the main.start() function and passed as an argument to the function, for reasons that appear to be no longer relevant. 
This PR moves the config read and "daemon" variable initialization inside the main.start() function.

Tested on Linux.