### PR TITLE
Fixed typo when closing tempfile in bitmessageqt.__init__

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3994,8 +3994,9 @@ class settingsDialog(QtGui.QDialog):
         else:
             try:
                 import tempfile
-                file = tempfile.NamedTemporaryFile(dir=paths.lookupExeFolder(), delete=True)
-                file.close # should autodelete
+                tempfile.NamedTemporaryFile(
+                    dir=paths.lookupExeFolder(), delete=True
+                ).close()  # should autodelete
             except:
                 self.ui.checkBoxPortableMode.setDisabled(True)
 


### PR DESCRIPTION
- Call `close()` method instead of getting the attribute.
- Avoid `file` as variable name.