### PR TITLE
Obvious fix for #1194

### DIFF
--- a/src/bitmessageqt/foldertree.py
+++ b/src/bitmessageqt/foldertree.py
@@ -233,8 +233,9 @@ class Ui_AddressWidget(BMTreeWidgetItem, SettingsMixin):
                 and self.type != AccountMixin.SUBSCRIPTION:
             BMConfigParser().set(
                 str(self.address), 'label',
-                str(value).toString().toUtf8()
-                if isinstance(value, QtCore.QVariant) else str(value)
+                str(value.toString().toUtf8())
+                if isinstance(value, QtCore.QVariant)
+                else value.encode('utf-8')
             )
             BMConfigParser().save()
         return super(Ui_AddressWidget, self).setData(column, role, value)


### PR DESCRIPTION
Excuse me, after creation of qt5 branch I forget to pay attention to unicode <-> str conversions, because it doesn't needed for qt5.

There was also my mistake in QtCore.QVariant -> str conversion, so maybe #1194 is not unicode bug.

* Fixes #1194