### PR TITLE
Consider to use defaults for 'apiport' and 'apiinterface'

### DIFF
--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -14,6 +14,8 @@ BMConfigDefaults = {
         "maxoutboundconnections": 8,
         "maxtotalconnections": 200,
         "maxuploadrate": 0,
+        "apiinterface": "127.0.0.1",
+        "apiport": 8442
     },
     "threads": {
         "receive": 3,


### PR DESCRIPTION
Adding `apienabled = true`, `apiusername = ` and `apipassword = ` to keys.dat leads to the error during startup:
```
Exception in thread singleAPI:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib64/python2.7/site-packages/pybitmessage/bitmessagemain.py", line 178, in run
    port = BMConfigParser().getint('bitmessagesettings', 'apiport')
  File "/usr/lib64/python2.7/ConfigParser.py", line 359, in getint
    return self._get(section, int, option)
  File "/usr/lib64/python2.7/ConfigParser.py", line 356, in _get
    return conv(self.get(section, option))
  File "/usr/lib64/python2.7/site-packages/pybitmessage/bmconfigparser.py", line 62, in get
    raise e
NoOptionError: No option 'apiport' in section: 'bitmessagesettings'
```

because PyBitmessage expects also `apiport` and `apiinterface`. Let's use defaults for that options.