### PR TITLE
bitmessage.pro needs update

### DIFF
--- a/src/translations/bitmessage.pro
+++ b/src/translations/bitmessage.pro
@@ -68,6 +68,7 @@ TRANSLATIONS = \
     bitmessage_pt.ts \
     bitmessage_sk.ts \
     bitmessage_ru.ts \
+    bitmessage_uk.ts \
     bitmessage_zh_cn.ts
 
 CODECFORTR      = UTF-8

--- a/src/translations/bitmessage.pro
+++ b/src/translations/bitmessage.pro
@@ -21,33 +21,35 @@ SOURCES	= 	../addresses.py\
 			../shared.py\
 			../upnp.py\
 			../bitmessageqt/__init__.py\
-			../bitmessageqt/about.py\
 			../bitmessageqt/account.py\
-			../bitmessageqt/addaddressdialog.py\
+			../bitmessageqt/address_dialogs.py\
 			../bitmessageqt/bitmessageui.py\
 			../bitmessageqt/blacklist.py\
-			../bitmessageqt/connect.py\
-			../bitmessageqt/emailgateway.py\
+			../bitmessageqt/dialogs.py\
 			../bitmessageqt/foldertree.py\
-			../bitmessageqt/help.py\
-			../bitmessageqt/iconglossary.py\
 			../bitmessageqt/languagebox.py\
 			../bitmessageqt/messagecompose.py\
 			../bitmessageqt/messageview.py\
 			../bitmessageqt/networkstatus.py\
-			../bitmessageqt/newaddressdialog.py\
 			../bitmessageqt/newchandialog.py\
-			../bitmessageqt/newsubscriptiondialog.py\
-			../bitmessageqt/regenerateaddresses.py\
 			../bitmessageqt/safehtmlparser.py\
 			../bitmessageqt/settings.py\
-                        ../bitmessageqt/specialaddressbehavior.py\
                         ../plugins/qrcodeui.py
 
 FORMS = \
+    ../bitmessageqt/about.ui\
+    ../bitmessageqt/addaddressdialog.ui\
     ../bitmessageqt/blacklist.ui\
+    ../bitmessageqt/connect.ui\
+    ../bitmessageqt/emailgateway.ui\
+    ../bitmessageqt/help.ui\
+    ../bitmessageqt/iconglossary.ui\
     ../bitmessageqt/networkstatus.ui\
-    ../bitmessageqt/newchandialog.ui
+    ../bitmessageqt/newaddressdialog.ui\
+    ../bitmessageqt/newchandialog.ui\
+    ../bitmessageqt/newsubscriptiondialog.ui\
+    ../bitmessageqt/regenerateaddresses.ui\
+    ../bitmessageqt/specialaddressbehavior.ui
 
 TRANSLATIONS = \
     bitmessage_ar.ts \


### PR DESCRIPTION
Hello!

I forgot to update the `bitmessage.pro` and many translation strings are disappeared from transifex. I hope most of them come back after this update at least as suggestions. Just checked .ts generated by `pylupdate4` after this update and I see not many changes.