### PR TITLE
qrcode plugin fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,8 +112,7 @@ if __name__ == "__main__":
         zip_safe=False,
         entry_points={
             'bitmessage.gui.menu': [
-                'popMenuYourIdentities.qrcode = '
-                'pybitmessage.plugins.qrcodeui [qrcode]'
+                'address.qrcode = pybitmessage.plugins.menu_qrcode [qrcode]'
             ],
             'bitmessage.notification.message': [
                 'notify2 = pybitmessage.plugins.notification_notify2'

--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3847,9 +3847,10 @@ class MyForm(settingsmixin.SMainWindow):
             self.popMenuYourIdentities.addAction(self.actionSpecialAddressBehaviorYourIdentities)
             self.popMenuYourIdentities.addAction(self.actionEmailGateway)
             self.popMenuYourIdentities.addSeparator()
-            # preloaded gui.menu plugins with prefix 'address'
-            for plugin in self.menu_plugins['address']:
-                self.popMenuYourIdentities.addAction(plugin)
+            if currentItem.type != AccountMixin.ALL:
+                # preloaded gui.menu plugins with prefix 'address'
+                for plugin in self.menu_plugins['address']:
+                    self.popMenuYourIdentities.addAction(plugin)
             self.popMenuYourIdentities.addSeparator()
         self.popMenuYourIdentities.addAction(self.actionMarkAllRead)
 

--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -255,6 +255,18 @@ class MyForm(settingsmixin.SMainWindow):
                 'customContextMenuRequested(const QPoint&)'),
                         self.on_context_menuYourIdentities)
 
+        # load all gui.menu plugins with prefix 'address'
+        self.menu_plugins = {'address': []}
+        for plugin in get_plugins('gui.menu', 'address'):
+            try:
+                handler, title = plugin(self)
+            except TypeError:
+                continue
+            self.menu_plugins['address'].append(
+                self.ui.addressContextMenuToolbarYourIdentities.addAction(
+                    title, handler
+                ))
+
     def init_chan_popup_menu(self, connectSignal=True):
         # Popup menu for the Channels tab
         self.ui.addressContextMenuToolbar = QtGui.QToolBar()
@@ -3421,6 +3433,10 @@ class MyForm(settingsmixin.SMainWindow):
             self.popMenuSubscriptions.addSeparator()
             self.popMenuSubscriptions.addAction(self.actionsubscriptionsClipboard)
             self.popMenuSubscriptions.addSeparator()
+            # preloaded gui.menu plugins with prefix 'address'
+            for plugin in self.menu_plugins['address']:
+                self.popMenuSubscriptions.addAction(plugin)
+            self.popMenuSubscriptions.addSeparator()
         self.popMenuSubscriptions.addAction(self.actionMarkAllRead)
         self.popMenuSubscriptions.exec_(
             self.ui.treeWidgetSubscriptions.mapToGlobal(point))
@@ -3831,12 +3847,11 @@ class MyForm(settingsmixin.SMainWindow):
             self.popMenuYourIdentities.addAction(self.actionSpecialAddressBehaviorYourIdentities)
             self.popMenuYourIdentities.addAction(self.actionEmailGateway)
             self.popMenuYourIdentities.addSeparator()
+            # preloaded gui.menu plugins with prefix 'address'
+            for plugin in self.menu_plugins['address']:
+                self.popMenuYourIdentities.addAction(plugin)
+            self.popMenuYourIdentities.addSeparator()
         self.popMenuYourIdentities.addAction(self.actionMarkAllRead)
-
-        if get_plugins:
-            for plugin in get_plugins(
-                    'gui.menu', 'popMenuYourIdentities'):
-                plugin(self)
 
         self.popMenuYourIdentities.exec_(
             self.ui.treeWidgetYourIdentities.mapToGlobal(point))
@@ -3856,6 +3871,10 @@ class MyForm(settingsmixin.SMainWindow):
             else:
                 self.popMenu.addAction(self.actionEnable)
             self.popMenu.addAction(self.actionSetAvatar)
+            self.popMenu.addSeparator()
+            # preloaded gui.menu plugins with prefix 'address'
+            for plugin in self.menu_plugins['address']:
+                self.popMenu.addAction(plugin)
             self.popMenu.addSeparator()
         self.popMenu.addAction(self.actionMarkAllRead)
         self.popMenu.exec_(

--- a/src/plugins/menu_qrcode.py
+++ b/src/plugins/menu_qrcode.py
@@ -70,7 +70,7 @@ def connect_plugin(form):
             dialog = form.qrcode_dialog
         except AttributeError:
             form.qrcode_dialog = dialog = QRCodeDialog(form)
-        dialog.render(str(form.getCurrentAccount()))
+        dialog.render('bitmessage:' + str(form.getCurrentAccount()))
         dialog.exec_()
 
     return on_action_ShowQR, _translate("MainWindow", "Show QR-code")

--- a/src/plugins/menu_qrcode.py
+++ b/src/plugins/menu_qrcode.py
@@ -73,10 +73,4 @@ def connect_plugin(form):
         dialog.render(str(form.getCurrentAccount()))
         dialog.exec_()
 
-    # return
-    form.actionShowQRCode = \
-        form.ui.addressContextMenuToolbarYourIdentities.addAction(
-            _translate("MainWindow", "Show QR-code"),
-            on_action_ShowQR
-        )
-    form.popMenuYourIdentities.addAction(form.actionShowQRCode)
+    return on_action_ShowQR, _translate("MainWindow", "Show QR-code")

--- a/src/plugins/menu_qrcode.py
+++ b/src/plugins/menu_qrcode.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+"""
+A menu plugin showing QR-Code for bitmessage address in modal dialog.
+"""
 
 from PyQt4 import QtGui, QtCore
 import qrcode
@@ -8,6 +11,7 @@ from pybitmessage.tr import _translate
 
 # http://stackoverflow.com/questions/20452486
 class Image(qrcode.image.base.BaseImage):
+    """Image output class for qrcode using QPainter"""
     def __init__(self, border, width, box_size):
         self.border = border
         self.width = width
@@ -18,9 +22,11 @@ class Image(qrcode.image.base.BaseImage):
         self._image.fill(QtCore.Qt.white)
 
     def pixmap(self):
+        """Get image pixmap"""
         return QtGui.QPixmap.fromImage(self._image)
 
     def drawrect(self, row, col):
+        """Draw a single rectangle - implementation"""
         painter = QtGui.QPainter(self._image)
         painter.fillRect(
             (col + self.border) * self.box_size,
@@ -28,12 +34,9 @@ class Image(qrcode.image.base.BaseImage):
             self.box_size, self.box_size,
             QtCore.Qt.black)
 
-    def save(self, stream, kind=None):
-        pass
-
 
 class QRCodeDialog(QtGui.QDialog):
-
+    """The dialog"""
     def __init__(self, parent):
         super(QRCodeDialog, self).__init__(parent)
         self.image = QtGui.QLabel(self)
@@ -55,9 +58,11 @@ class QRCodeDialog(QtGui.QDialog):
         self.retranslateUi()
 
     def retranslateUi(self):
+        """A conventional Qt Designer method for dynamic l10n"""
         self.setWindowTitle(_translate("QRCodeDialog", "QR-code"))
 
     def render(self, text):
+        """Draw QR-code and address in labels"""
         self.label.setText(text)
         self.image.setPixmap(
             qrcode.make(text, image_factory=Image).pixmap())
@@ -65,7 +70,9 @@ class QRCodeDialog(QtGui.QDialog):
 
 
 def connect_plugin(form):
+    """Plugin entry point"""
     def on_action_ShowQR():
+        """A slot for popup menu action"""
         try:
             dialog = form.qrcode_dialog
         except AttributeError:


### PR DESCRIPTION
Hello.

This is my technical debt on qrcode plugin:
  - all unused code removed;
  - menu entry is shown on any `QTreeWidgetItem` with address;
  - such plugins now have prefix `address.`;
  - 'BM:' is a schema for QR-code now.

Should I make that plugins also available for Address book and Blacklist entries?
