### PR TITLE
make ## ./bitmessagemain.py --curses ##  work in Konsole and xterm

### DIFF
--- a/src/depends.py
+++ b/src/depends.py
@@ -363,7 +363,7 @@ def check_curses():
     import subprocess
 
     try:
-        subprocess.check_call(       "dialog")
+        subprocess.check_call("dialog")
         #subprocess.check_call('which dialog') # no longer works
     except subprocess.CalledProcessError:
         logger.error(

--- a/src/depends.py
+++ b/src/depends.py
@@ -363,7 +363,8 @@ def check_curses():
     import subprocess
 
     try:
-        subprocess.check_call('which dialog')
+        subprocess.check_call(       "dialog")
+        #subprocess.check_call('which dialog') # no longer works
     except subprocess.CalledProcessError:
         logger.error(
             'Curses requires the `dialog` command to be installed as well as'


### PR DESCRIPTION
subprocess.check_call('which dialog') # no longer works

the "which" is superfluous