### PR TITLE
Use unicode instead of str for MessagingMenu

### DIFF
--- a/src/plugins/indicator_libmessaging.py
+++ b/src/plugins/indicator_libmessaging.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import gi
-gi.require_version('MessagingMenu', '1.0')
+gi.require_version('MessagingMenu', '1.0')  # noqa:E402
 from gi.repository import MessagingMenu
 
 from pybitmessage.bitmessageqt.utils import str_broadcast_subscribers
@@ -19,9 +19,9 @@ class IndicatorLibmessaging(object):
             return
 
         self._menu = {
-            'send': str(_translate('MainWindow', 'Send')),
-            'messages': str(_translate('MainWindow', 'Messages')),
-            'subscriptions': str(_translate('MainWindow', 'Subscriptions'))
+            'send': unicode(_translate('MainWindow', 'Send')),
+            'messages': unicode(_translate('MainWindow', 'Messages')),
+            'subscriptions': unicode(_translate('MainWindow', 'Subscriptions'))
         }
 
         self.new_message_item = self.new_broadcast_item = None


### PR DESCRIPTION
It's my own error ): I didn't notice it because used English locale in Ubuntu when tested this code. `UnicodeEncodeError` is raised here.