### PR TITLE
Added API for raw objects

### DIFF
--- a/src/queues.py
+++ b/src/queues.py
@@ -14,3 +14,4 @@ portCheckerQueue = Queue.Queue()
 receiveDataQueue = Queue.Queue()
 apiAddressGeneratorReturnQueue = Queue.Queue(
     )  # The address generator thread uses this queue to get information back to the API thread.
+processedRawObjectsQueue = Queue.Queue()


### PR DESCRIPTION
I found out that the database has no indexes, so it makes little sense to filter objects with complex queries, because they will be execuded by linear search anyway.

Apart from that, everything is done.

`disseminateRawObject`
----------------------

Parameter: a hex-encoded object without packet headers, starting from nonce.

Tries to send the object to the network. POW must be already calculated.

Raises an error or returns the object's inventory hash. It can return the hash for invalid objects, but this problem can be avoided by not sending invalid objects to this method.

`queueRawObject`
----------------

Parameter: a hex-encoded object without packet headers and nonce, starting from expiry time.

Queues the object for POW calculation and sending to the network.

Returns a unique handle to track the objects state.

`checkQueuedRawObject`
----------------------

Parameter: a handle returned from the `queueRawObject` method.

Returns current status of the object:
- `queued` for waiting objects;
- `failed` for invalid objects;
- hex-encoded inventory hash for sent object. As with the `disseminateRawObject` there may be false positives;
- `notfound` for wrong handles and for handles that previously returned `failed` or an inventory hash.

If a queued object enters the `notfound` state, it can mean that the daemon was restarted, because the queued objects are not saved to the disk.

`getRawObject`
--------------

Parameter: an inventory hash.

Raises an error or returns a JSON object with the following fields:
- `hash` - the inventory hash;
- `objectType` - an integer;
- `streamNumber`;
- `payload` - hex-encoded object without packet headers, starting from nonce;
- `expiresTime` - a UNIX timestamp;
- `tag` - hex-encoded object tag or an empty string.

`listRawObjects`
----------------

Parameters: desired object type or -1, stream number or 0, start and end of the object slice, may be negative.

Returns a list of JSON objects with the following fields:
- `hash` - an inventory hash of a found object;
- `slice` - a hex-encoded fragment of the object, determined by the provided slice boundaries.

---

I see no reason to sing the commit with GPG, because the guidelines allow sending patches through a public Bitmessage channel. But if really need it, I can sign it with a random key.