### PR TITLE
code audit showed wrong # of params;2 params is OK

### DIFF
--- a/src/pyelliptic/arithmetic.py
+++ b/src/pyelliptic/arithmetic.py
@@ -57,7 +57,7 @@ def base10_add(a,b):
   y = (m*(a[0]-x)-a[1]) % P
   return (x,y)
   
-def base10_double(a):
+def base10_double(a, var_unused):
   if a == None: return None
   m = ((3*a[0]*a[0]+A)*inv(2*a[1],P)) % P
   x = (m*m-2*a[0]) % P


### PR DESCRIPTION
the calls are done with 2 params , so we need a dummy to satisfy automatic code audit

**def** and the calls must be either 1 **or** 2 params, but not mixed. 