### PR TITLE
translate: could not load message from disk

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3873,7 +3873,7 @@ class MyForm(settingsmixin.SMainWindow):
         else:
             data = self.getCurrentMessageId()
             if data != False:
-                message = "Error occurred: could not load message from disk."
+                message = "Error occurred: could not load message from disk." #### TODO: _translate( this ! happens frequently
         messageTextedit.setCurrentFont(QtGui.QFont())
         messageTextedit.setTextColor(QtGui.QColor())
         messageTextedit.setContent(message)


### PR DESCRIPTION
message = "Error occurred: could not load message from disk." 
TODO: _translate( this ! 
it happens frequently. my suggestion:

"Error occurred: could not load message from disk. -- **This is not a (received) BitMessage, but an error message due to a read storage problem."**