### PR TITLE
Startup problem in openwrt

### DIFF
--- a/src/depends.py
+++ b/src/depends.py
@@ -93,7 +93,7 @@ def check_openssl():
             import os.path
             paths.insert(0, os.path.join(sys._MEIPASS, 'libeay32.dll'))
     else:
-        paths = ['libcrypto.so']
+        paths = ['libcrypto.so', 'libcrypto.so.1.0.0']
     if sys.platform == 'darwin':
         paths.extend([
             'libcrypto.dylib',

--- a/src/pyelliptic/openssl.py
+++ b/src/pyelliptic/openssl.py
@@ -534,6 +534,8 @@ def loadOpenSSL():
     else:
         libdir.append('libcrypto.so')
         libdir.append('libssl.so')
+        libdir.append('libcrypto.so.1.0.0')
+        libdir.append('libssl.so.1.0.0')
     if 'linux' in sys.platform or 'darwin' in sys.platform or 'bsd' in sys.platform:
         libdir.append(find_library('ssl'))
     elif 'win32' in sys.platform or 'win64' in sys.platform:


### PR DESCRIPTION
Hello.

There is no lib symlinks in openwrt, so pybitmessage doesn't start there without this patch.