### PR TITLE
New button "Blank" on tab "Send" to blank all fields (#919)

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -147,6 +147,8 @@ class MyForm(settingsmixin.SMainWindow):
             "clicked()"), self.click_pushButtonAddSubscription)
         QtCore.QObject.connect(self.ui.pushButtonTTL, QtCore.SIGNAL(
             "clicked()"), self.click_pushButtonTTL)
+        QtCore.QObject.connect(self.ui.pushButtonClear, QtCore.SIGNAL(
+            "clicked()"), self.click_pushButtonClear)
         QtCore.QObject.connect(self.ui.pushButtonSend, QtCore.SIGNAL(
             "clicked()"), self.click_pushButtonSend)
         QtCore.QObject.connect(self.ui.pushButtonFetchNamecoinID, QtCore.SIGNAL(
@@ -1840,13 +1842,18 @@ class MyForm(settingsmixin.SMainWindow):
     def rerenderSubscriptions(self):
         self.rerenderTabTreeSubscriptions()
 
-
     def click_pushButtonTTL(self):
         QtGui.QMessageBox.information(self, 'Time To Live', _translate(
             "MainWindow", """The TTL, or Time-To-Live is the length of time that the network will hold the message.
  The recipient must get it during this time. If your Bitmessage client does not hear an acknowledgement, it
  will resend the message automatically. The longer the Time-To-Live, the
  more work your computer must do to send the message. A Time-To-Live of four or five days is often appropriate."""), QtGui.QMessageBox.Ok)
+
+    def click_pushButtonClear(self):
+        self.ui.lineEditSubject.setText("")
+        self.ui.lineEditTo.setText("")
+        self.ui.textEditMessage.setText("")
+        self.ui.comboBoxSendFrom.setCurrentIndex(0)
 
     def click_pushButtonSend(self):
         encoding = 3 if QtGui.QApplication.queryKeyboardModifiers() & QtCore.Qt.ShiftModifier else 2

--- a/src/bitmessageqt/bitmessageui.py
+++ b/src/bitmessageqt/bitmessageui.py
@@ -337,6 +337,9 @@ class Ui_MainWindow(object):
         self.labelHumanFriendlyTTLDescription.setMinimumSize(QtCore.QSize(45, 0))
         self.labelHumanFriendlyTTLDescription.setObjectName(_fromUtf8("labelHumanFriendlyTTLDescription"))
         self.horizontalLayout_5.addWidget(self.labelHumanFriendlyTTLDescription, 1, QtCore.Qt.AlignLeft)
+        self.pushButtonClear = QtGui.QPushButton(self.send)
+        self.pushButtonClear.setObjectName(_fromUtf8("pushButtonClear"))
+        self.horizontalLayout_5.addWidget(self.pushButtonClear, 0, QtCore.Qt.AlignRight)
         self.pushButtonSend = QtGui.QPushButton(self.send)
         self.pushButtonSend.setObjectName(_fromUtf8("pushButtonSend"))
         self.horizontalLayout_5.addWidget(self.pushButtonSend, 0, QtCore.Qt.AlignRight)
@@ -701,6 +704,7 @@ class Ui_MainWindow(object):
         except:
             pass
         self.labelHumanFriendlyTTLDescription.setText(_translate("MainWindow", "%n hour(s)", None, QtCore.QCoreApplication.CodecForTr, hours))
+        self.pushButtonClear.setText(_translate("MainWindow", "Clear", None))
         self.pushButtonSend.setText(_translate("MainWindow", "Send", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.send), _translate("MainWindow", "Send", None))
         self.treeWidgetSubscriptions.headerItem().setText(0, _translate("MainWindow", "Subscriptions", None))


### PR DESCRIPTION
Hello!

Since new 0.6.3 release is soon (as you wrote), I decided to add also this button to current (non-refactored) code. Because I need it myself from time to time.

However I'm not sure about label: should it be "Discard" like proposed in #919 or maybe "Clear"?