### PR TITLE
Fixed statusbar message on error in namecoin name search

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -1999,7 +1999,7 @@ class MyForm(settingsmixin.SMainWindow):
         err, addr = nc.query(identities[-1].strip())
         if err is not None:
             self.statusBar().showMessage(_translate(
-                "MainWindow", "Error: " + err), 10000)
+                "MainWindow", "Error: %1").arg(err), 10000)
         else:
             identities[-1] = addr
             self.ui.lineEditTo.setText("; ".join(identities))


### PR DESCRIPTION
For languages with extended unicode symbols (russian for example) it currently shown like this

> Error: ?? id/name ?? ...