### PR TITLE
Zero Inventory().numberOfInventoryLookupsPerformed before update started

### DIFF
--- a/src/bitmessageqt/networkstatus.py
+++ b/src/bitmessageqt/networkstatus.py
@@ -46,6 +46,7 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
             self.timer, QtCore.SIGNAL("timeout()"), self.runEveryTwoSeconds)
 
     def startUpdate(self):
+        Inventory().numberOfInventoryLookupsPerformed = 0
         self.runEveryTwoSeconds()
         self.timer.start(2000)  # milliseconds
 


### PR DESCRIPTION
To remove minor update artifact introduced in #1115 when "Inventory lookups per second" shows abnormally high value.