### PR TITLE
Support modern namecoind

### DIFF
--- a/src/namecoin.py
+++ b/src/namecoin.py
@@ -162,7 +162,11 @@ class namecoinConnection (object):
 
         except Exception:
             logger.info("Namecoin connection test failure")
-            return ('failed', "The connection to namecoin failed.")
+            return (
+                'failed',
+                tr._translate(
+                    "MainWindow", "The connection to namecoin failed.")
+            )
 
     # Helper routine that actually performs an JSON RPC call.
     def callRPC (self, method, params):

--- a/src/namecoin.py
+++ b/src/namecoin.py
@@ -129,12 +129,14 @@ class namecoinConnection (object):
     # Test the connection settings.  This routine tries to query a "getinfo"
     # command, and builds either an error message or a success message with
     # some info from it.
-    def test (self):
+    def test(self):
         try:
             if self.nmctype == "namecoind":
-                res = self.callRPC ("getinfo", [])
-                vers = res["version"]
-                
+                try:
+                    vers = self.callRPC("getinfo", [])["version"]
+                except RPCError:
+                    vers = self.callRPC("getnetworkinfo", [])["version"]
+
                 v3 = vers % 100
                 vers = vers / 100
                 v2 = vers % 100


### PR DESCRIPTION
Hello.

This is a small fix for the problem with modern namecoind discussed in `[chan] bitmessage`. At least it works for me (namecoin 0.15.99 reported).

And one more missed `_translate`.