### PR TITLE
Round peer rating to 2 decimal places before saving knownnodes

### DIFF
--- a/src/knownnodes.py
+++ b/src/knownnodes.py
@@ -37,6 +37,7 @@ def json_serialize_knownnodes(output):
     _serialized = []
     for stream, peers in knownNodes.iteritems():
         for peer, info in peers.iteritems():
+            info.update(rating=round(info.get('rating', 0), 2))
             _serialized.append({
                 'stream': stream, 'peer': peer._asdict(), 'info': info
             })


### PR DESCRIPTION
Rounding the peer ratings helps avoid values like

> "rating": 0.30000000000000004, 
> "rating": 0.5000000000000001, 
> "rating": 0.8999999999999999,