### PR TITLE
No more shared.daemon variable

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -220,8 +220,6 @@ class Main:
             elif opt in ("-c", "--curses"):
                 state.curses = True
 
-        shared.daemon = daemon
-
         # is the application already running?  If yes then exit.
         shared.thisapp = singleinstance("", daemon)
 

--- a/src/class_singleCleaner.py
+++ b/src/class_singleCleaner.py
@@ -121,7 +121,7 @@ class singleCleaner(threading.Thread, StoppableThread):
                     if "Errno 28" in str(err):
                         logger.fatal('(while receiveDataThread knownnodes.needToWriteKnownNodesToDisk) Alert: Your disk or data storage volume is full. ')
                         queues.UISignalQueue.put(('alert', (tr._translate("MainWindow", "Disk full"), tr._translate("MainWindow", 'Alert: Your disk or data storage volume is full. Bitmessage will now exit.'), True)))
-                        if shared.daemon:
+                        if shared.thisapp.daemon:
                             os._exit(0)
                 shared.needToWriteKnownNodesToDisk = False
 

--- a/src/shared.py
+++ b/src/shared.py
@@ -49,7 +49,7 @@ clientHasReceivedIncomingConnections = False #used by API command clientStatus
 numberOfMessagesProcessed = 0
 numberOfBroadcastsProcessed = 0
 numberOfPubkeysProcessed = 0
-daemon = False
+
 needToWriteKnownNodesToDisk = False # If True, the singleCleaner will write it to disk eventually.
 maximumLengthOfTimeToBotherResendingMessages = 0
 timeOffsetWrongCount = 0


### PR DESCRIPTION
Hey, I did what you suggested in #1060. There is also `daemon` variables in other classes:

```sh
$ grep -Er 'daemon ?=' src | grep -v thisapp | grep -v singleinstance
src/class_outgoingSynSender.py:                rd.daemon = True  # close the main program even if there are threads left
src/bitmessagemain.py:        daemon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon')
src/bitmessagemain.py:                daemon = True
src/bitmessagemain.py:        addressGeneratorThread.daemon = True  # close the main program even if there are threads left
src/bitmessagemain.py:        singleWorkerThread.daemon = True  # close the main program even if there are threads left
src/bitmessagemain.py:        sqlLookup.daemon = False  # DON'T close the main program even if there are threads left. The closeEvent should command this thread to exit gracefully.
src/bitmessagemain.py:        objectProcessorThread.daemon = False  # DON'T close the main program even the thread remains. This thread checks the shutdown variable after processing each object.
src/bitmessagemain.py:        singleCleanerThread.daemon = True  # close the main program even if there are threads left
src/bitmessagemain.py:            singleAPIThread.daemon = True  # close the main program even if there are threads left
src/bitmessagemain.py:        asyncoreThread.daemon = True
src/bitmessagemain.py:            receiveQueueThread.daemon = True
src/bitmessagemain.py:        announceThread.daemon = True
src/bitmessagemain.py:        state.invThread.daemon = True
src/bitmessagemain.py:        state.addrThread.daemon = True
src/bitmessagemain.py:        state.downloadThread.daemon = True
src/bitmessagemain.py:        if daemon == False and BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon') == False:
src/tr.py:        is_daemon = False
src/bitmessagecli.py:            daemon = userInput("Daemon mode Enabled? (True) or (False)").lower()
src/bitmessagecli.py:    daemon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon')
src/bitmessagecli.py:    print '     daemon = ' + str(daemon)
src/class_singleListener.py:            rd.daemon = True  # close the main program even if there are threads left
src/class_sendDataThread.py:        self.objectHashHolderInstance.daemon = True
```

I see it's been set but cannot find where it used.
```sh
$ grep -r 'self.daemon' src | grep -v singleinstance
src/bitmessagemain.py:            self.daemonize()
```