### PR TITLE
Prevent settingsDialog from setting dontconnect = false

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -1555,6 +1555,8 @@ class MyForm(settingsmixin.SMainWindow):
                 BMConfigParser().save()
             elif dialog.radioButtonConfigureNetwork.isChecked():
                 self.click_actionSettings()
+            else:
+                self._firstrun = False
 
     def showMigrationWizard(self, level):
         self.migrationWizardInstance = Ui_MigrationWizard(["a"])


### PR DESCRIPTION
Hello.

This seems to be the last portion of dontconnect epic (#1161). settingsDialog sets dontconnect to false if it closed by OK button and `myapp._firstrun` is not False or None.