### PR TITLE
send ack even if message encoding is zero

### DIFF
--- a/src/class_objectProcessor.py
+++ b/src/class_objectProcessor.py
@@ -591,7 +591,6 @@ class objectProcessor(threading.Thread):
         # Don't send ACK if invalid, blacklisted senders, invisible messages, disabled or chan
         if self.ackDataHasAValidHeader(ackData) and \
             not blockMessage and \
-            messageEncodingType != 0 and \
             not BMConfigParser().safeGetBoolean(toAddress, 'dontsendack') and \
             not BMConfigParser().safeGetBoolean(toAddress, 'chan'):
             shared.checkAndShareObjectWithPeers(ackData[24:])


### PR DESCRIPTION
In the definition of BM message objects, a value of zero in the "message encoding" field indicates that the message "may be ignored". In practice, this means that, after a successful decryption, the message body is discarded without being stored on disk or displayed in the UI. However, the other metadata processing (pubkey extraction etc) is still performed. 
In the BM protocol, the message ACK object is broadcast on the network when the message has been successfully **decrypted** (subject to some flags and conditions) - **not** when the message has been displayed to, or read by, the recipient. 
Therefore, I suggest that the ACK object should also be broadcast in the case of messages with zero-type encoding that have been successfully decrypted, even if (by design) they are not displayed to the recipient. 
This PR removes the restriction on ACK sending for zero-type encoded messages. 