### PR TITLE
No need to import namecoin early because it's really used only in Qt UI

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -23,7 +23,7 @@ import shared
 from bitmessageui import Ui_MainWindow
 from bmconfigparser import BMConfigParser
 import defaults
-from namecoin import namecoinConnection
+import namecoin
 from messageview import MessageView
 from migrationwizard import Ui_MigrationWizard
 from foldertree import (
@@ -797,7 +797,8 @@ class MyForm(settingsmixin.SMainWindow):
 
         self.initSettings()
 
-        self.namecoin = namecoinConnection()
+        namecoin.ensureNamecoinOptions()
+        self.namecoin = namecoin.namecoinConnection()
 
         # Check to see whether we can connect to namecoin.
         # Hide the 'Fetch Namecoin ID' button if we can't.

--- a/src/helper_startup.py
+++ b/src/helper_startup.py
@@ -8,7 +8,6 @@ import os
 import platform
 from distutils.version import StrictVersion
 
-from namecoin import ensureNamecoinOptions
 import paths
 import state
 import helper_random
@@ -129,8 +128,6 @@ def loadConfig():
         # existing users. To do that, search the class_sqlThread.py file for the
         # text: "right above this line!"
 
-        ensureNamecoinOptions()
-
         if StoreConfigFilesInSameDirectoryAsProgramByDefault:
             # Just use the same directory as the program and forget about
             # the appdata folder
@@ -145,6 +142,7 @@ def loadConfig():
         BMConfigParser().save()
 
     _loadTrustedPeer()
+
 
 def isOurOperatingSystemLimitedToHavingVeryFewHalfOpenConnections():
     try:


### PR DESCRIPTION
Hello!

I'm trying to reduce early imports. This is a first of the changes that I test.