### PR TITLE
implement stealth ack objects

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -35,6 +35,7 @@ import network.stats
 
 # Classes
 from helper_sql import sqlQuery,sqlExecute,SqlBulkExecute,sqlStoredProcedure
+from helper_ackPayload import genAckPayload
 from debug import logger
 from inventory import Inventory
 from version import softwareVersion
@@ -679,7 +680,8 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
         if not fromAddressEnabled:
             raise APIError(14, 'Your fromAddress is disabled. Cannot send.')
 
-        ackdata = OpenSSL.rand(32)
+        stealthLevel = BMConfigParser().safeGetInt('bitmessagesettings', 'ackstealthlevel')
+        ackdata = genAckPayload(streamNumber, stealthLevel)
 
         t = ('', 
              toAddress, 
@@ -740,7 +742,7 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
                 fromAddress, 'enabled')
         except:
             raise APIError(13, 'could not find your fromAddress in the keys.dat file.')
-        ackdata = OpenSSL.rand(32)
+        ackdata = genAckPayload(streamNumber, 0)
         toAddress = '[Broadcast subscribers]'
         ripe = ''
 

--- a/src/bitmessagecurses/__init__.py
+++ b/src/bitmessagecurses/__init__.py
@@ -20,6 +20,7 @@ import curses
 import dialog
 from dialog import Dialog
 from helper_sql import *
+from helper_ackPayload import genAckPayload
 
 from addresses import *
 import ConfigParser
@@ -778,7 +779,8 @@ def sendMessage(sender="", recv="", broadcast=None, subject="", body="", reply=F
                     if len(shared.connectedHostsList) == 0:
                         set_background_title(d, "Not connected warning")
                         scrollbox(d, unicode("Because you are not currently connected to the network, "))
-                    ackdata = OpenSSL.rand(32)
+                    stealthLevel = BMConfigParser().safeGetInt('bitmessagesettings', 'ackstealthlevel')
+                    ackdata = genAckPayload(streamNumber, stealthLevel)
                     sqlExecute(
                         "INSERT INTO sent VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                         "",
@@ -802,7 +804,8 @@ def sendMessage(sender="", recv="", broadcast=None, subject="", body="", reply=F
             set_background_title(d, "Empty sender error")
             scrollbox(d, unicode("You must specify an address to send the message from."))
         else:
-            ackdata = OpenSSL.rand(32)
+            # dummy ackdata, no need for stealth
+            ackdata = genAckPayload(streamNumber, 0)
             recv = BROADCAST_STR
             ripe = ""
             sqlExecute(

--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -52,6 +52,7 @@ import random
 import string
 from datetime import datetime, timedelta
 from helper_sql import *
+from helper_ackPayload import genAckPayload
 import helper_search
 import l10n
 import openclpow
@@ -1879,7 +1880,8 @@ class MyForm(settingsmixin.SMainWindow):
                         if shared.statusIconColor == 'red':
                             self.statusBar().showMessage(_translate(
                                 "MainWindow", "Warning: You are currently not connected. Bitmessage will do the work necessary to send the message but it won\'t send until you connect."))
-                        ackdata = OpenSSL.rand(32)
+                        stealthLevel = BMConfigParser().safeGetInt('bitmessagesettings', 'ackstealthlevel')
+                        ackdata = genAckPayload(streamNumber, stealthLevel)
                         t = ()
                         sqlExecute(
                             '''INSERT INTO sent VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)''',
@@ -1933,7 +1935,7 @@ class MyForm(settingsmixin.SMainWindow):
                 # We don't actually need the ackdata for acknowledgement since
                 # this is a broadcast message, but we can use it to update the
                 # user interface when the POW is done generating.
-                ackdata = OpenSSL.rand(32)
+                ackdata = genAckPayload(streamNumber, 0)
                 toAddress = str_broadcast_subscribers
                 ripe = ''
                 t = ('', # msgid. We don't know what this will be until the POW is done. 

--- a/src/bitmessageqt/account.py
+++ b/src/bitmessageqt/account.py
@@ -5,6 +5,7 @@ import re
 import sys
 import inspect
 from helper_sql import *
+from helper_ackPayload import genAckPayload
 from addresses import decodeAddress
 from bmconfigparser import BMConfigParser
 from foldertree import AccountMixin
@@ -166,7 +167,8 @@ class GatewayAccount(BMAccount):
         
     def send(self):
         status, addressVersionNumber, streamNumber, ripe = decodeAddress(self.toAddress)
-        ackdata = OpenSSL.rand(32)
+        stealthLevel = BMConfigParser().safeGetInt('bitmessagesettings', 'ackstealthlevel')
+        ackdata = genAckPayload(streamNumber, stealthLevel)
         t = ()
         sqlExecute(
             '''INSERT INTO sent VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)''',

--- a/src/class_smtpServer.py
+++ b/src/class_smtpServer.py
@@ -14,6 +14,7 @@ from addresses import decodeAddress
 from bmconfigparser import BMConfigParser
 from debug import logger
 from helper_sql import sqlExecute
+from helper_ackPayload import genAckPayload
 from helper_threading import StoppableThread
 from pyelliptic.openssl import OpenSSL
 import queues
@@ -65,7 +66,8 @@ class smtpServerPyBitmessage(smtpd.SMTPServer):
 
     def send(self, fromAddress, toAddress, subject, message):
         status, addressVersionNumber, streamNumber, ripe = decodeAddress(toAddress)
-        ackdata = OpenSSL.rand(32)
+        stealthLevel = BMConfigParser().safeGetInt('bitmessagesettings', 'ackstealthlevel')
+        ackdata = genAckPayload(streamNumber, stealthLevel)
         t = ()
         sqlExecute(
             '''INSERT INTO sent VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)''',

--- a/src/helper_ackPayload.py
+++ b/src/helper_ackPayload.py
@@ -1,0 +1,40 @@
+import hashlib
+import highlevelcrypto
+import random
+import helper_random
+from binascii import hexlify, unhexlify
+from struct import pack, unpack
+from addresses import encodeVarint
+
+# This function generates payload objects for message acknowledgements
+# Several stealth levels are available depending on the privacy needs; 
+# a higher level means better stealth, but also higher cost (size+POW)
+#   - level 0: a random 32-byte sequence with a message header appended
+#   - level 1: a getpubkey request for a (random) dummy key hash
+#   - level 2: a standard message, encrypted to a random pubkey
+
+def genAckPayload(streamNumber=1, stealthLevel=0):
+    if (stealthLevel==2):      # Generate privacy-enhanced payload
+        # Generate a dummy privkey and derive the pubkey
+        dummyPubKeyHex = highlevelcrypto.privToPub(hexlify(helper_random.randomBytes(32)))
+        # Generate a dummy message of random length
+        # (the smallest possible standard-formatted message is 234 bytes)
+        dummyMessage = helper_random.randomBytes(random.randint(234, 800))
+        # Encrypt the message using standard BM encryption (ECIES)
+        ackdata = highlevelcrypto.encrypt(dummyMessage, dummyPubKeyHex)
+        acktype = 2  # message
+        version = 1
+
+    elif (stealthLevel==1):    # Basic privacy payload (random getpubkey)
+        ackdata = helper_random.randomBytes(32)
+        acktype = 0  # getpubkey
+        version = 4
+
+    else:            # Minimum viable payload (non stealth)
+        ackdata = helper_random.randomBytes(32)
+        acktype = 2  # message
+        version = 1
+
+    ackobject = pack('>I', acktype) + encodeVarint(version) + encodeVarint(streamNumber) + ackdata
+
+    return ackobject


### PR DESCRIPTION
By default, message ACK objects are generated as 32-byte random strings with a message header attached. Because of this, they are easily identified on the network (they're the only msg objects of size 54).
This PR implements some new types of ACK objects that blend in more realistically with the network traffic, and enables selection via the new configuration option **ackstealthlevel**. 
Three stealth levels are defined currently:
0 - the default format described above
1 - a getpubkey request for a randomly generated hash
2 - a standard formatted message encrypted to a randomly generated key
To support objects of types other than 2 (msg), the internal format of the ackdata has been changed to also include the type header (objtype/version/stream). The startup routine has been updated to convert the legacy (headerless) format to the new format automatically, to continue tracking of any unacknowledged messages after upgrade.

Any comments and feedback will be appreciated.