### PR TITLE
Download fixes

### DIFF
--- a/src/network/objectracker.py
+++ b/src/network/objectracker.py
@@ -104,6 +104,7 @@ class ObjectTracker(object):
                         del i.objectsNewToThem[hashid]
                 except KeyError:
                     pass
+        self.objectsNewToMe.setLastObject()
 
     def hasAddr(self, addr):
         if haveBloom:

--- a/src/randomtrackingdict.py
+++ b/src/randomtrackingdict.py
@@ -73,6 +73,7 @@ class RandomTrackingDict(object):
         self.pendingTimeout = pendingTimeout
 
     def setLastObject(self):
+        """Update timestamp for tracking of received objects"""
         self.lastObject = time()
 
     def randomKeys(self, count=1):

--- a/src/randomtrackingdict.py
+++ b/src/randomtrackingdict.py
@@ -12,6 +12,7 @@ class RandomTrackingDict(object):
         self.len = 0
         self.pendingLen = 0
         self.lastPoll = 0
+        self.lastObject = 0
         self.lock = RLock()
 
     def __len__(self):
@@ -71,14 +72,18 @@ class RandomTrackingDict(object):
     def setPendingTimeout(self, pendingTimeout):
         self.pendingTimeout = pendingTimeout
 
+    def setLastObject(self):
+        self.lastObject = time()
+
     def randomKeys(self, count=1):
         if self.len == 0 or ((self.pendingLen >= self.maxPending or
             self.pendingLen == self.len) and self.lastPoll +
             self.pendingTimeout > time()):
             raise KeyError
-        # reset if we've requested all
         with self.lock:
-            if self.pendingLen == self.len:
+            # reset if we've requested all
+            # or if last object received too long time ago
+            if self.pendingLen == self.len or self.lastObject + self.pendingTimeout > time():
                 self.pendingLen = 0
             available = self.len - self.pendingLen
             if count > available:


### PR DESCRIPTION
- in corner cases, download request could have contained an incorrect request length. I haven't actually checked if this can be triggered though
- wait for downloading until anti intersection delay expires. Doesn't necessarily mean that it will always avoid peer's anti intersection delay, but it's close enough
- tracks last time an object was received. If it was too long time ago, reset the download request queue. This avoid situations like when a request gets ignored during the anti intersection delay, but it will keep thinking there are still pending requests as long as not all missing objects have been requested. This caused staggered download (request 1000 items, wait 1 minute, request 1000 more, wait another minute, ...)
- with these fixes, you should end up downloading as fast as your network and CPU allow
- best tested with trustedpeer