### PR TITLE
Avoid importing big libs before decision to use them

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -51,8 +51,6 @@ from class_singleCleaner import singleCleaner
 from class_objectProcessor import objectProcessor
 from class_singleWorker import singleWorker
 from class_addressGenerator import addressGenerator
-from class_smtpDeliver import smtpDeliver
-from class_smtpServer import smtpServer
 from bmconfigparser import BMConfigParser
 
 from inventory import Inventory
@@ -310,12 +308,14 @@ class Main:
             # SMTP delivery thread
             if daemon and BMConfigParser().safeGet(
                     "bitmessagesettings", "smtpdeliver", '') != '':
+                from class_smtpDeliver import smtpDeliver
                 smtpDeliveryThread = smtpDeliver()
                 smtpDeliveryThread.start()
 
             # SMTP daemon thread
             if daemon and BMConfigParser().safeGetBoolean(
                     "bitmessagesettings", "smtpd"):
+                from class_smtpServer import smtpServer
                 smtpServerThread = smtpServer()
                 smtpServerThread.start()
 

--- a/src/openclpow.py
+++ b/src/openclpow.py
@@ -20,10 +20,11 @@ vendors = []
 hash_dt = None
 
 try:
-    import numpy
     import pyopencl as cl
-except:
+    import numpy
+except ImportError:
     libAvailable = False
+
 
 def initCL():
     global ctx, queue, program, hash_dt, libAvailable


### PR DESCRIPTION
Came in bitmessage chan:
[Patch](https://beamstat.com/chan/bitmessage/30b1357084631806d8abf97e35452a80b65cda8b317b3446f8ee39b484cc94dc): try to load `pyopencl` before `numpy`
[Patch2](https://beamstat.com/chan/bitmessage/83d50cdaafd9919431a59093611d71281644ae93a6252b9c0e0428600ac15f15): do not load modules which use `email` if not configured

It makes sense  for me. I looked into top -Hp `cat .config/PyBitmessage/singleton.lock` and got these values for VIRT and RES just after pybitmessage started:

```
no changes:   1572.2m 117.2m
no email:     1570.5m 115.3m
and no numpy: 1529.9m 106.6m
```