### PR TITLE
Properly handle SIGTERM if daemon ran with -d 

### DIFF
--- a/src/class_singleCleaner.py
+++ b/src/class_singleCleaner.py
@@ -66,7 +66,7 @@ class singleCleaner(threading.Thread, StoppableThread):
             # If we are running as a daemon then we are going to fill up the UI
             # queue which will never be handled by a UI. We should clear it to
             # save memory.
-            if BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon'):
+            if shared.thisapp.daemon:
                 queues.UISignalQueue.queue.clear()
             if timeWeLastClearedInventoryAndPubkeysTables < int(time.time()) - 7380:
                 timeWeLastClearedInventoryAndPubkeysTables = int(time.time())

--- a/src/helper_generic.py
+++ b/src/helper_generic.py
@@ -6,7 +6,7 @@ from multiprocessing import current_process
 from threading import current_thread, enumerate
 import traceback
 
-from bmconfigparser import BMConfigParser
+import shared
 from debug import logger
 import queues
 import shutdown
@@ -54,7 +54,7 @@ def signal_handler(signal, frame):
     if current_thread().name not in ("PyBitmessage", "MainThread"):
         return
     logger.error("Got signal %i", signal)
-    if BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon'):
+    if shared.thisapp.daemon:
         shutdown.doCleanShutdown()
     else:
         allThreadTraceback(frame)

--- a/src/shutdown.py
+++ b/src/shutdown.py
@@ -3,7 +3,6 @@ import Queue
 import threading
 import time
 
-from bmconfigparser import BMConfigParser
 from debug import logger
 from helper_sql import sqlQuery, sqlStoredProcedure
 from helper_threading import StoppableThread
@@ -60,7 +59,7 @@ def doCleanShutdown():
             except Queue.Empty:
                 break
 
-    if BMConfigParser().safeGetBoolean('bitmessagesettings','daemon'):
+    if shared.thisapp.daemon:
         logger.info('Clean shutdown complete.')
         shared.thisapp.cleanup()
         os._exit(0)

--- a/src/tr.py
+++ b/src/tr.py
@@ -1,6 +1,6 @@
 import os
 
-from bmconfigparser import BMConfigParser
+import shared
 
 # This is used so that the translateText function can be used when we are in daemon mode and not using any QT functions.
 class translateClass:
@@ -17,7 +17,7 @@ def _translate(context, text, disambiguation = None, encoding = None, n = None):
     return translateText(context, text, n)
 
 def translateText(context, text, n = None):
-    if not BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon'):
+    if not shared.thisapp.daemon:
         try:
             from PyQt4 import QtCore, QtGui
         except Exception as err:

--- a/src/tr.py
+++ b/src/tr.py
@@ -17,7 +17,11 @@ def _translate(context, text, disambiguation = None, encoding = None, n = None):
     return translateText(context, text, n)
 
 def translateText(context, text, n = None):
-    if not shared.thisapp.daemon:
+    try:
+        is_daemon = shared.thisapp.daemon
+    except AttributeError:  # inside the plugin
+        is_daemon = False
+    if not is_daemon:
         try:
             from PyQt4 import QtCore, QtGui
         except Exception as err:


### PR DESCRIPTION
There is a minor problem: if no `daemon` setting in `keys.dat` pybitmessage ignores `SIGTERM`. I suggest to check `singleistance.daemon` variable instead of config to determine daemon status.