### PR TITLE
Update "Network Status" information only when the tab selected

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -686,6 +686,10 @@ class MyForm(settingsmixin.SMainWindow):
             "itemSelectionChanged ()"), self.treeWidgetItemClicked)
         QtCore.QObject.connect(self.ui.treeWidgetChans, QtCore.SIGNAL(
             "itemChanged (QTreeWidgetItem *, int)"), self.treeWidgetItemChanged)
+        QtCore.QObject.connect(
+            self.ui.tabWidget, QtCore.SIGNAL("currentChanged(int)"),
+            self.tabWidgetCurrentChanged
+        )
 
         # Put the colored icon on the status bar
         # self.pushButtonStatusIcon.setIcon(QIcon(":/newPrefix/images/yellowicon.png"))
@@ -4011,6 +4015,12 @@ class MyForm(settingsmixin.SMainWindow):
             if unicode(completerList[i]).endswith(" <" + item.address + ">"):
                 completerList[i] = item.label + " <" + item.address + ">"
         self.ui.lineEditTo.completer().model().setStringList(completerList)
+
+    def tabWidgetCurrentChanged(self, n):
+        if n == self.ui.tabWidget.indexOf(self.ui.networkstatus):
+            self.ui.networkstatus.startUpdate()
+        else:
+            self.ui.networkstatus.stopUpdate()
 
     def writeNewAddressToTable(self, label, address, streamNumber):
         self.rerenderTabTreeMessages()

--- a/src/bitmessageqt/networkstatus.py
+++ b/src/bitmessageqt/networkstatus.py
@@ -39,10 +39,18 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
             "updateNumberOfBroadcastsProcessed()"), self.updateNumberOfBroadcastsProcessed)
         QtCore.QObject.connect(self.UISignalThread, QtCore.SIGNAL(
             "updateNetworkStatusTab(PyQt_PyObject,PyQt_PyObject,PyQt_PyObject)"), self.updateNetworkStatusTab)
-        
+
         self.timer = QtCore.QTimer()
-        self.timer.start(2000) # milliseconds
-        QtCore.QObject.connect(self.timer, QtCore.SIGNAL("timeout()"), self.runEveryTwoSeconds)
+
+        QtCore.QObject.connect(
+            self.timer, QtCore.SIGNAL("timeout()"), self.runEveryTwoSeconds)
+
+    def startUpdate(self):
+        self.runEveryTwoSeconds()
+        self.timer.start(2000)  # milliseconds
+
+    def stopUpdate(self):
+        self.timer.stop()
 
     def formatBytes(self, num):
         for x in [_translate("networkstatus", "byte(s)", None, QtCore.QCoreApplication.CodecForTr, num), "kB", "MB", "GB"]:


### PR DESCRIPTION
Hello.

This little patch starts `NetworkStatus.timer` when "Network Status" tab is selected and stops when user selects other tab.