### PR TITLE
Moved class singleAPI to api module and `import api` below config check

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -68,6 +68,7 @@ class StoppableXMLRPCServer(SimpleXMLRPCServer):
 
 # This thread, of which there is only one, runs the API.
 class singleAPI(threading.Thread, helper_threading.StoppableThread):
+    """API thread"""
     def __init__(self):
         threading.Thread.__init__(self, name="singleAPI")
         self.initStop()
@@ -88,8 +89,8 @@ class singleAPI(threading.Thread, helper_threading.StoppableThread):
     def run(self):
         port = BMConfigParser().getint('bitmessagesettings', 'apiport')
         try:
-            from errno import WSAEADDRINUSE
-        except (ImportError, AttributeError):
+            getattr(errno, 'WSAEADDRINUSE')
+        except AttributeError:
             errno.WSAEADDRINUSE = errno.EADDRINUSE
         for attempt in range(50):
             try:
@@ -133,7 +134,7 @@ class singleAPI(threading.Thread, helper_threading.StoppableThread):
 # Modified by Jonathan Warren (Atheros).
 # http://code.activestate.com/recipes/501148-xmlrpc-serverclient-which-does-cookie-handling-and/
 class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
-
+    """The main API handler"""
     def do_POST(self):
         # Handles the HTTP POST request.
         # Attempts to interpret all HTTP POST requests as XML-RPC calls,

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -288,7 +288,7 @@ class Main:
 
             # API is also objproc dependent
             if BMConfigParser().safeGetBoolean('bitmessagesettings', 'apienabled'):
-                import api
+                import api  # pylint: disable=relative-import
                 singleAPIThread = api.singleAPI()
                 # close the main program even if there are threads left
                 singleAPIThread.daemon = True


### PR DESCRIPTION
This allows to further reduce early imports in `bitmessagemain` and potentially to not import `api` at all.