### PR TITLE
Do not duplicate avatar in address column of Address book

### DIFF
--- a/src/bitmessageqt/foldertree.py
+++ b/src/bitmessageqt/foldertree.py
@@ -491,7 +491,15 @@ class Ui_AddressBookWidgetItemAddress(Ui_AddressBookWidgetItem):
         Ui_AddressBookWidgetItem.__init__(self, address, type)
         self.address = address
         self.setFlags(QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled)
-        
+
+    def data(self, role):
+        if role == QtCore.Qt.ToolTipRole:
+            return self.address
+        if role == QtCore.Qt.DecorationRole:
+            return
+        return super(Ui_AddressBookWidgetItemAddress, self).data(role)
+
+
 class AddressBookCompleter(QtGui.QCompleter):
     def __init__(self):
         super(QtGui.QCompleter, self).__init__()


### PR DESCRIPTION
Hello!

I slightly changed `foldertree` module to not draw avatar in the address column and show an address as tooltip instead of `<address> (<address>)` string.

Hope this change is in the right direction