### PR TITLE
Massive changes to src/bitmessagecli.py

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -7,72 +7,90 @@ This is not what you run to run the Bitmessage API. Instead, enable the API
 ( https://bitmessage.org/wiki/Daemon ) then run bitmessagemain.py.
 """
 
-import base64
-import hashlib
-import json
-import time
-from binascii import hexlify, unhexlify
-from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer
-from struct import pack
+from __future__ import print_function
 
-import shared
-from addresses import (
-    decodeAddress, addBMIfNotPresent, decodeVarint,
-    calculateInventoryHash, varintDecodeError)
+import time
+from services import APIError, Services
+from addresses import varintDecodeError
+
+try:
+    # import SocketServer
+    from SocketServer import BaseServer
+    from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer, SimpleXMLRPCDispatcher
+    from thread import start_new_thread
+except ImportError:
+    from socketserver import BaseServer
+    from xmlrpc.server import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer, SimpleXMLRPCDispatcher
+    from _thread import start_new_thread
+
+import ssl
+import socket
+from threading import Thread, Condition
+
 from bmconfigparser import BMConfigParser
-import defaults
-import helper_inbox
-import helper_sent
 
 import state
-import queues
-import shutdown
-import network.stats
+import sys
+import errno
+import threading
+import helper_threading
 
 # Classes
-from helper_sql import sqlQuery, sqlExecute, SqlBulkExecute, sqlStoredProcedure
-from helper_ackPayload import genAckPayload
 from debug import logger
-from inventory import Inventory
-from version import softwareVersion
+import traceback
 
-# Helper Functions
-import proofofwork
+DEFAULTKEYFILE = 'sslkeys/key.pem'
+DEFAULTFILE = 'sslkeys/cert.pem'
 
-str_chan = '[chan]'
+class CustomThreadingMixIn:
+    """Mix-in class to handle each resquest in new thread."""
+    # Decides how threads will act upon termination of the main process
+    daemon_threads = True
+
+    def process_request_thread(self, request, client_address):
+        """Same as in BaseServer but as a thread.
+        In addition, exception handling is done here.
+        """
+        try:
+            self.finish_request(request, client_address)
+            self.close_request(request)
+
+        except socket.error as err:
+            logger.warning('socket.error finishing request from "%s"; Error: %s' % (client_address, str(err)))
+            self.close_request(request)
+        except Exception:
+            self.handle_error(request, client_address)
+            self.close_request(request)
+
+    def process_request(self, request, client_address):
+        """Start a new thread to process the request."""
+        t = Thread(target=self.process_request_thread, args=(request, client_address))
+        if self.daemon_threads:
+            t.setDaemon(1)
+        t.start()
 
 
-class APIError(Exception):
-    def __init__(self, error_number, error_message):
-        super(APIError, self).__init__()
-        self.error_number = error_number
-        self.error_message = error_message
+class VerifyingRequestHandler(SimpleXMLRPCRequestHandler):
+    cookies = []
 
-    def __str__(self):
-        return "API Error %04i: %s" % (self.error_number, self.error_message)
+    def setup(self):
+        self.connection = self.request
+        self.rfile = socket.socket.makefile(self.request, 'rb', self.rbufsize)
+        self.wfile = socket.socket.makefile(self.request, 'wb', self.wbufsize)
 
-
-class StoppableXMLRPCServer(SimpleXMLRPCServer):
-    allow_reuse_address = True
-
-    def serve_forever(self):
-        while state.shutdown == 0:
-            self.handle_request()
-
-
-# This is one of several classes that constitute the API
-# This class was written by Vaibhav Bhatia.
-# Modified by Jonathan Warren (Atheros).
-# http://code.activestate.com/recipes/501148-xmlrpc-serverclient-which-does-cookie-handling-and/
-class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
+    def address_string(self):
+        """Getting 'FQDN' from host seems to stall on some ip address, so... just (quickly!) return raw host address"""
+        host, port = self.client_address[:2]
+        # return socket.getfqdn(host)
+        return host
 
     def do_POST(self):
-        # Handles the HTTP POST request.
-        # Attempts to interpret all HTTP POST requests as XML-RPC calls,
-        # which are forwarded to the server's _dispatch method for handling.
+        """ Handles the HTTP(S) POST request.
+        It was copied out from SimpleXMLRPCServer.py and modified to shutdown the socket cleanly and handle cookies.
 
-        # Note: this method is the same as in SimpleXMLRPCRequestHandler,
-        # just hacked to handle cookies
+        Attempts to interpret all HTTP POST requests as XML-RPC calls,
+        which are forwarded to the server's _dispatch method for handling.
+        """
 
         # Check that the path is legal
         if not self.is_rpc_path_valid():
@@ -89,9 +107,17 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             L = []
             while size_remaining:
                 chunk_size = min(size_remaining, max_chunk_size)
-                L.append(self.rfile.read(chunk_size))
+                chunk = self.rfile.read(chunk_size)
+                if not chunk:
+                    break
+                L.append(chunk)
                 size_remaining -= len(L[-1])
-            data = ''.join(L)
+            data = b''.join(L)
+
+            # skip encoding checking
+            # data = SimpleXMLRPCRequestHandler.decode_request_content(data)
+            # if data is None:
+            #     return  # response has been sent
 
             # In previous versions of SimpleXMLRPCServer, _dispatch
             # could be overridden in this class, instead of in
@@ -99,16 +125,19 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             # check to see if a subclass implements _dispatch and dispatch
             # using that method if present.
             response = self.server._marshaled_dispatch(
-                data, getattr(self, '_dispatch', None)
+                data, getattr(self, '_dispatch', None), self.path
             )
-        except:  # This should only happen if the module is buggy
+        except Exception as err:  # This should only happen if the module is buggy
             # internal error, report as HTTP server error
+            logger.exception('do_POST Exception:')
             self.send_response(500)
+            # traceback response removed
             self.end_headers()
         else:
             # got a valid XML RPC response
             self.send_response(200)
             self.send_header("Content-type", "text/xml")
+            # zip encoding request ignored //self.encode_threshold 1400(default)
             self.send_header("Content-length", str(len(response)))
 
             # HACK :start -> sends cookies here
@@ -124,1170 +153,200 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             self.wfile.flush()
             self.connection.shutdown(1)
 
-    def APIAuthenticateClient(self):
-        if 'Authorization' in self.headers:
-            # handle Basic authentication
+        return
+
+    def do_GET(self):
+        if not self.is_rpc_path_valid():
+            self.report_404()
+            return
+
+        response = self.server.generate_html_documentation()
+        self.send_response(200)
+        self.send_header("Content-type", "text/xml")
+        self.send_header("Content-length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+        # shut down the connection
+        self.wfile.flush()
+        self.connection.shutdown(1)
+
+        return
+
+    def report_404 (self):
+            # Report a 404 error
+        self.send_response(404)
+        response = b'No such page'
+        self.send_header("Content-type", "text/plain")
+        self.send_header("Content-length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+        # shut down the connection
+        self.wfile.flush()
+        self.connection.shutdown(1)
+
+    def parse_request(self):
+        """Http version checking and connection close, force Basic Authentication"""
+
+        import base64
+        try:
+            from urllib import unquote as unquote_to_bytes
+        except ImportError:
+            from urllib.parse import unquote_to_bytes
+
+        isValid = False
+        if SimpleXMLRPCRequestHandler.parse_request(self):
             enctype, encstr = self.headers.get('Authorization').split()
-            emailid, password = encstr.decode('base64').split(':')
-            return (
-                emailid ==
-                BMConfigParser().get('bitmessagesettings', 'apiusername')
-                and password ==
-                BMConfigParser().get('bitmessagesettings', 'apipassword')
-            )
+            encstr = base64.b64decode(encstr).decode("utf-8")
+            emailid, password = encstr.split(':')
+            emailid = unquote_to_bytes(emailid).decode("utf-8")
+            password = unquote_to_bytes(password).decode("utf-8")
+            isValid = emailid == BMConfigParser().get('bitmessagesettings', 'apiusername') and password == BMConfigParser().get('bitmessagesettings', 'apipassword')
         else:
             logger.warning(
                 'Authentication failed because header lacks'
                 ' Authentication field')
             time.sleep(2)
-            return False
 
-        return False
+        if isValid is False:
+            self.send_error(401, b'Authetication failed')
 
-    def _decode(self, text, decode_type):
-        try:
-            if decode_type == 'hex':
-                return unhexlify(text)
-            elif decode_type == 'base64':
-                return base64.b64decode(text)
-        except Exception as e:
-            raise APIError(
-                22, "Decode error - %s. Had trouble while decoding string: %r"
-                % (e, text)
-            )
+        return isValid
 
-    def _verifyAddress(self, address):
-        status, addressVersionNumber, streamNumber, ripe = \
-            decodeAddress(address)
-        if status != 'success':
-            logger.warning(
-                'API Error 0007: Could not decode address %s. Status: %s.',
-                address, status
-            )
 
-            if status == 'checksumfailed':
-                raise APIError(8, 'Checksum failed for address: ' + address)
-            if status == 'invalidcharacters':
-                raise APIError(9, 'Invalid characters in address: ' + address)
-            if status == 'versiontoohigh':
-                raise APIError(
-                    10,
-                    'Address version number too high (or zero) in address: '
-                    + address
-                )
-            if status == 'varintmalformed':
-                raise APIError(26, 'Malformed varint in address: ' + address)
-            raise APIError(
-                7, 'Could not decode address: %s : %s' % (address, status))
-        if addressVersionNumber < 2 or addressVersionNumber > 4:
-            raise APIError(
-                11, 'The address version number currently must be 2, 3 or 4.'
-                ' Others aren\'t supported. Check the address.'
-            )
-        if streamNumber != 1:
-            raise APIError(
-                12, 'The stream number must be 1. Others aren\'t supported.'
-                ' Check the address.'
-            )
+class StoppableXMLRPCServer(CustomThreadingMixIn, SimpleXMLRPCServer, VerifyingRequestHandler, Services):
 
-        return (status, addressVersionNumber, streamNumber, ripe)
-
-    # Request Handlers
-
-    def HandleListAddresses(self, method):
-        data = '{"addresses":['
-        for addressInKeysFile in BMConfigParser().addresses():
-            status, addressVersionNumber, streamNumber, hash01 = decodeAddress(
-                addressInKeysFile)
-            if len(data) > 20:
-                data += ','
-            if BMConfigParser().has_option(addressInKeysFile, 'chan'):
-                chan = BMConfigParser().getboolean(addressInKeysFile, 'chan')
-            else:
-                chan = False
-            label = BMConfigParser().get(addressInKeysFile, 'label')
-            if method == 'listAddresses2':
-                label = base64.b64encode(label)
-            data += json.dumps({
-                'label': label,
-                'address': addressInKeysFile,
-                'stream': streamNumber,
-                'enabled':
-                BMConfigParser().getboolean(addressInKeysFile, 'enabled'),
-                'chan': chan
-                }, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleListAddressBookEntries(self, params):
-        if len(params) == 1:
-            label, = params
-            label = self._decode(label, "base64")
-            queryreturn = sqlQuery(
-                "SELECT label, address from addressbook WHERE label = ?",
-                label)
-        elif len(params) > 1:
-            raise APIError(0, "Too many paremeters, max 1")
-        else:
-            queryreturn = sqlQuery("SELECT label, address from addressbook")
-        data = '{"addresses":['
-        for row in queryreturn:
-            label, address = row
-            label = shared.fixPotentiallyInvalidUTF8Data(label)
-            if len(data) > 20:
-                data += ','
-            data += json.dumps({
-                'label': base64.b64encode(label),
-                'address': address}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleAddAddressBookEntry(self, params):
-        if len(params) != 2:
-            raise APIError(0, "I need label and address")
-        address, label = params
-        label = self._decode(label, "base64")
-        address = addBMIfNotPresent(address)
-        self._verifyAddress(address)
-        queryreturn = sqlQuery(
-            "SELECT address FROM addressbook WHERE address=?", address)
-        if queryreturn != []:
-            raise APIError(
-                16, 'You already have this address in your address book.')
-
-        sqlExecute("INSERT INTO addressbook VALUES(?,?)", label, address)
-        queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
-        queues.UISignalQueue.put(('rerenderMessagelistToLabels', ''))
-        queues.UISignalQueue.put(('rerenderAddressBook', ''))
-        return "Added address %s to address book" % address
-
-    def HandleDeleteAddressBookEntry(self, params):
-        if len(params) != 1:
-            raise APIError(0, "I need an address")
-        address, = params
-        address = addBMIfNotPresent(address)
-        self._verifyAddress(address)
-        sqlExecute('DELETE FROM addressbook WHERE address=?', address)
-        queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
-        queues.UISignalQueue.put(('rerenderMessagelistToLabels', ''))
-        queues.UISignalQueue.put(('rerenderAddressBook', ''))
-        return "Deleted address book entry for %s if it existed" % address
-
-    def HandleCreateRandomAddress(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        elif len(params) == 1:
-            label, = params
-            eighteenByteRipe = False
-            nonceTrialsPerByte = BMConfigParser().get(
-                'bitmessagesettings', 'defaultnoncetrialsperbyte')
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 2:
-            label, eighteenByteRipe = params
-            nonceTrialsPerByte = BMConfigParser().get(
-                'bitmessagesettings', 'defaultnoncetrialsperbyte')
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 3:
-            label, eighteenByteRipe, totalDifficulty = params
-            nonceTrialsPerByte = int(
-                defaults.networkDefaultProofOfWorkNonceTrialsPerByte
-                * totalDifficulty)
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 4:
-            label, eighteenByteRipe, totalDifficulty, \
-                smallMessageDifficulty = params
-            nonceTrialsPerByte = int(
-                defaults.networkDefaultProofOfWorkNonceTrialsPerByte
-                * totalDifficulty)
-            payloadLengthExtraBytes = int(
-                defaults.networkDefaultPayloadLengthExtraBytes
-                * smallMessageDifficulty)
-        else:
-            raise APIError(0, 'Too many parameters!')
-        label = self._decode(label, "base64")
-        try:
-            unicode(label, 'utf-8')
-        except:
-            raise APIError(17, 'Label is not valid UTF-8 data.')
-        queues.apiAddressGeneratorReturnQueue.queue.clear()
-        streamNumberForAddress = 1
-        queues.addressGeneratorQueue.put((
-            'createRandomAddress', 4, streamNumberForAddress, label, 1, "",
-            eighteenByteRipe, nonceTrialsPerByte, payloadLengthExtraBytes
-        ))
-        return queues.apiAddressGeneratorReturnQueue.get()
-
-    def HandleCreateDeterministicAddresses(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        elif len(params) == 1:
-            passphrase, = params
-            numberOfAddresses = 1
-            addressVersionNumber = 0
-            streamNumber = 0
-            eighteenByteRipe = False
-            nonceTrialsPerByte = BMConfigParser().get(
-                'bitmessagesettings', 'defaultnoncetrialsperbyte')
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 2:
-            passphrase, numberOfAddresses = params
-            addressVersionNumber = 0
-            streamNumber = 0
-            eighteenByteRipe = False
-            nonceTrialsPerByte = BMConfigParser().get(
-                'bitmessagesettings', 'defaultnoncetrialsperbyte')
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 3:
-            passphrase, numberOfAddresses, addressVersionNumber = params
-            streamNumber = 0
-            eighteenByteRipe = False
-            nonceTrialsPerByte = BMConfigParser().get(
-                'bitmessagesettings', 'defaultnoncetrialsperbyte')
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 4:
-            passphrase, numberOfAddresses, addressVersionNumber, \
-                streamNumber = params
-            eighteenByteRipe = False
-            nonceTrialsPerByte = BMConfigParser().get(
-                'bitmessagesettings', 'defaultnoncetrialsperbyte')
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 5:
-            passphrase, numberOfAddresses, addressVersionNumber, \
-                streamNumber, eighteenByteRipe = params
-            nonceTrialsPerByte = BMConfigParser().get(
-                'bitmessagesettings', 'defaultnoncetrialsperbyte')
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 6:
-            passphrase, numberOfAddresses, addressVersionNumber, \
-                streamNumber, eighteenByteRipe, totalDifficulty = params
-            nonceTrialsPerByte = int(
-                defaults.networkDefaultProofOfWorkNonceTrialsPerByte
-                * totalDifficulty)
-            payloadLengthExtraBytes = BMConfigParser().get(
-                'bitmessagesettings', 'defaultpayloadlengthextrabytes')
-        elif len(params) == 7:
-            passphrase, numberOfAddresses, addressVersionNumber, \
-                streamNumber, eighteenByteRipe, totalDifficulty, \
-                smallMessageDifficulty = params
-            nonceTrialsPerByte = int(
-                defaults.networkDefaultProofOfWorkNonceTrialsPerByte
-                * totalDifficulty)
-            payloadLengthExtraBytes = int(
-                defaults.networkDefaultPayloadLengthExtraBytes
-                * smallMessageDifficulty)
-        else:
-            raise APIError(0, 'Too many parameters!')
-        if len(passphrase) == 0:
-            raise APIError(1, 'The specified passphrase is blank.')
-        if not isinstance(eighteenByteRipe, bool):
-            raise APIError(
-                23, 'Bool expected in eighteenByteRipe, saw %s instead' %
-                type(eighteenByteRipe))
-        passphrase = self._decode(passphrase, "base64")
-        # 0 means "just use the proper addressVersionNumber"
-        if addressVersionNumber == 0:
-            addressVersionNumber = 4
-        if addressVersionNumber != 3 and addressVersionNumber != 4:
-            raise APIError(
-                2, 'The address version number currently must be 3, 4, or 0'
-                ' (which means auto-select). %i isn\'t supported.' %
-                addressVersionNumber)
-        if streamNumber == 0:  # 0 means "just use the most available stream"
-            streamNumber = 1
-        if streamNumber != 1:
-            raise APIError(
-                3, 'The stream number must be 1 (or 0 which means'
-                ' auto-select). Others aren\'t supported.')
-        if numberOfAddresses == 0:
-            raise APIError(
-                4, 'Why would you ask me to generate 0 addresses for you?')
-        if numberOfAddresses > 999:
-            raise APIError(
-                5, 'You have (accidentally?) specified too many addresses to'
-                ' make. Maximum 999. This check only exists to prevent'
-                ' mischief; if you really want to create more addresses than'
-                ' this, contact the Bitmessage developers and we can modify'
-                ' the check or you can do it yourself by searching the source'
-                ' code for this message.')
-        queues.apiAddressGeneratorReturnQueue.queue.clear()
-        logger.debug(
-            'Requesting that the addressGenerator create %s addresses.',
-            numberOfAddresses)
-        queues.addressGeneratorQueue.put((
-            'createDeterministicAddresses', addressVersionNumber, streamNumber,
-            'unused API address', numberOfAddresses, passphrase,
-            eighteenByteRipe, nonceTrialsPerByte, payloadLengthExtraBytes
-        ))
-        data = '{"addresses":['
-        queueReturn = queues.apiAddressGeneratorReturnQueue.get()
-        for item in queueReturn:
-            if len(data) > 20:
-                data += ','
-            data += "\"" + item + "\""
-        data += ']}'
-        return data
-
-    def HandleGetDeterministicAddress(self, params):
-        if len(params) != 3:
-            raise APIError(0, 'I need exactly 3 parameters.')
-        passphrase, addressVersionNumber, streamNumber = params
-        numberOfAddresses = 1
-        eighteenByteRipe = False
-        if len(passphrase) == 0:
-            raise APIError(1, 'The specified passphrase is blank.')
-        passphrase = self._decode(passphrase, "base64")
-        if addressVersionNumber != 3 and addressVersionNumber != 4:
-            raise APIError(
-                2, 'The address version number currently must be 3 or 4. %i'
-                ' isn\'t supported.' % addressVersionNumber)
-        if streamNumber != 1:
-            raise APIError(
-                3, ' The stream number must be 1. Others aren\'t supported.')
-        queues.apiAddressGeneratorReturnQueue.queue.clear()
-        logger.debug(
-            'Requesting that the addressGenerator create %s addresses.',
-            numberOfAddresses)
-        queues.addressGeneratorQueue.put((
-            'getDeterministicAddress', addressVersionNumber, streamNumber,
-            'unused API address', numberOfAddresses, passphrase,
-            eighteenByteRipe
-        ))
-        return queues.apiAddressGeneratorReturnQueue.get()
-
-    def HandleCreateChan(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters.')
-        elif len(params) == 1:
-            passphrase, = params
-        passphrase = self._decode(passphrase, "base64")
-        if len(passphrase) == 0:
-            raise APIError(1, 'The specified passphrase is blank.')
-        # It would be nice to make the label the passphrase but it is
-        # possible that the passphrase contains non-utf-8 characters.
-        try:
-            unicode(passphrase, 'utf-8')
-            label = str_chan + ' ' + passphrase
-        except:
-            label = str_chan + ' ' + repr(passphrase)
-
-        addressVersionNumber = 4
-        streamNumber = 1
-        queues.apiAddressGeneratorReturnQueue.queue.clear()
-        logger.debug(
-            'Requesting that the addressGenerator create chan %s.', passphrase)
-        queues.addressGeneratorQueue.put((
-            'createChan', addressVersionNumber, streamNumber, label,
-            passphrase, True
-        ))
-        queueReturn = queues.apiAddressGeneratorReturnQueue.get()
-        if len(queueReturn) == 0:
-            raise APIError(24, 'Chan address is already present.')
-        address = queueReturn[0]
-        return address
-
-    def HandleJoinChan(self, params):
-        if len(params) < 2:
-            raise APIError(0, 'I need two parameters.')
-        elif len(params) == 2:
-            passphrase, suppliedAddress = params
-        passphrase = self._decode(passphrase, "base64")
-        if len(passphrase) == 0:
-            raise APIError(1, 'The specified passphrase is blank.')
-        # It would be nice to make the label the passphrase but it is
-        # possible that the passphrase contains non-utf-8 characters.
-        try:
-            unicode(passphrase, 'utf-8')
-            label = str_chan + ' ' + passphrase
-        except:
-            label = str_chan + ' ' + repr(passphrase)
-
-        status, addressVersionNumber, streamNumber, toRipe = \
-            self._verifyAddress(suppliedAddress)
-        suppliedAddress = addBMIfNotPresent(suppliedAddress)
-        queues.apiAddressGeneratorReturnQueue.queue.clear()
-        queues.addressGeneratorQueue.put((
-            'joinChan', suppliedAddress, label, passphrase, True
-        ))
-        addressGeneratorReturnValue = \
-            queues.apiAddressGeneratorReturnQueue.get()
-
-        if addressGeneratorReturnValue[0] == \
-                'chan name does not match address':
-            raise APIError(18, 'Chan name does not match address.')
-        if len(addressGeneratorReturnValue) == 0:
-            raise APIError(24, 'Chan address is already present.')
-        # TODO: this variable is not used to anything
-        # in case we ever want it for anything.
-        # createdAddress = addressGeneratorReturnValue[0]
-        return "success"
-
-    def HandleLeaveChan(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters.')
-        elif len(params) == 1:
-            address, = params
-        status, addressVersionNumber, streamNumber, toRipe = \
-            self._verifyAddress(address)
-        address = addBMIfNotPresent(address)
-        if not BMConfigParser().has_section(address):
-            raise APIError(
-                13, 'Could not find this address in your keys.dat file.')
-        if not BMConfigParser().safeGetBoolean(address, 'chan'):
-            raise APIError(
-                25, 'Specified address is not a chan address.'
-                ' Use deleteAddress API call instead.')
-        BMConfigParser().remove_section(address)
-        with open(state.appdata + 'keys.dat', 'wb') as configfile:
-            BMConfigParser().write(configfile)
-        return 'success'
-
-    def HandleDeleteAddress(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters.')
-        elif len(params) == 1:
-            address, = params
-        status, addressVersionNumber, streamNumber, toRipe = \
-            self._verifyAddress(address)
-        address = addBMIfNotPresent(address)
-        if not BMConfigParser().has_section(address):
-            raise APIError(
-                13, 'Could not find this address in your keys.dat file.')
-        BMConfigParser().remove_section(address)
-        with open(state.appdata + 'keys.dat', 'wb') as configfile:
-            BMConfigParser().write(configfile)
-        queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
-        queues.UISignalQueue.put(('rerenderMessagelistToLabels', ''))
-        shared.reloadMyAddressHashes()
-        return 'success'
-
-    def HandleGetAllInboxMessages(self, params):
-        queryreturn = sqlQuery(
-            "SELECT msgid, toaddress, fromaddress, subject, received, message,"
-            " encodingtype, read FROM inbox where folder='inbox'"
-            " ORDER BY received"
-        )
-        data = '{"inboxMessages":['
-        for row in queryreturn:
-            msgid, toAddress, fromAddress, subject, received, message, \
-                encodingtype, read = row
-            subject = shared.fixPotentiallyInvalidUTF8Data(subject)
-            message = shared.fixPotentiallyInvalidUTF8Data(message)
-            if len(data) > 25:
-                data += ','
-            data += json.dumps({
-                'msgid': hexlify(msgid),
-                'toAddress': toAddress,
-                'fromAddress': fromAddress,
-                'subject': base64.b64encode(subject),
-                'message': base64.b64encode(message),
-                'encodingType': encodingtype,
-                'receivedTime': received,
-                'read': read}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleGetAllInboxMessageIds(self, params):
-        queryreturn = sqlQuery(
-            "SELECT msgid FROM inbox where folder='inbox' ORDER BY received")
-        data = '{"inboxMessageIds":['
-        for row in queryreturn:
-            msgid = row[0]
-            if len(data) > 25:
-                data += ','
-            data += json.dumps(
-                {'msgid': hexlify(msgid)}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleGetInboxMessageById(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        elif len(params) == 1:
-            msgid = self._decode(params[0], "hex")
-        elif len(params) >= 2:
-            msgid = self._decode(params[0], "hex")
-            readStatus = params[1]
-            if not isinstance(readStatus, bool):
-                raise APIError(
-                    23, 'Bool expected in readStatus, saw %s instead.' %
-                    type(readStatus))
-            queryreturn = sqlQuery(
-                "SELECT read FROM inbox WHERE msgid=?", msgid)
-            # UPDATE is slow, only update if status is different
-            if queryreturn != [] and (queryreturn[0][0] == 1) != readStatus:
-                sqlExecute(
-                    "UPDATE inbox set read = ? WHERE msgid=?",
-                    readStatus, msgid)
-                queues.UISignalQueue.put(('changedInboxUnread', None))
-        queryreturn = sqlQuery(
-            "SELECT msgid, toaddress, fromaddress, subject, received, message,"
-            " encodingtype, read FROM inbox WHERE msgid=?", msgid
-        )
-        data = '{"inboxMessage":['
-        for row in queryreturn:
-            msgid, toAddress, fromAddress, subject, received, message, \
-                encodingtype, read = row
-            subject = shared.fixPotentiallyInvalidUTF8Data(subject)
-            message = shared.fixPotentiallyInvalidUTF8Data(message)
-            data += json.dumps({
-                'msgid': hexlify(msgid),
-                'toAddress': toAddress,
-                'fromAddress': fromAddress,
-                'subject': base64.b64encode(subject),
-                'message': base64.b64encode(message),
-                'encodingType': encodingtype,
-                'receivedTime': received,
-                'read': read}, indent=4, separators=(',', ': '))
-            data += ']}'
-            return data
-
-    def HandleGetAllSentMessages(self, params):
-        queryreturn = sqlQuery(
-            "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
-            " message, encodingtype, status, ackdata FROM sent"
-            " WHERE folder='sent' ORDER BY lastactiontime"
-        )
-        data = '{"sentMessages":['
-        for row in queryreturn:
-            msgid, toAddress, fromAddress, subject, lastactiontime, message, \
-                encodingtype, status, ackdata = row
-            subject = shared.fixPotentiallyInvalidUTF8Data(subject)
-            message = shared.fixPotentiallyInvalidUTF8Data(message)
-            if len(data) > 25:
-                data += ','
-            data += json.dumps({
-                'msgid': hexlify(msgid),
-                'toAddress': toAddress,
-                'fromAddress': fromAddress,
-                'subject': base64.b64encode(subject),
-                'message': base64.b64encode(message),
-                'encodingType': encodingtype,
-                'lastActionTime': lastactiontime,
-                'status': status,
-                'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleGetAllSentMessageIds(self, params):
-        queryreturn = sqlQuery(
-            "SELECT msgid FROM sent where folder='sent'"
-            " ORDER BY lastactiontime"
-        )
-        data = '{"sentMessageIds":['
-        for row in queryreturn:
-            msgid = row[0]
-            if len(data) > 25:
-                data += ','
-            data += json.dumps(
-                {'msgid': hexlify(msgid)}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleInboxMessagesByReceiver(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        toAddress = params[0]
-        queryreturn = sqlQuery(
-            "SELECT msgid, toaddress, fromaddress, subject, received, message,"
-            " encodingtype FROM inbox WHERE folder='inbox' AND toAddress=?",
-            toAddress)
-        data = '{"inboxMessages":['
-        for row in queryreturn:
-            msgid, toAddress, fromAddress, subject, received, message, \
-                encodingtype = row
-            subject = shared.fixPotentiallyInvalidUTF8Data(subject)
-            message = shared.fixPotentiallyInvalidUTF8Data(message)
-            if len(data) > 25:
-                data += ','
-            data += json.dumps({
-                'msgid': hexlify(msgid),
-                'toAddress': toAddress,
-                'fromAddress': fromAddress,
-                'subject': base64.b64encode(subject),
-                'message': base64.b64encode(message),
-                'encodingType': encodingtype,
-                'receivedTime': received}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleGetSentMessageById(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        msgid = self._decode(params[0], "hex")
-        queryreturn = sqlQuery(
-            "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
-            " message, encodingtype, status, ackdata FROM sent WHERE msgid=?",
-            msgid
-        )
-        data = '{"sentMessage":['
-        for row in queryreturn:
-            msgid, toAddress, fromAddress, subject, lastactiontime, message, \
-                encodingtype, status, ackdata = row
-            subject = shared.fixPotentiallyInvalidUTF8Data(subject)
-            message = shared.fixPotentiallyInvalidUTF8Data(message)
-            data += json.dumps({
-                'msgid': hexlify(msgid),
-                'toAddress': toAddress,
-                'fromAddress': fromAddress,
-                'subject': base64.b64encode(subject),
-                'message': base64.b64encode(message),
-                'encodingType': encodingtype,
-                'lastActionTime': lastactiontime,
-                'status': status,
-                'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
-            data += ']}'
-            return data
-
-    def HandleGetSentMessagesByAddress(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        fromAddress = params[0]
-        queryreturn = sqlQuery(
-            "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
-            " message, encodingtype, status, ackdata FROM sent"
-            " WHERE folder='sent' AND fromAddress=? ORDER BY lastactiontime",
-            fromAddress
-        )
-        data = '{"sentMessages":['
-        for row in queryreturn:
-            msgid, toAddress, fromAddress, subject, lastactiontime, message, \
-                encodingtype, status, ackdata = row
-            subject = shared.fixPotentiallyInvalidUTF8Data(subject)
-            message = shared.fixPotentiallyInvalidUTF8Data(message)
-            if len(data) > 25:
-                data += ','
-            data += json.dumps({
-                'msgid': hexlify(msgid),
-                'toAddress': toAddress,
-                'fromAddress': fromAddress,
-                'subject': base64.b64encode(subject),
-                'message': base64.b64encode(message),
-                'encodingType': encodingtype,
-                'lastActionTime': lastactiontime,
-                'status': status,
-                'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleGetSentMessagesByAckData(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        ackData = self._decode(params[0], "hex")
-        queryreturn = sqlQuery(
-            "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
-            " message, encodingtype, status, ackdata FROM sent"
-            " WHERE ackdata=?", ackData
-        )
-        data = '{"sentMessage":['
-        for row in queryreturn:
-            msgid, toAddress, fromAddress, subject, lastactiontime, message, \
-                encodingtype, status, ackdata = row
-            subject = shared.fixPotentiallyInvalidUTF8Data(subject)
-            message = shared.fixPotentiallyInvalidUTF8Data(message)
-            data += json.dumps({
-                'msgid': hexlify(msgid),
-                'toAddress': toAddress,
-                'fromAddress': fromAddress,
-                'subject': base64.b64encode(subject),
-                'message': base64.b64encode(message),
-                'encodingType': encodingtype,
-                'lastActionTime': lastactiontime,
-                'status': status,
-                'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
-
-    def HandleTrashMessage(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        msgid = self._decode(params[0], "hex")
-
-        # Trash if in inbox table
-        helper_inbox.trash(msgid)
-        # Trash if in sent table
-        sqlExecute('''UPDATE sent SET folder='trash' WHERE msgid=?''', msgid)
-        return 'Trashed message (assuming message existed).'
-
-    def HandleTrashInboxMessage(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        msgid = self._decode(params[0], "hex")
-        helper_inbox.trash(msgid)
-        return 'Trashed inbox message (assuming message existed).'
-
-    def HandleTrashSentMessage(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        msgid = self._decode(params[0], "hex")
-        sqlExecute('''UPDATE sent SET folder='trash' WHERE msgid=?''', msgid)
-        return 'Trashed sent message (assuming message existed).'
-
-    def HandleSendMessage(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        elif len(params) == 4:
-            toAddress, fromAddress, subject, message = params
-            encodingType = 2
-            TTL = 4 * 24 * 60 * 60
-        elif len(params) == 5:
-            toAddress, fromAddress, subject, message, encodingType = params
-            TTL = 4 * 24 * 60 * 60
-        elif len(params) == 6:
-            toAddress, fromAddress, subject, message, encodingType, TTL = \
-                params
-        if encodingType not in [2, 3]:
-            raise APIError(6, 'The encoding type must be 2 or 3.')
-        subject = self._decode(subject, "base64")
-        message = self._decode(message, "base64")
-        if len(subject + message) > (2 ** 18 - 500):
-            raise APIError(27, 'Message is too long.')
-        if TTL < 60 * 60:
-            TTL = 60 * 60
-        if TTL > 28 * 24 * 60 * 60:
-            TTL = 28 * 24 * 60 * 60
-        toAddress = addBMIfNotPresent(toAddress)
-        fromAddress = addBMIfNotPresent(fromAddress)
-        status, addressVersionNumber, streamNumber, toRipe = \
-            self._verifyAddress(toAddress)
-        self._verifyAddress(fromAddress)
-        try:
-            fromAddressEnabled = BMConfigParser().getboolean(
-                fromAddress, 'enabled')
-        except:
-            raise APIError(
-                13, 'Could not find your fromAddress in the keys.dat file.')
-        if not fromAddressEnabled:
-            raise APIError(14, 'Your fromAddress is disabled. Cannot send.')
-
-        stealthLevel = BMConfigParser().safeGetInt(
-            'bitmessagesettings', 'ackstealthlevel')
-        ackdata = genAckPayload(streamNumber, stealthLevel)
-
-        t = ('',
-             toAddress,
-             toRipe,
-             fromAddress,
-             subject,
-             message,
-             ackdata,
-             int(time.time()),  # sentTime (this won't change)
-             int(time.time()),  # lastActionTime
-             0,
-             'msgqueued',
-             0,
-             'sent',
-             2,
-             TTL)
-        helper_sent.insert(t)
-
-        toLabel = ''
-        queryreturn = sqlQuery(
-            "SELECT label FROM addressbook WHERE address=?", toAddress)
-        if queryreturn != []:
-            for row in queryreturn:
-                toLabel, = row
-        # apiSignalQueue.put(('displayNewSentMessage',(toAddress,toLabel,fromAddress,subject,message,ackdata)))
-        queues.UISignalQueue.put(('displayNewSentMessage', (
-            toAddress, toLabel, fromAddress, subject, message, ackdata)))
-
-        queues.workerQueue.put(('sendmessage', toAddress))
-
-        return hexlify(ackdata)
-
-    def HandleSendBroadcast(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        if len(params) == 3:
-            fromAddress, subject, message = params
-            encodingType = 2
-            TTL = 4 * 24 * 60 * 60
-        elif len(params) == 4:
-            fromAddress, subject, message, encodingType = params
-            TTL = 4 * 24 * 60 * 60
-        elif len(params) == 5:
-            fromAddress, subject, message, encodingType, TTL = params
-        if encodingType not in [2, 3]:
-            raise APIError(6, 'The encoding type must be 2 or 3.')
-        subject = self._decode(subject, "base64")
-        message = self._decode(message, "base64")
-        if len(subject + message) > (2 ** 18 - 500):
-            raise APIError(27, 'Message is too long.')
-        if TTL < 60 * 60:
-            TTL = 60 * 60
-        if TTL > 28 * 24 * 60 * 60:
-            TTL = 28 * 24 * 60 * 60
-        fromAddress = addBMIfNotPresent(fromAddress)
-        self._verifyAddress(fromAddress)
-        try:
-            BMConfigParser().getboolean(fromAddress, 'enabled')
-        except:
-            raise APIError(
-                13, 'could not find your fromAddress in the keys.dat file.')
-        streamNumber = decodeAddress(fromAddress)[2]
-        ackdata = genAckPayload(streamNumber, 0)
-        toAddress = '[Broadcast subscribers]'
-        ripe = ''
-
-        t = ('',
-             toAddress,
-             ripe,
-             fromAddress,
-             subject,
-             message,
-             ackdata,
-             int(time.time()),  # sentTime (this doesn't change)
-             int(time.time()),  # lastActionTime
-             0,
-             'broadcastqueued',
-             0,
-             'sent',
-             2,
-             TTL)
-        helper_sent.insert(t)
-
-        toLabel = '[Broadcast subscribers]'
-        queues.UISignalQueue.put(('displayNewSentMessage', (
-            toAddress, toLabel, fromAddress, subject, message, ackdata)))
-        queues.workerQueue.put(('sendbroadcast', ''))
-
-        return hexlify(ackdata)
-
-    def HandleGetStatus(self, params):
-        if len(params) != 1:
-            raise APIError(0, 'I need one parameter!')
-        ackdata, = params
-        if len(ackdata) < 76:
-            # The length of ackData should be at least 38 bytes (76 hex digits)
-            raise APIError(15, 'Invalid ackData object size.')
-        ackdata = self._decode(ackdata, "hex")
-        queryreturn = sqlQuery(
-            "SELECT status FROM sent where ackdata=?", ackdata)
-        if queryreturn == []:
-            return 'notfound'
-        for row in queryreturn:
-            status, = row
-            return status
-
-    def HandleAddSubscription(self, params):
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        if len(params) == 1:
-            address, = params
-            label = ''
-        if len(params) == 2:
-            address, label = params
-            label = self._decode(label, "base64")
+    def serve_forever(self):
+        while state.shutdown == 0:
             try:
-                unicode(label, 'utf-8')
-            except:
-                raise APIError(17, 'Label is not valid UTF-8 data.')
-        if len(params) > 2:
-            raise APIError(0, 'I need either 1 or 2 parameters!')
-        address = addBMIfNotPresent(address)
-        self._verifyAddress(address)
-        # First we must check to see if the address is already in the
-        # subscriptions list.
-        queryreturn = sqlQuery(
-            "SELECT * FROM subscriptions WHERE address=?", address)
-        if queryreturn != []:
-            raise APIError(16, 'You are already subscribed to that address.')
-        sqlExecute(
-            "INSERT INTO subscriptions VALUES (?,?,?)", label, address, True)
-        shared.reloadBroadcastSendersForWhichImWatching()
-        queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
-        queues.UISignalQueue.put(('rerenderSubscriptions', ''))
-        return 'Added subscription.'
+                self.rCondition.acquire()
+                start_new_thread(self.handle_request, ())  # we do this async, because handle_request blocks!
+                while not self.requests:
+                    self.rCondition.wait(timeout=3.0)
+                if self.requests:
+                    self.requests -= 1
+                self.rCondition.release()
+            except KeyboardInterrupt:
+                logger.warning('quit signaled. i am done.')
+                break
 
-    def HandleDeleteSubscription(self, params):
-        if len(params) != 1:
-            raise APIError(0, 'I need 1 parameter!')
-        address, = params
-        address = addBMIfNotPresent(address)
-        sqlExecute('''DELETE FROM subscriptions WHERE address=?''', address)
-        shared.reloadBroadcastSendersForWhichImWatching()
-        queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
-        queues.UISignalQueue.put(('rerenderSubscriptions', ''))
-        return 'Deleted subscription if it existed.'
+        self.server_close()
+        return
 
-    def ListSubscriptions(self, params):
-        queryreturn = sqlQuery(
-            "SELECT label, address, enabled FROM subscriptions")
-        data = {'subscriptions': []}
-        for row in queryreturn:
-            label, address, enabled = row
-            label = shared.fixPotentiallyInvalidUTF8Data(label)
-            data['subscriptions'].append({
-                'label': base64.b64encode(label),
-                'address': address,
-                'enabled': enabled == 1
-            })
-        return json.dumps(data, indent=4, separators=(',', ': '))
+    def get_request(self):
+        request, client_address = self.socket.accept()
+        self.rCondition.acquire()
+        self.requests += 1
+        self.rCondition.notifyAll()
+        self.rCondition.release()
+        return (request, client_address)
 
-    def HandleDisseminatePreEncryptedMsg(self, params):
-        # The device issuing this command to PyBitmessage supplies a msg
-        # object that has already been encrypted but which still needs the POW
-        # to be done. PyBitmessage accepts this msg object and sends it out
-        # to the rest of the Bitmessage network as if it had generated
-        # the message itself. Please do not yet add this to the api doc.
-        if len(params) != 3:
-            raise APIError(0, 'I need 3 parameter!')
-        encryptedPayload, requiredAverageProofOfWorkNonceTrialsPerByte, \
-            requiredPayloadLengthExtraBytes = params
-        encryptedPayload = self._decode(encryptedPayload, "hex")
-        # Let us do the POW and attach it to the front
-        target = 2**64 / (
-            (len(encryptedPayload) + requiredPayloadLengthExtraBytes + 8)
-            * requiredAverageProofOfWorkNonceTrialsPerByte)
-        with shared.printLock:
-            print '(For msg message via API) Doing proof of work. Total required difficulty:', float(requiredAverageProofOfWorkNonceTrialsPerByte) / defaults.networkDefaultProofOfWorkNonceTrialsPerByte, 'Required small message difficulty:', float(requiredPayloadLengthExtraBytes) / defaults.networkDefaultPayloadLengthExtraBytes
-        powStartTime = time.time()
-        initialHash = hashlib.sha512(encryptedPayload).digest()
-        trialValue, nonce = proofofwork.run(target, initialHash)
-        with shared.printLock:
-            print '(For msg message via API) Found proof of work', trialValue, 'Nonce:', nonce
-            try:
-                print 'POW took', int(time.time() - powStartTime), 'seconds.', nonce / (time.time() - powStartTime), 'nonce trials per second.'
-            except:
-                pass
-        encryptedPayload = pack('>Q', nonce) + encryptedPayload
-        toStreamNumber = decodeVarint(encryptedPayload[16:26])[0]
-        inventoryHash = calculateInventoryHash(encryptedPayload)
-        objectType = 2
-        TTL = 2.5 * 24 * 60 * 60
-        Inventory()[inventoryHash] = (
-            objectType, toStreamNumber, encryptedPayload,
-            int(time.time()) + TTL, ''
-        )
-        with shared.printLock:
-            print 'Broadcasting inv for msg(API disseminatePreEncryptedMsg command):', hexlify(inventoryHash)
-        queues.invQueue.put((toStreamNumber, inventoryHash))
+    def __init__(self,  addr, logRequests=True, allow_none=False, encoding=None, allow_dotted_names = False, bind_and_activate=True, keyFile=DEFAULTKEYFILE, certFile=DEFAULTFILE):
+        self.logRequests = logRequests
+        self.allow_none = allow_none
+        self.encoding = encoding
+        self.allow_dotted_names = allow_dotted_names
 
-    def HandleTrashSentMessageByAckDAta(self, params):
-        # This API method should only be used when msgid is not available
-        if len(params) == 0:
-            raise APIError(0, 'I need parameters!')
-        ackdata = self._decode(params[0], "hex")
-        sqlExecute("UPDATE sent SET folder='trash' WHERE ackdata=?", ackdata)
-        return 'Trashed sent message (assuming message existed).'
+        # This is one of several classes that constitute the API
+        # This class was written by Vaibhav Bhatia.
+        # Modified by Jonathan Warren (Atheros).
+        # http://code.activestate.com/recipes/501148-xmlrpc-serverclient-which-does-cookie-handling-and/
 
-    def HandleDissimatePubKey(self, params):
-        # The device issuing this command to PyBitmessage supplies a pubkey
-        # object to be disseminated to the rest of the Bitmessage network.
-        # PyBitmessage accepts this pubkey object and sends it out to the rest
-        # of the Bitmessage network as if it had generated the pubkey object
-        # itself. Please do not yet add this to the api doc.
-        if len(params) != 1:
-            raise APIError(0, 'I need 1 parameter!')
-        payload, = params
-        payload = self._decode(payload, "hex")
+        SimpleXMLRPCDispatcher.__init__(self, self.allow_none, self.encoding)
 
-        # Let us do the POW
-        target = 2 ** 64 / (
-            (len(payload) + defaults.networkDefaultPayloadLengthExtraBytes
-             + 8) * defaults.networkDefaultProofOfWorkNonceTrialsPerByte)
-        print '(For pubkey message via API) Doing proof of work...'
-        initialHash = hashlib.sha512(payload).digest()
-        trialValue, nonce = proofofwork.run(target, initialHash)
-        print '(For pubkey message via API) Found proof of work', trialValue, 'Nonce:', nonce
-        payload = pack('>Q', nonce) + payload
+        self.funcs = {}
+        self.register_introspection_functions()
+        self.register_multicall_functions()
 
-        pubkeyReadPosition = 8  # bypass the nonce
-        if payload[pubkeyReadPosition:pubkeyReadPosition+4] == \
-                '\x00\x00\x00\x00':  # if this pubkey uses 8 byte time
-            pubkeyReadPosition += 8
-        else:
-            pubkeyReadPosition += 4
-        addressVersion, addressVersionLength = decodeVarint(
-            payload[pubkeyReadPosition:pubkeyReadPosition+10])
-        pubkeyReadPosition += addressVersionLength
-        pubkeyStreamNumber = decodeVarint(
-            payload[pubkeyReadPosition:pubkeyReadPosition+10])[0]
-        inventoryHash = calculateInventoryHash(payload)
-        objectType = 1  # TODO: support v4 pubkeys
-        TTL = 28 * 24 * 60 * 60
-        Inventory()[inventoryHash] = (
-            objectType, pubkeyStreamNumber, payload, int(time.time()) + TTL, ''
-        )
-        with shared.printLock:
-            print 'broadcasting inv within API command disseminatePubkey with hash:', hexlify(inventoryHash)
-        queues.invQueue.put((pubkeyStreamNumber, inventoryHash))
+        self.requests = 0
+        self.rCondition = Condition()
 
-    def HandleGetMessageDataByDestinationHash(self, params):
-        # Method will eventually be used by a particular Android app to
-        # select relevant messages. Do not yet add this to the api
-        # doc.
-        if len(params) != 1:
-            raise APIError(0, 'I need 1 parameter!')
-        requestedHash, = params
-        if len(requestedHash) != 32:
-            raise APIError(
-                19, 'The length of hash should be 32 bytes (encoded in hex'
-                ' thus 64 characters).')
-        requestedHash = self._decode(requestedHash, "hex")
+        BaseServer.__init__(self, addr, VerifyingRequestHandler)
+        # SocketServer.TCPServer.__init__(self, addr, VerifyingRequestHandler, bind_and_activate)
 
-        # This is not a particularly commonly used API function. Before we
-        # use it we'll need to fill out a field in our inventory database
-        # which is blank by default (first20bytesofencryptedmessage).
-        queryreturn = sqlQuery(
-            "SELECT hash, payload FROM inventory WHERE tag = ''"
-            " and objecttype = 2")
-        with SqlBulkExecute() as sql:
-            for row in queryreturn:
-                hash01, payload = row
-                readPosition = 16  # Nonce length + time length
-                # Stream Number length
-                readPosition += decodeVarint(
-                    payload[readPosition:readPosition+10])[1]
-                t = (payload[readPosition:readPosition+32], hash01)
-                sql.execute("UPDATE inventory SET tag=? WHERE hash=?", *t)
+        # [Bug #1222790] If possible, set close-on-exec flag; if a
+        # method spawns a subprocess, the subprocess shouldn't have
+        # the listening socket open.
+    #        if fcntl is not None and hasattr(fcntl, 'FD_CLOEXEC'):
+    #            flags = fcntl.fcntl(self.fileno(), fcntl.F_GETFD)
+    #            flags |= fcntl.FD_CLOEXEC
+    #            fcntl.fcntl(self.fileno(), fcntl.F_SETFD, flags)
 
-        queryreturn = sqlQuery(
-            "SELECT payload FROM inventory WHERE tag = ?", requestedHash)
-        data = '{"receivedMessageDatas":['
-        for row in queryreturn:
-            payload, = row
-            if len(data) > 25:
-                data += ','
-            data += json.dumps(
-                {'data': hexlify(payload)}, indent=4, separators=(',', ': '))
-        data += ']}'
-        return data
+        # ssl socket stuff
+    #        ctx = ssl.Context(ssl.SSLv23_METHOD)
+    #        ctx.use_privatekey_file(keyFile)
+    #        ctx.use_certificate_file(certFile)
+    #        self.socket = ssl.Connection(ctx, socket.socket(self.address_family, self.socket_type))
+        self.allow_reuse_address = True
+        self.socket = socket.socket(self.address_family, self.socket_type)
+        self.server_bind()
+        self.server_activate()
 
-    def HandleClientStatus(self, params):
-        if len(network.stats.connectedHostsList()) == 0:
-            networkStatus = 'notConnected'
-        elif len(network.stats.connectedHostsList()) > 0 \
-                and not shared.clientHasReceivedIncomingConnections:
-            networkStatus = 'connectedButHaveNotReceivedIncomingConnections'
-        else:
-            networkStatus = 'connectedAndReceivingIncomingConnections'
-        return json.dumps({
-            'networkConnections': len(network.stats.connectedHostsList()),
-            'numberOfMessagesProcessed': shared.numberOfMessagesProcessed,
-            'numberOfBroadcastsProcessed': shared.numberOfBroadcastsProcessed,
-            'numberOfPubkeysProcessed': shared.numberOfPubkeysProcessed,
-            'networkStatus': networkStatus,
-            'softwareName': 'PyBitmessage',
-            'softwareVersion': softwareVersion
-            }, indent=4, separators=(',', ': '))
+        self.register_function(self.HandleListAddresses, name='listAddresses')
+        self.register_function(self.HandleListAddressBookEntries, name='listAddressBookEntries')
+        self.register_function(self.HandleAddAddressBookEntry, name='addAddressBookEntry')
+        self.register_function(self.HandleDeleteAddressBookEntry, name='deleteAddressBookEntry')
+        self.register_function(self.HandleCreateRandomAddress, name='createRandomAddress')
+        self.register_function(self.HandleCreateDeterministicAddresses, name='createDeterministicAddresses')
+        self.register_function(self.HandleGetDeterministicAddress, name='getDeterministicAddress')
+        self.register_function(self.HandleCreateChan, name='createChan')
+        self.register_function(self.HandleJoinChan, name='joinChan')
+        self.register_function(self.HandleLeaveChan, name='leaveChan')
+        self.register_function(self.HandleDeleteAddress, name='deleteAddress')
+        self.register_function(self.HandleGetAllInboxMessages, name='getAllInboxMessages')
+        self.register_function(self.HandleGetAllInboxMessageIds, name='getAllInboxMessageIds')
+        self.register_function(self.HandleGetInboxMessageById, name='getInboxMessageById')
+        self.register_function(self.HandleGetAllSentMessages, name='getAllSentMessages')
+        self.register_function(self.HandleGetAllSentMessageIds, name='getAllSentMessageIds')
+        self.register_function(self.HandleInboxMessagesByReceiver, name='getInboxMessagesByReceiver')
+        self.register_function(self.HandleGetSentMessageById, name='getSentMessageById')
+        self.register_function(self.HandleGetSentMessagesBySender, name='getSentMessagesBySender')
+        self.register_function(self.HandleGetSentMessagesByAckData, name='getSentMessageByAckData')
+        self.register_function(self.HandleTrashMessage, name='trashMessage')
+        self.register_function(self.HandleTrashInboxMessage, name='trashInboxMessage')
+        self.register_function(self.HandleTrashSentMessage, name='trashSentMessage')
+        self.register_function(self.HandleSendMessage, name='sendMessage')
+        self.register_function(self.HandleSendBroadcast, name='sendBroadcast')
+        self.register_function(self.HandleGetStatus, name='getStatus')
+        self.register_function(self.HandleAddSubscription, name='addSubscription')
+        self.register_function(self.HandleDeleteSubscription, name='deleteSubscription')
+        self.register_function(self.HandleListSubscriptions, name='listSubscriptions')
+        self.register_function(self.HandleDisseminatePreEncryptedMsg, name='disseminatePreEncryptedMsg')
+        self.register_function(self.HandleTrashSentMessageByAckDAta, name='trashSentMessageByAckData')
+        self.register_function(self.HandleDissimatePubKey, name='disseminatePubkey')
+        self.register_function(self.HandleGetMessageDataByDestinationHash, name='getMessageDataByDestinationHash')
+        self.register_function(self.HandleClientStatus, name='clientStatus')
+        self.register_function(self.HandleDecodeAddress, name='decodeAddress')
+        self.register_function(self.HandleHelloWorld, name='helloWorld')
+        self.register_function(self.HandleAdd, name='add')
+        self.register_function(self.HandleStatusBar, name='statusBar')
+        self.register_function(self.HandleDeleteAndVacuum, name='deleteAndVacuum')
+        self.register_function(self.HandleShutdown, name='shutdown')
 
-    def HandleDecodeAddress(self, params):
-        # Return a meaningful decoding of an address.
-        if len(params) != 1:
-            raise APIError(0, 'I need 1 parameter!')
-        address, = params
-        status, addressVersion, streamNumber, ripe = decodeAddress(address)
-        return json.dumps({
-            'status': status,
-            'addressVersion': addressVersion,
-            'streamNumber': streamNumber,
-            'ripe': base64.b64encode(ripe)
-            }, indent=4, separators=(',', ': '))
-
-    def HandleHelloWorld(self, params):
-        a, b = params
-        return a + '-' + b
-
-    def HandleAdd(self, params):
-        a, b = params
-        return a + b
-
-    def HandleStatusBar(self, params):
-        message, = params
-        queues.UISignalQueue.put(('updateStatusBar', message))
-
-    def HandleDeleteAndVacuum(self, params):
-        if not params:
-            sqlStoredProcedure('deleteandvacuume')
-            return 'done'
-
-    def HandleShutdown(self, params):
-        if not params:
-            shutdown.doCleanShutdown()
-            return 'done'
-
-    handlers = {}
-    handlers['helloWorld'] = HandleHelloWorld
-    handlers['add'] = HandleAdd
-    handlers['statusBar'] = HandleStatusBar
-    handlers['listAddresses'] = HandleListAddresses
-    handlers['listAddressBookEntries'] = HandleListAddressBookEntries
-    # the listAddressbook alias should be removed eventually.
-    handlers['listAddressbook'] = HandleListAddressBookEntries
-    handlers['addAddressBookEntry'] = HandleAddAddressBookEntry
-    # the addAddressbook alias should be deleted eventually.
-    handlers['addAddressbook'] = HandleAddAddressBookEntry
-    handlers['deleteAddressBookEntry'] = HandleDeleteAddressBookEntry
-    # The deleteAddressbook alias should be deleted eventually.
-    handlers['deleteAddressbook'] = HandleDeleteAddressBookEntry
-    handlers['createRandomAddress'] = HandleCreateRandomAddress
-    handlers['createDeterministicAddresses'] = \
-        HandleCreateDeterministicAddresses
-    handlers['getDeterministicAddress'] = HandleGetDeterministicAddress
-    handlers['createChan'] = HandleCreateChan
-    handlers['joinChan'] = HandleJoinChan
-    handlers['leaveChan'] = HandleLeaveChan
-    handlers['deleteAddress'] = HandleDeleteAddress
-    handlers['getAllInboxMessages'] = HandleGetAllInboxMessages
-    handlers['getAllInboxMessageIds'] = HandleGetAllInboxMessageIds
-    handlers['getAllInboxMessageIDs'] = HandleGetAllInboxMessageIds
-    handlers['getInboxMessageById'] = HandleGetInboxMessageById
-    handlers['getInboxMessageByID'] = HandleGetInboxMessageById
-    handlers['getAllSentMessages'] = HandleGetAllSentMessages
-    handlers['getAllSentMessageIds'] = HandleGetAllSentMessageIds
-    handlers['getAllSentMessageIDs'] = HandleGetAllSentMessageIds
-    handlers['getInboxMessagesByReceiver'] = HandleInboxMessagesByReceiver
-    # after some time getInboxMessagesByAddress should be removed
-    handlers['getInboxMessagesByAddress'] = HandleInboxMessagesByReceiver
-    handlers['getSentMessageById'] = HandleGetSentMessageById
-    handlers['getSentMessageByID'] = HandleGetSentMessageById
-    handlers['getSentMessagesByAddress'] = HandleGetSentMessagesByAddress
-    handlers['getSentMessagesBySender'] = HandleGetSentMessagesByAddress
-    handlers['getSentMessageByAckData'] = HandleGetSentMessagesByAckData
-    handlers['trashMessage'] = HandleTrashMessage
-    handlers['trashInboxMessage'] = HandleTrashInboxMessage
-    handlers['trashSentMessage'] = HandleTrashSentMessage
-    handlers['trashSentMessageByAckData'] = HandleTrashSentMessageByAckDAta
-    handlers['sendMessage'] = HandleSendMessage
-    handlers['sendBroadcast'] = HandleSendBroadcast
-    handlers['getStatus'] = HandleGetStatus
-    handlers['addSubscription'] = HandleAddSubscription
-    handlers['deleteSubscription'] = HandleDeleteSubscription
-    handlers['listSubscriptions'] = ListSubscriptions
-    handlers['disseminatePreEncryptedMsg'] = HandleDisseminatePreEncryptedMsg
-    handlers['disseminatePubkey'] = HandleDissimatePubKey
-    handlers['getMessageDataByDestinationHash'] = \
-        HandleGetMessageDataByDestinationHash
-    handlers['getMessageDataByDestinationTag'] = \
-        HandleGetMessageDataByDestinationHash
-    handlers['clientStatus'] = HandleClientStatus
-    handlers['decodeAddress'] = HandleDecodeAddress
-    handlers['deleteAndVacuum'] = HandleDeleteAndVacuum
-    handlers['shutdown'] = HandleShutdown
-
-    def _handle_request(self, method, params):
-        if method not in self.handlers:
-            raise APIError(20, 'Invalid method: %s' % method)
-        return self.handlers[method](self, params)
+        # should be removed eventually
+        self.register_function(self.HandleListAddressBookEntries, name='listAddressbook')
+        self.register_function(self.HandleAddAddressBookEntry, name='addAddressbook')
+        self.register_function(self.HandleDeleteAddressBookEntry, name='deleteAddressbook')
+        self.register_function(self.HandleGetAllInboxMessageIds, name='getAllInboxMessageIDs')
+        self.register_function(self.HandleGetInboxMessageById, name='getInboxMessageByID')
+        self.register_function(self.HandleGetAllSentMessageIds, name='getAllSentMessageIDs')
+        self.register_function(self.HandleGetSentMessageById, name='getSentMessageByID')
+        self.register_function(self.HandleGetSentMessagesBySender, name='getSentMessagesByAddress')
+        self.register_function(self.HandleInboxMessagesByReceiver, name='getInboxMessagesByAddress')
+        self.register_function(self.HandleGetMessageDataByDestinationHash, name='getMessageDataByDestinationTag')
 
     def _dispatch(self, method, params):
-        self.cookies = []
-
-        validuser = self.APIAuthenticateClient()
-        if not validuser:
-            time.sleep(2)
-            return "RPC Username or password incorrect or HTTP header lacks authentication at all."
 
         try:
-            return self._handle_request(method, params)
+            # _dispatch method handle skiped
+            func = self.funcs.get(method, None)
+            if func is not None:
+                if method[:7] == 'system.':
+                    return func(*params)
+                else:
+                    return func(params)
+            else:
+                raise APIError(20, 'Invalid method: %s' % method)
         except APIError as e:
             return str(e)
         except varintDecodeError as e:
@@ -1295,5 +354,105 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             return "API Error 0026: Data contains a malformed varint. Some details: %s" % e
         except Exception as e:
             logger.exception(e)
-
             return "API Error 0021: Unexpected API Failure - %s" % e
+
+
+class singleAPI(threading.Thread, helper_threading.StoppableThread):
+
+    def __init__(self):
+        threading.Thread.__init__(self, name="singleAPI")
+        self.port = BMConfigParser().safeGetInt('bitmessagesettings', 'apiport')
+        self.interface = BMConfigParser().get('bitmessagesettings', 'apiinterface')
+        self.serve = None
+        self.initStop()
+
+    def stopThread(self):
+        super(singleAPI, self).stopThread()
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            s.connect((self.interface,self.port))
+            s.shutdown(socket.SHUT_RDWR)
+            s.close()
+        except:
+            pass
+
+    def run(self):
+        try:
+            from errno import WSAEADDRINUSE
+        except (ImportError, AttributeError):
+            errno.WSAEADDRINUSE = errno.EADDRINUSE
+        try:
+            se = StoppableXMLRPCServer((self.interface, self.port), True, True)
+            sa = se.socket.getsockname()
+            print('Serving API on %s, port %d' % (sa[0],sa[1]))
+            self.serve = se
+            se.serve_forever()
+        except socket.error as e:
+            if e.errno in (errno.EADDRINUSE, errno.WSAEADDRINUSE):
+                print('interface not useable: (%s:%d)' % (self.interface, self.port))
+
+    def test(self):
+        try:
+            import xmlrpclib
+        except ImportError:
+            import xmlrpc.client as xmlrpclib
+
+        emailid = BMConfigParser().get('bitmessagesettings', 'apiusername')
+        password = BMConfigParser().get('bitmessagesettings', 'apipassword')
+        uri = 'http://%s:%s@%s:%d/' % (emailid, password, self.interface, self.port)
+
+        ret = False
+        try:
+            api = xmlrpclib.ServerProxy(uri)
+            print('api: %s' % api)
+            response = api.system.listMethods()
+            if response:
+                print('Methods = %s' % response)
+            print('MultiCall...')
+            multi = xmlrpclib.MultiCall(api)
+            multi.add(1, 2)
+            multi.add(2, 3)
+            for response in multi():
+                print(response)
+            ret = True
+        except TypeError as err:  # unsupported XML-RPC protocol
+            print('XML-RPC not initialed correctly. {%s}\n' % str(err))
+        except xmlrpclib.Fault as err:
+            print
+        except Exception:  # /httplib.BadStatusLine: connection close immediatly
+            print('Unexpected error. {%s}\n' % sys.exc_info()[0])
+
+        if ret is False:
+            traceback.print_exc()
+
+        return ret
+
+
+def __repr__(self):
+    return '<%s.%s object at %s>' % (
+        self.__class__.__module__,
+        self.__class__.__name__,
+        hex(id(self))
+        )
+
+
+def main():
+    success = False
+    print('XMLRPC API daemon...')
+    singleAPIThread = singleAPI()
+    singleAPIThread.daemon = True
+    singleAPIThread.start()
+    time.sleep(3)
+    if singleAPIThread.serve:
+        print('XMLRPC Testing...')
+        success = singleAPIThread.test()
+        singleAPIThread.stopThread()
+    else:
+        print('XMLRPC API daemon failed!')
+
+    sys.exit(success is False)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/bitmessagecli.py
+++ b/src/bitmessagecli.py
@@ -7,646 +7,1153 @@
 Created by Adam Melton (.dok) referenceing https://bitmessage.org/wiki/API_Reference for API documentation
 Distributed under the MIT/X11 software license. See http://www.opensource.org/licenses/mit-license.php.
 
-This is an example of a daemon client for PyBitmessage 0.6.2, by .dok (Version 0.3.1) , modified
+This is an example of a daemon client for PyBitmessage 0.6.2, original by .dok (Version 0.3.1)
+Modified by .pt (Version 0.4.0), for PyBitmessage 0.6.3
 
 TODO: fix the following (currently ignored) violations:
 
 """
 
-import xmlrpclib
-import datetime
+import argparse
+import ConfigParser
 import imghdr
 import ntpath
 import json
-import socket
-import time
 import sys
 import os
 
-from bmconfigparser import BMConfigParser
+import base64
+import ssl
+import socket
 
+# python3 maybe
+try:
+    import httplib
+    import xmlrpclib
+    from urlparse import urlparse
+    from urllib import unquote
+except ImportError:
+    import http.client as httplib
+    import xmlrpc.client as xmlrpclib
+    from urllib.parse import urlparse, unquote
 
-api = ''
-keysName = 'keys.dat'
-keysPath = 'keys.dat'
+import traceback
+
+import time
+import datetime
+import inspect
+import re
+import subprocess
+
+from collections import OrderedDict
+
 usrPrompt = 0  # 0 = First Start, 1 = prompt, 2 = no prompt if the program is starting up
-knownAddresses = dict()
+api = ''
+knownAddresses = dict({'addresses': []})
+cmdStr = 'getLabel'.lower()
+# menu by this order
+cmdTbl = OrderedDict()
+cmdTbl['Command'] = 'Description'
+cmdTbl['s1'] = '-'
+cmdTbl['help'] = 'This help'
+cmdTbl['daemon'] = 'Try to start PyBitmessage daemon locally'
+cmdTbl['apiTest'] = 'Daemon API connection tests'
+cmdTbl['status'] = 'Get the summary of running daemon'
+cmdTbl['addInfo'] = 'Request detailed info to a address'
+cmdTbl['bmSettings'] = 'PyBitmessage settings "keys.dat"'
+cmdTbl['exit'] = 'Use anytime to return to main menu'
+cmdTbl['quit'] = 'Quit this CLI'
+cmdTbl['shutdown'] = 'Shutdown the connectable daemon via. API'
+cmdTbl['s2'] = '-'
+cmdTbl['listAddresses'] = 'List user\'s addresse(s) (Senders)'
+cmdTbl['newAddress'] = 'Generate a new sender address'
+cmdTbl['getAddress'] = 'Get determinist address from passphrase'
+cmdTbl['s3'] = '-'
+cmdTbl['listAddressBK'] = 'List the "Address Book" entry (Contacts)'
+cmdTbl['addAddressBK'] = 'Add a address to the "Address Book"'
+cmdTbl['delAddressBK'] = 'Delete a address from the "Address Book"'
+cmdTbl['s4'] = '-'
+cmdTbl['listsubscrips'] = 'List subscriped addresses'
+cmdTbl['subscribe'] = 'Subscribes to an address'
+cmdTbl['unsubscribe'] = 'Unsubscribe from an address'
+cmdTbl['s5'] = '-'
+cmdTbl['create'] = 'Create a channel'
+cmdTbl['join'] = 'Join to a channel'
+cmdTbl['leave'] = 'Leave from a channel'
+cmdTbl['s6'] = '-'
+cmdTbl['getLabel'] = 'Retrieve addresse(s) label for message heads'
+cmdTbl['s7'] = '-'
+cmdTbl['inbox'] = 'List all inbox message heads'
+cmdTbl['outbox'] = 'List all outbox message heads heads'
+cmdTbl['news'] = 'List all "unread" inbox message heads'
+cmdTbl['send'] = 'Send out new message or broadcast'
+cmdTbl['s8'] = '-'
+cmdTbl['read'] = 'Read a message from in(out)box'
+cmdTbl['readAll'] = 'Mard "read" for all inbox message(s)'
+cmdTbl['unreadAll'] = 'Mark "unread" for all inbox message(s)'
+cmdTbl['s9'] = '-'
+cmdTbl['save'] = 'Save(Dump) a in(out)box message to disk'
+cmdTbl['delete'] = 'Delete a(ll) in(out)box messages from remote'
+cmdShorts = dict()
+
+retStrings = dict({
+    'none': '',
+    'usercancel': '\n     User canceled.\n',
+    'invalidinput': '\n     Invalid input.\n',
+    'invalidindex': '\n     Invalid message index.\n',
+    'invalidaddr': '\n     Invalid address.\n',
+    'indexoutofbound': '\n     Reach end of index.\n',
+    'bmsnotallow': '\n     Daemon configure command not allowed.\n',
+    'nomain': '\n     Cannot locate "bitmessagemain.py", daemon start failed.\n',
+    })
+inputShorts = dict({
+    'yes': ['y', 'yes'],
+    'no': ['n', 'no'],
+    'exit': ['e', 'ex', 'exit'],
+    'save': ['save', 's', 'sv'],
+    'deterministic': ['d', 'dt'],
+    'random': ['r', 'rd', 'random'],
+    'message': ['m', 'msg', 'message'],
+    'broadcast': ['b', 'br', 'brd', 'broadcast'],
+    'inbox': ['i', 'in', 'ib', 'inbox'],
+    'outbox': ['o', 'ou', 'out', 'ob', 'outbox'],
+    'dump': ['d', 'dp', 'dump'],
+    'save': ['s', 'sa', 'save'],
+    'reply': ['r', 'rp', 'reply'],
+    'forward': ['f', 'fw', 'forward'],
+    'delete': ['d', 'del', 'delete'],
+    'all': ['a', 'all'],
+    })
+inputs = dict()
+
+
+def duplicated(out):
+
+    global cmdShorts
+
+    seen = dict()
+    dups = list()
+    dcmds = dict()
+    for x in out:
+        if x not in seen:
+            seen[x] = 1
+        else:
+            if seen[x] == 1:
+                dups.append(x)
+            seen[x] += 1
+    for x in dups:
+        for cmd in cmdShorts:
+            if x in cmdShorts[cmd]:
+                dcmds[cmd] = cmdShorts[cmd]
+    return dcmds
+
+
+def cmdGuess():
+
+    global cmdTbl, cmdShorts
+
+    fullWords = [
+        'api', 'test', 'info', 'settings', 'quit', 'exit', 'set', 'list',
+        'add', 'addresses', 'subscrips', 'label', 'all', 'delete', 'join',
+        'scribe', 'build', 'in', 'out', 'box', 'new', 'create', 'end', 'shut',
+        'read', 'down', 'get',  'del', 'address',
+        'ubs', 'un', 'addressb', 'tatus', 'ave'
+        ]
+    halfWords = [
+        'rate', 'lete', 'oin', 'lea', 'ead', 'eave', 'tatus', 'bke', 'un', 've',
+        'fo', 'dress', 'boo', 'lete', 'reate', 'dae', 'mon', 'reate', 'sa',
+        'inbox', 'outbox', 'send', 'in', 'add', 'news', 'all',
+        ]
+    fullWords.sort(key=lambda item: (-len(item), item))
+    halfWords.sort(key=lambda item: (-len(item), item))
+
+    out = list()
+    # shorten
+    wordscounter = 0
+    for guessWords in [fullWords, halfWords]:
+        wordscounter += 1
+        for cmd in cmdTbl:
+            lcmd = cmd.lower()
+            if not any(cmdShorts.get(cmd, [])):  # keep full command name
+                cmdShorts[cmd] = [lcmd]
+            for words in guessWords:
+                lwords = words.lower()
+                lcmd = lcmd.replace(lwords, lwords[0], 1)
+            if lcmd == lwords:
+                break
+            counter = len(cmdShorts[cmd])
+            if lcmd not in cmdShorts[cmd]:
+                if counter > 1 and len(lcmd) < len(cmdShorts[cmd][1]):
+                    cmdShorts[cmd].insert(1, lcmd)
+                else:
+                    cmdShorts[cmd].append(lcmd)
+                out.append(lcmd)
+
+        dcmds = duplicated(out)
+        if any(dcmds):
+            print '\n     cmdGuess() Fail!'
+            print '     duplicated =', dcmds
+            print '     Change your "guessWords" list(%d).\n' % wordscounter
+            return False
+
+    cmdShorts['Command'] = ''
+    cmdShorts['exit'] = ''
+    cmdShorts['help'] = list(['help', 'h', '?'])
+    return True
+
+
+def showCmdTbl():
+
+    global cmdTbl, cmdShorts
+
+    url = 'https://github.com/BitMessage/PyBitmessage'
+    print
+    print ''.join([5 * ' ', 73 * '-'])
+    print ''.join([5 * ' ', '|', url[:int(len(url)/2)].rjust(35), url[int(len(url)/2):].ljust(36), '|'])
+    print ''.join([5 * ' ', 73 * '-'])
+    for cmd in cmdTbl:
+        lcmd = ('' if len(cmd) > 18 else cmd + ' ') + str(cmdShorts[cmd][1:])
+        if len(lcmd) > 23:
+            lcmd = lcmd[:20] + '...'
+        des = cmdTbl[cmd]
+        if len(des) > 45:
+            des = des[:42] + '...'
+        if des == '-':
+            print '|'.join([5 * ' ', 24 * '-', 46 * '-', ''])
+        else:
+            print '| '.join([5 * ' ', lcmd.ljust(23), des.ljust(45), ''])
+    print ''.join([5 * ' ', 73 * '-'])
+
+
+class Config(object):
+    def __init__(self, argv):
+        self.version = "0.4.0"
+        self.argv = argv
+        self.action = None
+        self.config_file = "client.dat"  # for initial default value
+        self.conn = 'HTTP://127.0.0.1:8445/'  # default API uri
+        self.createParser()
+        self.createArguments()
+
+    def createParser(self):
+        # Create parser
+        self.parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        self.parser.register('type', 'bool', self.strToBool)
+        self.subparsers = self.parser.add_subparsers(title="Actions", dest="action")
+
+    def __str__(self):
+        return str(self.arguments).replace("Namespace", "Config")  # Using argparse str output
+
+    def strToBool(self, v):
+        return v.lower() in ("yes", "true", "t", "1")
+
+    # Create command line arguments
+    def createArguments(self):
+        # this_file = os.path.abspath(__file__).replace("\\", "/").rstrip("cd")
+        # if this_file.endswith("/src/bitmessagecli.py"):
+
+        # main
+        action = self.subparsers.add_parser("main", help='Start this CLI (default)')
+        action = self.parser
+        self.parser.add_argument('--version', action='version', version='BitMessageCLI %s' % (self.version))
+        self.parser.add_argument('--start_daemon', help='Start BMs API daemon locally', default=None, metavar='BMs_host_uri')
+
+        # api settings
+        # action = self.subparsers.add_parser('api', help='Set API settings.')
+        action.add_argument('--api_username', help='BMs API basic auth user name.', default=None, metavar='username')
+        action.add_argument('--api_password', help='BMs API basic auth password.', default=None, metavar='password')
+        action.add_argument('--api_path', help='BMs API host address.', default=self.conn, metavar='ip:port')
+        action.add_argument('--api_type', help='BMs API hosts type.', default='HTTP', choices=["HTTP", "HTTPS"])
+
+        # proxy settings
+        # action = self.subparsers.add_parser('proxy', help='Use proxy for connections.')
+        action.add_argument('--proxy_username', help='Username to authenticate to the proxy server.', default=None, metavar='username')
+        action.add_argument('--proxy_password', help='Password to authenticate to the proxy server.', default=None, metavar='password')
+        action.add_argument('--proxy_path', help='Address of the proxy server.', default='127.0.0.1:1080', metavar='ip:port')
+        action.add_argument('--proxy_type', help='Proxy type.', default='none', choices=['none', 'SOCKS4', 'SOCKS5', 'HTTP'])
+        action.add_argument('--proxy_remotedns', help='Send DNS request to remote(socks proxied).', type='bool', choices=[True, False], default=True)
+        action.add_argument('--proxy_timeout', help='Network connection timeout.', default=30, type=int, metavar='seconds')
+
+        self.parser.add_argument('--config_file', help='Path of config file.', default=self.config_file, metavar='path')
+        self.parser.add_argument('--end', help='Stop multi value argument parsing(inner_use).', action='store_true')
+
+        return self.parser
+
+    # Find arguments specified for current action
+    def getActionArguments(self):
+        back = {}
+        arguments = self.parser._subparsers._group_actions[0].choices[self.action]._actions[0:]  # First is --version
+        # for argument in arguments:
+        #    if argument.dest != 'help':
+        #        back[argument.dest] = getattr(self, argument.dest)
+        return back
+
+    # Try to find action from argv
+    def getAction(self, argv):
+        actions = [action.choices.keys() for action in self.parser._actions if action.dest == "action"][0]  # Valid actions
+        found_action = False
+        for action in actions:  # See if any in argv
+            if action in argv:
+                found_action = action
+                break
+        return found_action
+
+    # Move unknown parameters to end of argument list
+    def moveUnknownToEnd(self, argv, default_action):
+        valid_actions = sum([action.option_strings for action in self.parser._actions], [])
+        valid_parameters = []
+        unkown_parameters = []
+        unkown = False
+        for arg in argv:
+            if arg.startswith("--"):
+                if arg not in valid_actions:
+                    unkown = True
+                else:
+                    unkown = False
+            elif arg == default_action:
+                unkown = False
+
+            if unkown:
+                unkown_parameters.append(arg)
+            else:
+                valid_parameters.append(arg)
+        return valid_parameters + unkown_parameters
+
+    # Parse arguments from config file and command line
+    def parse(self, parse_config=True):
+        argv = self.argv[:]  # Copy command line arguments
+        self.parseCommandline(argv)  # Parse argv
+        self.setAttributes()
+        if parse_config:
+            argv = self.parseConfig(argv)  # Add arguments from config file
+
+        self.parseCommandline(argv)  # Parse argv
+        self.setAttributes()
+
+    # Parse command line arguments
+    def parseCommandline(self, argv):
+        # Find out if action is specificed on start
+        action = self.getAction(argv)
+        if not action:
+            argv.append("--end")
+            argv.append("main")
+
+        action = "main"
+        argv = self.moveUnknownToEnd(argv, action)
+        self.arguments = self.parser.parse_args(argv[1:])
+
+    # Parse config file
+    def parseConfig(self, argv):
+        # Find config file path from parameters
+        if "--config_file" in argv:
+            self.config_file = argv[argv.index("--config_file") + 1]
+        print '- Configuration loading . (%s)' % os.path.realpath(self.config_file)
+        if os.path.isfile(self.config_file):
+            config = ConfigParser.ConfigParser(allow_no_value=True)
+            config.read(self.config_file)
+            for section in config.sections():
+                for key, val in config.items(section):
+                    if section != "global":  # If not global prefix key with section
+                        key = section + "_" + key
+
+                    to_end = key == "start_daemon"  # Prefer config value over argument
+                    argv_extend = ["--%s" % key]
+                    if val:
+                        argv_extend.append(val)
+
+                    if to_end:
+                        argv = argv[:-1] + argv_extend + argv[-1:]
+                    else:
+                        argv = argv[:1] + argv_extend + argv[1:]
+        return argv
+
+    # Expose arguments as class attributes
+    def setAttributes(self):
+        # Set attributes from arguments
+        if self.arguments:
+            args = vars(self.arguments)
+            for key, val in args.items():
+                if type(val) is list:
+                    val = val[:]
+                setattr(self, key, val)
+
+    def saveValue(self, key, value):
+        if not os.path.isfile(self.config_file):
+            content = ""
+        else:
+            content = open(self.config_file).read()
+        lines = content.splitlines()
+
+        global_line_i = None
+        key_line_i = None
+        i = 0
+        for line in lines:
+            if line.strip() == "[global]":
+                global_line_i = i
+            if line.startswith(key + " ="):
+                key_line_i = i
+            i += 1
+
+        if key_line_i and len(lines) > key_line_i + 1:
+            while True:  # Delete previous multiline values
+                is_value_line = lines[key_line_i + 1].startswith(" ") or lines[key_line_i + 1].startswith("\t")
+                if not is_value_line:
+                    break
+                del lines[key_line_i + 1]
+
+        if value is None:  # Delete line
+            if key_line_i:
+                del lines[key_line_i]
+
+        else:  # Add / update
+            if type(value) is list:
+                value_lines = [""] + [str(line).replace("\n", "").replace("\r", "") for line in value]
+            else:
+                value_lines = [str(value).replace("\n", "").replace("\r", "")]
+            new_line = "%s = %s" % (key, "\n ".join(value_lines))
+            if key_line_i:  # Already in the config, change the line
+                lines[key_line_i] = new_line
+            elif global_line_i is None:  # No global section yet, append to end of file
+                lines.append("[global]")
+                lines.append(new_line)
+            else:  # Has global section, append the line after it
+                lines.insert(global_line_i + 1, new_line)
+
+        open(self.config_file, "w").write("\n".join(lines))
+
+
+class Actions(object):
+    def call(self, function_name, kwargs):
+        print '- Original by .dok (Version 0.3.1) https://github.com/Dokument/PyBitmessage-Daemon'
+        print '- Modified by .pt (Version 0.4.0) https://github.com/BitMessage/PyBitmessage'
+        print '- Version: %s, Python %s' % (config.version, sys.version)
+
+        func = getattr(self, function_name, None)
+        back = func(**kwargs)
+        if back:
+            print back
+
+    # Default action: Start CLI only
+    def main(self, *argv):
+        while True:
+            try:
+                CLI()
+            except InputException as err:
+                print retStrings.get(err.resKey, '\n     Not defined error raised: %s.\n' % err.resKey)
+
+    def api(self, api_username, api_password, api_path, api_type):
+        print 'action api: api_username:', api_username
+
+    def proxy(self, proxy_username, proxy_password, proxy_path, proxy_type, proxy_timeout):
+        print 'action proxy: proxy_username:', proxy_username
+
+
+def start():
+    ''' Call actions '''
+
+    # action_kwargs = config.getActionArguments()
+    actions.call(config.action, {})
+
+
+# proxied start
+# original https://github.com/benhengx/xmlrpclibex
+# add basic auth support for top level host while none/HTTP proxied
+
+
+class ProxyError(Exception): pass
+class GeneralProxyError(ProxyError): pass
+class Socks5AuthError(ProxyError): pass
+class Socks5Error(ProxyError): pass
+class Socks4Error(ProxyError): pass
+class HTTPError(ProxyError): pass
+
+def init_socks(proxy, timeout):
+    '''init a socks proxy socket.'''
+    import urllib
+
+    map_to_type = {
+        'SOCKS4':   socks.PROXY_TYPE_SOCKS4,
+        'SOCKS5':   socks.PROXY_TYPE_SOCKS5,
+        'HTTP': socks.PROXY_TYPE_HTTP
+    }
+    address_family = socket.AF_INET
+    ssock = socks.socksocket(address_family, socket.SOCK_STREAM)
+    ssock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    # ssock.setsockopt()
+    if isinstance(timeout, (int, float)):
+        ssock.settimeout(timeout)
+    proxytype = map_to_type[proxy['proxy_type']]
+    rdns = proxy['proxy_remotedns']
+    addr, port = proxy['proxy_path'].split(':', 1)
+    port = int(port)
+    username = proxy['proxy_username']
+    password = proxy['proxy_password']
+    isauth = username and password
+    if isauth is True:
+        ssock.setproxy(proxytype, addr, port, username, password, rdns)
+        socks.setdefaultproxy(proxytype, addr, port, username, password, rdns)
+    else:
+        ssock.setproxy(proxytype, addr, port, rdns)
+        socks.setdefaultproxy(proxytype, addr, port, rdns)
+
+    socket.socket = socks.socksocket
+    # ssock.connect(("www.google.com", 443))
+    # urllib.urlopen("https://www.google.com/")
+    return ssock
+
+
+class SocksProxiedHTTPConnection(httplib.HTTPConnection):
+    '''Proxy the http connection through a socks proxy.'''
+
+    def init_socks(self, proxy):
+        self.ssock = init_socks(proxy, self.timeout)
+
+    def connect(self):
+        self.ssock.connect((self.host, self.port))
+        self.sock = self.ssock
+
+
+class SocksProxiedHTTPSConnection(httplib.HTTPSConnection):
+    '''Proxy the https connection through a socks proxy.'''
+
+    def init_socks(self, proxy):
+        self.ssock = init_socks(proxy, self.timeout)
+
+    def connect(self):
+        self.ssock.connect((self.host, self.port))
+        self.sock = ssl.wrap_socket(self.ssock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_TLSv1)
+
+    def close(self):
+        httplib.HTTPSConnection.close(self)
+
+        if self.ssock:
+            self.ssock.close()
+            self.ssock = None
+
+
+class TransportWithTo(xmlrpclib.Transport):
+    '''Transport support timeout'''
+
+    cls_http_conn = httplib.HTTPConnection
+    cls_https_conn = httplib.HTTPSConnection
+
+    def __init__(self, use_datetime=0, is_https=False, timeout=None):
+        xmlrpclib.Transport.__init__(self, use_datetime)
+
+        self.is_https = is_https
+        if timeout is None:
+            timeout = socket._GLOBAL_DEFAULT_TIMEOUT
+        self.timeout = timeout
+
+    def make_connection(self, host):
+        self.realhost = host
+        if self._connection and host == self._connection[0]:
+            return self._connection[1]
+
+        # create a HTTP/HTTPS connection object from a host descriptor
+        # host may be a string, or a (host, x509-dict) tuple
+        # no basic auth head returns here
+        chost, self._extra_headers, x509 = self.get_host_info(host)
+
+        # store the host argument along with the connection object
+        if self.is_https:  # xmlrpclib.SafeTransport + timeout
+            self._connection = host, self.cls_https_conn(chost, None, timeout=self.timeout, **(x509 or {}))
+        else:    # xmlrpclib.Transport + timeout
+            self._connection = host, self.cls_http_conn(chost, timeout=self.timeout)
+        return self._connection[1]
+
+#    def send_request(self, connection, handler, request_body):
+#        connection.putrequest('POST', '%s://%s' % (self.realhost, handler))
+
+#    def send_host(self, connection, host):
+#        connection.putheader('Host', self.realhost)
+
+#    def send_user_agent(self, connection):
+#        connection.putheader("User-Agent", self.send_user_agent)
+
+
+class ProxiedTransportWithTo(TransportWithTo):
+    '''Transport supports timeout and http proxy'''
+
+    def __init__(self, proxy, use_datetime=0, timeout=None, api_cred=None):
+        TransportWithTo.__init__(self, use_datetime, False, timeout)
+        self.api_cred = api_cred
+        self.proxy_path = proxy['proxy_path']
+        if proxy['proxy_username'] and proxy['proxy_password']:
+            self.proxy_cred = base64.encodestring('%s:%s' % (unquote(proxy['proxy_username']), unquote(proxy['proxy_password']))).strip()
+        else:
+            self.proxy_cred = None
+
+    def request(self, host, handler, request_body, verbose=False):
+        realhandler = 'HTTP://%s%s' % (host, handler)
+        return TransportWithTo.request(self, host, realhandler, request_body, verbose)
+
+    def make_connection(self, host):
+        return TransportWithTo.make_connection(self, self.proxy_path)
+
+    def send_content(self, connection, request_body):
+        if self.proxy_cred:
+            connection.putheader('Proxy-Authorization', 'Basic ' + self.proxy_cred)
+        if self.api_cred:
+            connection.putheader('Authorization', 'Basic ' + self.api_cred)
+        return TransportWithTo.send_content(self, connection, request_body)
+
+
+class SocksProxiedTransportWithTo(TransportWithTo):
+    '''Transport supports timeout and socks SOCKS4/SOCKS5 and http connect tunnel'''
+
+    cls_http_conn = SocksProxiedHTTPConnection
+    cls_https_conn = SocksProxiedHTTPSConnection
+
+    def __init__(self, proxy, use_datetime=0, is_https=False, timeout=None):
+        TransportWithTo.__init__(self, use_datetime, is_https, timeout)
+        self.proxy = proxy
+
+    def make_connection(self, host):
+        conn = TransportWithTo.make_connection(self, host)
+        conn.init_socks(self.proxy)
+        return conn
+
+
+class Proxiedxmlrpclib(xmlrpclib.ServerProxy):
+    """New added keyword arguments
+    timeout: seconds waiting for the socket
+    proxy: a dict specify the proxy settings, it supports the following fields:
+        proxy_path: the address of the proxy server. default: 127.0.0.1:1080
+        proxy_username: username to authenticate to the server. default None
+        proxy_password: password to authenticate to the server, only relevant when
+                  username is set. default None
+        proxy_type: string, 'SOCKS4', 'SOCKS5', 'HTTP' (HTTP connect tunnel), only
+                    relevant when is_socks is True. default 'SOCKS5'
+    """
+
+    def __init__(self, uri, transport=None, encoding=None, verbose=0,
+                 allow_none=0, use_datetime=0, timeout=None, proxy=None):
+
+        scheme, netloc, path, x, xx, xxx = urlparse(uri)
+        api_username = unquote(urlparse(uri).username)
+        api_password = unquote(urlparse(uri).password)
+        api_cred = None
+        self.uri = uri
+        if api_username and api_password:
+            api_cred = base64.encodestring('%s:%s' % (api_username, api_password)).strip()
+            netloc = netloc.split('@')[1]
+
+        if transport is None and (timeout or proxy):
+            is_https = scheme == 'https'
+
+            if proxy.get('proxy_type', 'none') == 'none':
+                transport = TransportWithTo(use_datetime, is_https, timeout)
+            else:
+                timeout = proxy.get('timeout', timeout)  # overide default timeout from proxy dict
+                is_socks = 'SOCKS' in proxy['proxy_type']
+
+                if is_https and not is_socks:  # set default HTTP type for https uri
+                    # https must be tunnelled through http connect
+                    is_socks = True
+                    proxy['proxy_type'] = 'HTTP'
+
+                if not is_socks:  # http proxy
+                    self.uri = '%s://%s%s' % (scheme, netloc, path)
+                    transport = ProxiedTransportWithTo(proxy, use_datetime, timeout, api_cred)
+                else:  # http connect and socksx
+                    transport = SocksProxiedTransportWithTo(proxy, use_datetime, is_https, timeout)
+
+        xmlrpclib.ServerProxy.__init__(self, self.uri, transport, encoding, verbose, allow_none, use_datetime)
+# proxied end
+
+
+class BMAPIWrapper(object):
+
+    def set_proxy(self, proxy=None):
+        self.proxy = proxy
+        self.__init__(self.conn, self.proxy)
+
+    def __init__(self, uri=None, proxy=None):
+        self.proxy = proxy
+        self.conn = uri
+
+        proxied = 'non-proxied'
+        if proxy:
+            proxied = proxy['proxy_type'] + ' | ' + proxy['proxy_path']
+
+        try:
+            self.xmlrpc = Proxiedxmlrpclib(uri, verbose=False, allow_none=True, use_datetime=True, timeout=30, proxy=self.proxy)
+            print '\n     XML-RPC initialed on: "%s" (%s)' % (self.conn, proxied)
+
+        except Exception as err:  # IOError, unsupported XML-RPC protocol/
+            self.xmlrpc = None
+            print '\n     XML-RPC initial failed on: "%s" - {%s}\n' % (self.conn, err)
+            # traceback.print_exc()
+
+    def __getattr__(self, apiname):
+        attr = getattr(self.xmlrpc, apiname, None)
+
+        def wrapper(*args, **kwargs):
+            error = 0
+            result = ''
+            errormsg = ''
+            try:
+                if attr is None:
+                    error = 1
+                    errormsg = '     Not prepared for calling API methods. (%s)' % apiname
+                    return {'error': error, 'result': result, 'errormsg': errormsg}
+
+                response = attr(*args, **kwargs)
+                if type(response) is str and ("API Error" in response or 'RPC ' in response):  # API Error, Authorization Error, Proxy Error
+                        error = 2
+                        if "API Error" in response:
+                            error = getAPIErrorCode(response)
+                            if error in [20, 21]:  # programing error, Invalid method/Unexpected API Failure
+                                print '\n     Maybe no such API method:', apiname
+                                print '     Try helping:', self.xmlrpc.system.listMethods() if error == 20 else self.xmlrpc.system.methodHelp(apiname)
+                        errormsg = '\n     ' + response + '\n'
+                        return {'error': error, 'result': result, 'errormsg': errormsg}
+
+                if apiname in [
+                        'add',
+                        'helloWorld',
+                        'statusBar',
+                        ]:
+                    result = response
+                else:  # pre-checking for API returns
+                    try:
+                        if apiname in [
+                                'getAllInboxMessageIDs',
+                                'getAllInboxMessageIds',
+                                ]:
+                            result = json.loads(response)['inboxMessageIds']
+                        elif apiname in [
+                                'getInboxMessageByID',
+                                'getInboxMessageById',
+                                ]:
+                            result = json.loads(response)['inboxMessage']
+                        elif apiname in [
+                                'GetAllInboxMessages',
+                                'getInboxMessagesByReceiver',
+                                'getInboxMessagesByAddress',
+                                ]:
+                            result = json.loads(response)['inboxMessages']
+                        elif apiname in [
+                                'getAllSentMessageIDs',
+                                'getAllSentMessageIds',
+                                ]:
+                            result = json.loads(response)['sentMessageIds']
+                        elif apiname in [
+                                'getAllSentMessages',
+                                'getSentMessagesByAddress',
+                                'getSentMessagesBySender',
+                                'getSentMessageByAckData',
+                                ]:
+                            result = json.loads(response)['sentMessages']
+                        elif apiname in [
+                                'getSentMessageByID',
+                                'getSentMessageById',
+                                ]:
+                            result = json.loads(response)['sentMessage']
+                        elif apiname in [
+                                'listAddressBookEntries',
+                                'listAddressbook',
+                                'listAddresses',
+                                'listAddressbook',
+                                'createDeterministicAddresses',
+                                ]:
+                            result = json.loads(response)['addresses']
+                        elif apiname in [
+                                'listSubscriptions',
+                                ]:
+                            result = json.loads(response)['subscriptions']
+                        elif apiname in [
+                                'decodeAddress',
+                                'clientStatus',
+                                'getMessageDataByDestinationHash',
+                                'getMessageDataByDestinationTag',
+                                ]:
+                            result = json.loads(response)
+                        elif apiname in [
+                                'addSubscription',
+                                'deleteSubscription',
+                                'createChan',
+                                'joinChan',
+                                'leaveChan',
+                                'sendMessage',
+                                'sendBroadcast',
+                                'getStatus',
+                                'trashMessage',
+                                'trashInboxMessage',
+                                'trashSentMessageByAckData',
+                                'trashSentMessage',
+                                'addAddressBK',
+                                'addAddressbook',
+                                'delAddressBK',
+                                'deleteAddressbook',
+                                'createRandomAddress',
+                                'getDeterministicAddress',
+                                'deleteAddress',
+                                'disseminatePreEncryptedMsg',
+                                'disseminatePubkey',
+                                'deleteAndVacuum',
+                                'shutdown',
+                                ]:
+                            result = response
+                        else:
+                            error = 99
+                            errormsg = '\n     BMAPIWrapper error: unexpected api. <%s>\n' % apiname
+                    except ValueError as err:  # json.loads error
+                        error = 3
+                        result = response
+                        errormsg = '\n     Server returns unexpected data, maybe a network problem there? (%s)\n' % err
+
+            except TypeError as err:  # unsupported XML-RPC protocol
+                error = -1
+                errormsg = '\n     XML-RPC not initialed correctly: %s.\n' % str(err)
+                # traceback.print_exc()
+            except (ProxyError, GeneralProxyError, Socks5AuthError, Socks5Error, Socks4Error, HTTPError, socket.error, xmlrpclib.ProtocolError, xmlrpclib.Fault) as err:  # (xmlrpclib.Error, ConnectionError, socks.GeneralProxyError)
+                error = -2
+                errormsg = '\n     Connection error: %s.\n' % str(err)
+                # traceback.print_exc()
+            except Exception:  # /httplib.BadStatusLine: connection close immediatly
+                error = -99
+                errormsg = '\n     Unexpected error: %s.\n' % sys.exc_info()[0]
+                # traceback.print_exc()
+
+            # print json.dumps({'error': error, 'result': result, 'errormsg': errormsg})
+            return {'error': error, 'result': result, 'errormsg': errormsg}
+
+        return wrapper
+
+
+class InputException(Exception):
+    def __init__(self, resKey):
+        Exception.__init__(self, resKey)
+        self.resKey = resKey
+
+    def __str__(self):
+        return self.resKey
+
+
+def inputAddress(prompt='What is the address?'):
+
+    global retStrings
+
+    src = retStrings['invalidaddr']
+    while True:
+        address = userInput(prompt + '\nTry again or')
+        if not validAddress(address):
+            print src
+            continue
+        else:
+            break
+
+    return address
+
+
+def inputIndex(prompt='Input a index: ', maximum=-1, alter=[]):
+
+    global retStrings
+
+    while True:
+        cinput = userInput(prompt + '\nTry again, (c) or').lower()
+        try:
+            if cinput == "c":
+                cinput = '-1'
+                raise InputException('usercancel')
+
+            elif cinput in alter:
+                break
+
+            elif int(cinput) < 0 or (maximum >= 0 and int(cinput) > maximum):
+                src = retStrings['invalidindex']
+                print src
+
+            else:
+                break
+
+        except (InputException, KeyboardInterrupt) as err:
+            raise
+
+        except ValueError:
+            src = retStrings['invalidinput']
+            print src
+
+    return cinput
 
 
 def userInput(message):
     """Checks input for exit or quit. Also formats for input, etc"""
 
-    global usrPrompt
+    global cmdStr, retStrings
 
-    print '\n' + message
-    uInput = raw_input('> ')
+    stack = list(inspect.stack())
+    where = ''.join([
+        str(stack[3][2]),
+        stack[3][3],
+        str(stack[2][2]),
+        stack[1][3],
+        str(stack[1][2]),
+        stack[3][3],
+        cmdStr
+        ])
+    print ('\n%s (exit) to cancel.\nPress Enter to input default [%s]: ' % (message, inputs.get(where, '')))
+    uInput = raw_input('>')
 
     if uInput.lower() == 'exit':  # Returns the user to the main menu
-        usrPrompt = 1
-        main()
+        raise InputException('usercancel')
 
-    elif uInput.lower() == 'quit':  # Quits the program
-        print '\n     Bye\n'
-        sys.exit(0)
+    elif uInput == '':  # Return last value.
+        return inputs.get(where, '')
 
     else:
-        return uInput
+        inputs[where] = uInput
 
-
-def restartBmNotify():
-    """Prompt the user to restart Bitmessage"""
-    print '\n     *******************************************************************'
-    print '     WARNING: If Bitmessage is running locally, you must restart it now.'
-    print '     *******************************************************************\n'
-
-
-# Begin keys.dat interactions
-
-
-def lookupAppdataFolder():
-    """gets the appropriate folders for the .dat files depending on the OS. Taken from bitmessagemain.py"""
-
-    APPNAME = "PyBitmessage"
-    if sys.platform == 'darwin':
-        if "HOME" in os.environ:
-            dataFolder = os.path.join(os.environ["HOME"], "Library/Application support/", APPNAME) + '/'
-        else:
-            print(
-                '     Could not find home folder, please report '
-                'this message and your OS X version to the Daemon Github.')
-            sys.exit(1)
-
-    elif 'win32' in sys.platform or 'win64' in sys.platform:
-        dataFolder = os.path.join(os.environ['APPDATA'], APPNAME) + '\\'
-    else:
-        dataFolder = os.path.expanduser(os.path.join("~", ".config/" + APPNAME + "/"))
-    return dataFolder
-
-
-def configInit():
-    """Initialised the configuration"""
-
-    BMConfigParser().add_section('bitmessagesettings')
-    # Sets the bitmessage port to stop the warning about the api not properly
-    # being setup. This is in the event that the keys.dat is in a different
-    # directory or is created locally to connect to a machine remotely.
-    BMConfigParser().set('bitmessagesettings', 'port', '8444')
-    BMConfigParser().set('bitmessagesettings', 'apienabled', 'true')  # Sets apienabled to true in keys.dat
-
-    with open(keysName, 'wb') as configfile:
-        BMConfigParser().write(configfile)
-
-    print '\n     ' + str(keysName) + ' Initalized in the same directory as daemon.py'
-    print '     You will now need to configure the ' + str(keysName) + ' file.\n'
-
-
-def apiInit(apiEnabled):
-    """Initialise the API"""
-
-    global usrPrompt
-    BMConfigParser().read(keysPath)
-
-    if apiEnabled is False:  # API information there but the api is disabled.
-        uInput = userInput("The API is not enabled. Would you like to do that now, (Y)es or (N)o?").lower()
-
-        if uInput == "y":
-            BMConfigParser().set('bitmessagesettings', 'apienabled', 'true')  # Sets apienabled to true in keys.dat
-            with open(keysPath, 'wb') as configfile:
-                BMConfigParser().write(configfile)
-
-            print 'Done'
-            restartBmNotify()
-            return True
-
-        elif uInput == "n":
-            print '     \n************************************************************'
-            print '            Daemon will not work when the API is disabled.       '
-            print '     Please refer to the Bitmessage Wiki on how to setup the API.'
-            print '     ************************************************************\n'
-            usrPrompt = 1
-            main()
-
-        else:
-            print '\n     Invalid Entry\n'
-            usrPrompt = 1
-            main()
-
-    elif apiEnabled:  # API correctly setup
-        # Everything is as it should be
-        return True
-
-    else:  # API information was not present.
-        print '\n     ' + str(keysPath) + ' not properly configured!\n'
-        uInput = userInput("Would you like to do this now, (Y)es or (N)o?").lower()
-
-        if uInput == "y":  # User said yes, initalize the api by writing these values to the keys.dat file
-            print ' '
-
-            apiUsr = userInput("API Username")
-            apiPwd = userInput("API Password")
-            apiPort = userInput("API Port")
-            apiEnabled = userInput("API Enabled? (True) or (False)").lower()
-            daemon = userInput("Daemon mode Enabled? (True) or (False)").lower()
-
-            if (daemon != 'true' and daemon != 'false'):
-                print '\n     Invalid Entry for Daemon.\n'
-                uInput = 1
-                main()
-
-            print '     -----------------------------------\n'
-
-            # sets the bitmessage port to stop the warning about the api not properly
-            # being setup. This is in the event that the keys.dat is in a different
-            # directory or is created locally to connect to a machine remotely.
-            BMConfigParser().set('bitmessagesettings', 'port', '8444')
-            BMConfigParser().set('bitmessagesettings', 'apienabled', 'true')
-            BMConfigParser().set('bitmessagesettings', 'apiport', apiPort)
-            BMConfigParser().set('bitmessagesettings', 'apiinterface', '127.0.0.1')
-            BMConfigParser().set('bitmessagesettings', 'apiusername', apiUsr)
-            BMConfigParser().set('bitmessagesettings', 'apipassword', apiPwd)
-            BMConfigParser().set('bitmessagesettings', 'daemon', daemon)
-            with open(keysPath, 'wb') as configfile:
-                BMConfigParser().write(configfile)
-
-            print '\n     Finished configuring the keys.dat file with API information.\n'
-            restartBmNotify()
-            return True
-
-        elif uInput == "n":
-            print '\n     ***********************************************************'
-            print '     Please refer to the Bitmessage Wiki on how to setup the API.'
-            print '     ***********************************************************\n'
-            usrPrompt = 1
-            main()
-        else:
-            print '     \nInvalid entry\n'
-            usrPrompt = 1
-            main()
-
-
-def apiData():
-    """TBC"""
-
-    global keysName
-    global keysPath
-    global usrPrompt
-
-    BMConfigParser().read(keysPath)  # First try to load the config file (the keys.dat file) from the program directory
-
-    try:
-        BMConfigParser().get('bitmessagesettings', 'port')
-        appDataFolder = ''
-    except:
-        # Could not load the keys.dat file in the program directory. Perhaps it is in the appdata directory.
-        appDataFolder = lookupAppdataFolder()
-        keysPath = appDataFolder + keysPath
-        BMConfigParser().read(keysPath)
-
-        try:
-            BMConfigParser().get('bitmessagesettings', 'port')
-        except:
-            # keys.dat was not there either, something is wrong.
-            print '\n     ******************************************************************'
-            print '     There was a problem trying to access the Bitmessage keys.dat file'
-            print '                    or keys.dat is not set up correctly'
-            print '       Make sure that daemon is in the same directory as Bitmessage. '
-            print '     ******************************************************************\n'
-
-            uInput = userInput("Would you like to create a keys.dat in the local directory, (Y)es or (N)o?").lower()
-
-            if (uInput == "y" or uInput == "yes"):
-                configInit()
-                keysPath = keysName
-                usrPrompt = 0
-                main()
-            elif (uInput == "n" or uInput == "no"):
-                print '\n     Trying Again.\n'
-                usrPrompt = 0
-                main()
-            else:
-                print '\n     Invalid Input.\n'
-
-            usrPrompt = 1
-            main()
-
-    try:  # checks to make sure that everyting is configured correctly. Excluding apiEnabled, it is checked after
-        BMConfigParser().get('bitmessagesettings', 'apiport')
-        BMConfigParser().get('bitmessagesettings', 'apiinterface')
-        BMConfigParser().get('bitmessagesettings', 'apiusername')
-        BMConfigParser().get('bitmessagesettings', 'apipassword')
-
-    except:
-        apiInit("")  # Initalize the keys.dat file with API information
-
-    # keys.dat file was found or appropriately configured, allow information retrieval
-    # apiEnabled =
-    # apiInit(BMConfigParser().safeGetBoolean('bitmessagesettings','apienabled'))
-    # #if false it will prompt the user, if true it will return true
-
-    BMConfigParser().read(keysPath)  # read again since changes have been made
-    apiPort = int(BMConfigParser().get('bitmessagesettings', 'apiport'))
-    apiInterface = BMConfigParser().get('bitmessagesettings', 'apiinterface')
-    apiUsername = BMConfigParser().get('bitmessagesettings', 'apiusername')
-    apiPassword = BMConfigParser().get('bitmessagesettings', 'apipassword')
-
-    print '\n     API data successfully imported.\n'
-
-    # Build the api credentials
-    return "http://" + apiUsername + ":" + apiPassword + "@" + apiInterface + ":" + str(apiPort) + "/"
-
-
-# End keys.dat interactions
+    return uInput
 
 
 def apiTest():
     """Tests the API connection to bitmessage. Returns true if it is connected."""
 
-    try:
-        result = api.add(2, 3)
-    except:
-        return False
-
-    return result == 5
-
-
-def bmSettings():
-    """Allows the viewing and modification of keys.dat settings."""
-
-    global keysPath
-    global usrPrompt
-
-    keysPath = 'keys.dat'
-
-    BMConfigParser().read(keysPath)  # Read the keys.dat
-    try:
-        port = BMConfigParser().get('bitmessagesettings', 'port')
-    except:
-        print '\n     File not found.\n'
-        usrPrompt = 0
-        main()
-
-    startonlogon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'startonlogon')
-    minimizetotray = BMConfigParser().safeGetBoolean('bitmessagesettings', 'minimizetotray')
-    showtraynotifications = BMConfigParser().safeGetBoolean('bitmessagesettings', 'showtraynotifications')
-    startintray = BMConfigParser().safeGetBoolean('bitmessagesettings', 'startintray')
-    defaultnoncetrialsperbyte = BMConfigParser().get('bitmessagesettings', 'defaultnoncetrialsperbyte')
-    defaultpayloadlengthextrabytes = BMConfigParser().get('bitmessagesettings', 'defaultpayloadlengthextrabytes')
-    daemon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon')
-
-    socksproxytype = BMConfigParser().get('bitmessagesettings', 'socksproxytype')
-    sockshostname = BMConfigParser().get('bitmessagesettings', 'sockshostname')
-    socksport = BMConfigParser().get('bitmessagesettings', 'socksport')
-    socksauthentication = BMConfigParser().safeGetBoolean('bitmessagesettings', 'socksauthentication')
-    socksusername = BMConfigParser().get('bitmessagesettings', 'socksusername')
-    sockspassword = BMConfigParser().get('bitmessagesettings', 'sockspassword')
-
-    print '\n     -----------------------------------'
-    print '     |   Current Bitmessage Settings   |'
-    print '     -----------------------------------'
-    print '     port = ' + port
-    print '     startonlogon = ' + str(startonlogon)
-    print '     minimizetotray = ' + str(minimizetotray)
-    print '     showtraynotifications = ' + str(showtraynotifications)
-    print '     startintray = ' + str(startintray)
-    print '     defaultnoncetrialsperbyte = ' + defaultnoncetrialsperbyte
-    print '     defaultpayloadlengthextrabytes = ' + defaultpayloadlengthextrabytes
-    print '     daemon = ' + str(daemon)
-    print '\n     ------------------------------------'
-    print '     |   Current Connection Settings   |'
-    print '     -----------------------------------'
-    print '     socksproxytype = ' + socksproxytype
-    print '     sockshostname = ' + sockshostname
-    print '     socksport = ' + socksport
-    print '     socksauthentication = ' + str(socksauthentication)
-    print '     socksusername = ' + socksusername
-    print '     sockspassword = ' + sockspassword
-    print ' '
-
-    uInput = userInput("Would you like to modify any of these settings, (Y)es or (N)o?").lower()
-
-    if uInput == "y":
-        while True:  # loops if they mistype the setting name, they can exit the loop with 'exit'
-            invalidInput = False
-            uInput = userInput("What setting would you like to modify?").lower()
-            print ' '
-
-            if uInput == "port":
-                print '     Current port number: ' + port
-                uInput = userInput("Enter the new port number.")
-                BMConfigParser().set('bitmessagesettings', 'port', str(uInput))
-            elif uInput == "startonlogon":
-                print '     Current status: ' + str(startonlogon)
-                uInput = userInput("Enter the new status.")
-                BMConfigParser().set('bitmessagesettings', 'startonlogon', str(uInput))
-            elif uInput == "minimizetotray":
-                print '     Current status: ' + str(minimizetotray)
-                uInput = userInput("Enter the new status.")
-                BMConfigParser().set('bitmessagesettings', 'minimizetotray', str(uInput))
-            elif uInput == "showtraynotifications":
-                print '     Current status: ' + str(showtraynotifications)
-                uInput = userInput("Enter the new status.")
-                BMConfigParser().set('bitmessagesettings', 'showtraynotifications', str(uInput))
-            elif uInput == "startintray":
-                print '     Current status: ' + str(startintray)
-                uInput = userInput("Enter the new status.")
-                BMConfigParser().set('bitmessagesettings', 'startintray', str(uInput))
-            elif uInput == "defaultnoncetrialsperbyte":
-                print '     Current default nonce trials per byte: ' + defaultnoncetrialsperbyte
-                uInput = userInput("Enter the new defaultnoncetrialsperbyte.")
-                BMConfigParser().set('bitmessagesettings', 'defaultnoncetrialsperbyte', str(uInput))
-            elif uInput == "defaultpayloadlengthextrabytes":
-                print '     Current default payload length extra bytes: ' + defaultpayloadlengthextrabytes
-                uInput = userInput("Enter the new defaultpayloadlengthextrabytes.")
-                BMConfigParser().set('bitmessagesettings', 'defaultpayloadlengthextrabytes', str(uInput))
-            elif uInput == "daemon":
-                print '     Current status: ' + str(daemon)
-                uInput = userInput("Enter the new status.").lower()
-                BMConfigParser().set('bitmessagesettings', 'daemon', str(uInput))
-            elif uInput == "socksproxytype":
-                print '     Current socks proxy type: ' + socksproxytype
-                print "Possibilities: 'none', 'SOCKS4a', 'SOCKS5'."
-                uInput = userInput("Enter the new socksproxytype.")
-                BMConfigParser().set('bitmessagesettings', 'socksproxytype', str(uInput))
-            elif uInput == "sockshostname":
-                print '     Current socks host name: ' + sockshostname
-                uInput = userInput("Enter the new sockshostname.")
-                BMConfigParser().set('bitmessagesettings', 'sockshostname', str(uInput))
-            elif uInput == "socksport":
-                print '     Current socks port number: ' + socksport
-                uInput = userInput("Enter the new socksport.")
-                BMConfigParser().set('bitmessagesettings', 'socksport', str(uInput))
-            elif uInput == "socksauthentication":
-                print '     Current status: ' + str(socksauthentication)
-                uInput = userInput("Enter the new status.")
-                BMConfigParser().set('bitmessagesettings', 'socksauthentication', str(uInput))
-            elif uInput == "socksusername":
-                print '     Current socks username: ' + socksusername
-                uInput = userInput("Enter the new socksusername.")
-                BMConfigParser().set('bitmessagesettings', 'socksusername', str(uInput))
-            elif uInput == "sockspassword":
-                print '     Current socks password: ' + sockspassword
-                uInput = userInput("Enter the new password.")
-                BMConfigParser().set('bitmessagesettings', 'sockspassword', str(uInput))
-            else:
-                print "\n     Invalid input. Please try again.\n"
-                invalidInput = True
-
-            if invalidInput is not True:  # don't prompt if they made a mistake.
-                uInput = userInput("Would you like to change another setting, (Y)es or (N)o?").lower()
-
-                if uInput != "y":
-                    print '\n     Changes Made.\n'
-                    with open(keysPath, 'wb') as configfile:
-                        BMConfigParser().write(configfile)
-                    restartBmNotify()
-                    break
-
-    elif uInput == "n":
-        usrPrompt = 1
-        main()
-    else:
-        print "Invalid input."
-        usrPrompt = 1
-        main()
+    response = api.add(2, 3)
+    return response['result'] == 5 if response['error'] == 0 else False
 
 
 def validAddress(address):
     """Predicate to test address validity"""
-    address_information = json.loads(api.decodeAddress(address))
 
-    return 'success' in str(address_information['status']).lower()
+    print '     Validating...', address
+    response = api.decodeAddress(address)
+    if response['error'] != 0:
+        print response['errormsg']
+        return False
+
+    return 'success' in response['result']['status'].lower()
 
 
 def getAddress(passphrase, vNumber, sNumber):
     """Get a deterministic address"""
-    passphrase = passphrase.encode('base64')  # passphrase must be encoded
 
-    return api.getDeterministicAddress(passphrase, vNumber, sNumber)
+    passPhrase = passphrase.encode('base64')  # passphrase must be encoded
+    print '     Getting address:', passphrase
+    response = api.getDeterministicAddress(passPhrase, vNumber, sNumber)
+    if response['error'] != 0:
+        return response['errormsg']
+
+    print '     Address:', response['result']
 
 
-def subscribe():
+def subscribe(address, label):
     """Subscribe to an address"""
-    global usrPrompt
 
-    while True:
-        address = userInput("What address would you like to subscribe to?")
-
-        if address == "c":
-            usrPrompt = 1
-            print ' '
-            main()
-        elif validAddress(address) is False:
-            print '\n     Invalid. "c" to cancel. Please try again.\n'
-        else:
-            break
-
-    label = userInput("Enter a label for this address.")
     label = label.encode('base64')
+    print '     Subscribing address:', label
+    response = api.addSubscription(address, label)
+    if response['error'] != 0:
+        return response['errormsg']
 
-    api.addSubscription(address, label)
-    print '\n     You are now subscribed to: ' + address + '\n'
+    return '\n    ' + response['result']
 
 
-def unsubscribe():
+def unsubscribe(address):
     """Unsusbcribe from an address"""
-    global usrPrompt
 
-    while True:
-        address = userInput("What address would you like to unsubscribe from?")
+    print '     unSubscribing address:', address
+    response = api.deleteSubscription(address)
+    if response['error'] != 0:
+        return response['errormsg']
 
-        if address == "c":
-            usrPrompt = 1
-            print ' '
-            main()
-        elif validAddress(address) is False:
-            print '\n     Invalid. "c" to cancel. Please try again.\n'
-        else:
-            break
-
-    userInput("Are you sure, (Y)es or (N)o?").lower()  # uInput =
-
-    api.deleteSubscription(address)
-    print '\n     You are now unsubscribed from: ' + address + '\n'
+    return '\n     ' + response['result']
 
 
 def listSubscriptions():
     """List subscriptions"""
 
-    global usrPrompt
-    print '\nLabel, Address, Enabled\n'
-    try:
-        print api.listSubscriptions()
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
-    print ' '
+    print '     Subscribed list retrieving...'
+    response = api.listSubscriptions()
+    if response['error'] != 0:
+        return response['errormsg']
+
+    jsonAddresses = response['result']
+    numAddresses = len(jsonAddresses)
+    print
+    print '     ------------------------------------------------------------------------'
+    print '     | #  |       Label        |               Address              |Enabled|'
+    print '     |----|--------------------|------------------------------------|-------|'
+    for addNum in range(0, numAddresses):  # processes all of the addresses and lists them out
+        label = (jsonAddresses[addNum]['label'].decode('base64')).encode(
+            'utf-8')              # may still misdiplay in some consoles
+        address = str(jsonAddresses[addNum]['address'])
+        enabled = str(jsonAddresses[addNum]['enabled'])
+
+        if len(label) > 19:
+            label = label[:16] + '...'
+
+        print '| '.join(['     ', str(addNum).ljust(3), label.ljust(19), address.ljust(35), enabled.ljust(6), '', ])
+
+    print ''.join(['     ', 72 * '-', '\n', ])
+
+    return ''
 
 
-def createChan():
+def createChan(password):
     """Create a channel"""
 
-    global usrPrompt
-    password = userInput("Enter channel name")
-    password = password.encode('base64')
-    try:
-        print api.createChan(password)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    base64 = password.encode('base64')
+    print '     Channel creating...', password
+    response = api.createChan(base64)
+    if response['error'] != 0:
+        return response['errormsg']
+
+    return '\n     ' + response['result']
 
 
 def joinChan():
     """Join a channel"""
 
-    global usrPrompt
-    while True:
-        address = userInput("Enter channel address")
+    uInput = ''
+    address = inputAddress('Enter channel address')
+    while uInput == '':
+        uInput = userInput('Enter channel name[1~]')
+    password = uInput.encode('base64')
 
-        if address == "c":
-            usrPrompt = 1
-            print ' '
-            main()
-        elif validAddress(address) is False:
-            print '\n     Invalid. "c" to cancel. Please try again.\n'
-        else:
-            break
+    print '     Channel joining...', uInput
+    response = api.joinChan(password, address)
+    if response['error'] != 0:
+        return response['errormsg']
 
-    password = userInput("Enter channel name")
-    password = password.encode('base64')
-    try:
-        print api.joinChan(password, address)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    return '\n     ' + response['result']
 
 
 def leaveChan():
     """Leave a channel"""
 
-    global usrPrompt
-    while True:
-        address = userInput("Enter channel address")
+    address = inputAddress("Enter channel address")
+    print '     Channel leaving...', 'address'
+    response = api.leaveChan(address)
+    if response['error'] != 0:
+        return response['errormsg']
 
-        if address == "c":
-            usrPrompt = 1
-            print ' '
-            main()
-        elif validAddress(address) is False:
-            print '\n     Invalid. "c" to cancel. Please try again.\n'
-        else:
-            break
-
-    try:
-        print api.leaveChan(address)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    return '\n     ' + response['result']
 
 
 def listAdd():
     """List all of the addresses and their info"""
-    global usrPrompt
-    try:
-        jsonAddresses = json.loads(api.listAddresses())
-        numAddresses = len(jsonAddresses['addresses'])  # Number of addresses
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
 
-    # print '\nAddress Number,Label,Address,Stream,Enabled\n'
-    print '\n     --------------------------------------------------------------------------'
-    print '     | # |       Label       |               Address               |S#|Enabled|'
-    print '     |---|-------------------|-------------------------------------|--|-------|'
+    print '     Retrieving...', 'Senders'
+    response = api.listAddresses()
+    if response['error'] != 0:
+        return response['errormsg']
+
+    jsonAddresses = response['result']
+    numAddresses = len(jsonAddresses)  # Number of addresses
+    # print '\nAddress Index,Label,Address,Stream,Enabled\n'
+    print
+    print '     ------------------------------------------------------------------------------'
+    print '     | #  |       Label        |               Address                |S# |Enabled|'
+    print '     |----|--------------------|--------------------------------------|---|-------|'
     for addNum in range(0, numAddresses):  # processes all of the addresses and lists them out
-        label = (jsonAddresses['addresses'][addNum]['label']).encode(
-            'utf')              # may still misdiplay in some consoles
-        address = str(jsonAddresses['addresses'][addNum]['address'])
-        stream = str(jsonAddresses['addresses'][addNum]['stream'])
-        enabled = str(jsonAddresses['addresses'][addNum]['enabled'])
+        label = jsonAddresses[addNum]['label'].encode(
+            'utf-8')              # may still misdiplay in some consoles
+        address = str(jsonAddresses[addNum]['address'])
+        stream = str(jsonAddresses[addNum]['stream'])
+        enabled = str(jsonAddresses[addNum]['enabled'])
 
         if len(label) > 19:
             label = label[:16] + '...'
 
-        print ''.join([
-            '     |',
-            str(addNum).ljust(3),
-            '|',
-            label.ljust(19),
-            '|',
-            address.ljust(37),
-            '|',
-            stream.ljust(1),
-            '|',
-            enabled.ljust(7),
-            '|',
-        ])
+        print '| '.join(['     ', str(addNum).ljust(3), label.ljust(19), address.ljust(37), stream.ljust(2), enabled.ljust(6), '', ])
 
-    print ''.join([
-        '     ',
-        74 * '-',
-        '\n',
-    ])
+    print ''.join(['     ', 78 * '-', '\n', ])
+
+    return ''
 
 
 def genAdd(lbl, deterministic, passphrase, numOfAdd, addVNum, streamNum, ripe):
     """Generate address"""
 
-    global usrPrompt
-
     if deterministic is False:  # Generates a new address with the user defined label. non-deterministic
         addressLabel = lbl.encode('base64')
-        try:
-            generatedAddress = api.createRandomAddress(addressLabel)
-        except:
-            print '\n     Connection Error\n'
-            usrPrompt = 0
-            main()
+        print '     Address requesting...', lbl
+        response = api.createRandomAddress(addressLabel)
+        if response['error'] != 0:
+            return response['errormsg']
 
-        return generatedAddress
+    else:  # Generates a new deterministic address with the user inputs.
+        passPhrase = passphrase.encode('base64')
+        print '     Address deterministic...', passphrase
+        response = api.createDeterministicAddresses(passPhrase, numOfAdd, addVNum, streamNum, ripe)
+        if response['error'] != 0:
+            return response['errormsg']
 
-    elif deterministic:  # Generates a new deterministic address with the user inputs.
-        passphrase = passphrase.encode('base64')
-        try:
-            generatedAddress = api.createDeterministicAddresses(passphrase, numOfAdd, addVNum, streamNum, ripe)
-        except:
-            print '\n     Connection Error\n'
-            usrPrompt = 0
-            main()
-        return generatedAddress
-
-    return 'Entry Error'
+    return '\n     Address:', response['result']
 
 
-def saveFile(fileName, fileData):
+def getBase64Len(x=''):
+    return int(len(x)*(3/4)) - 2 if x[-2:] == '==' else 1 if x[-1] == '=' else 0
+
+
+def dump2File(fileName, fileData, deCoded):
     """Allows attachments and messages/broadcats to be saved"""
 
+    global inputShorts
+
     # This section finds all invalid characters and replaces them with ~
-    fileName = fileName.replace(" ", "")
-    fileName = fileName.replace("/", "~")
-    # fileName = fileName.replace("\\", "~") How do I get this to work...?
-    fileName = fileName.replace(":", "~")
-    fileName = fileName.replace("*", "~")
-    fileName = fileName.replace("?", "~")
-    fileName = fileName.replace('"', "~")
-    fileName = fileName.replace("<", "~")
-    fileName = fileName.replace(">", "~")
-    fileName = fileName.replace("|", "~")
+    for s in ' /\\:*?"<>|':
+        fileName = fileName.replace(s, '~')
 
     directory = os.path.abspath('attachments')
 
     if not os.path.exists(directory):
-        os.makedirs(directory)
+        try:
+            os.makedirs(directory)
+
+        except OSError as err:
+            return '\n     %s.\n' % str(err)
+            # return '\n     Failed creating ' + directory + '\n'
+        except Exception:
+            return '\n     Unexpected error: %s.\n' % sys.exc_info()[0]
 
     filePath = os.path.join(directory, fileName)
 
-    with open(filePath, 'wb+') as path_to_file:
-        path_to_file.write(fileData.decode("base64"))
-    print '\n     Successfully saved ' + filePath + '\n'
+    if not deCoded:
+        x = filter(lambda z: not re.match(r'^\s*$', z), fileData)
+        trydecode = False
+        if len(x) % 4 == 0:  # check by length before decode.
+            trydecode = True
+        else:
+            print '\n'.join([
+                '     -----------------------------------',
+                '     Contents seems not "BASE64" encoded. (base on length check)',
+                '     Start[%d] ~ Ends[%d].' % (x[:3], x[-3:]),
+                '     About: %d(bytes).' % getBase64Len(x),
+                '     FileName: "%s"' % fileName,
+                ])
+            uInput = userInput('Try to decode it anyway, (n)o or (Y)es?')
+            if uInput not in inputShorts['no']:
+                trydecode = True
+
+        if trydecode is True:
+            try:
+                y = x.decode('base64', 'strict')
+                if x == y.encode('base64').replace('\n', ''):  # double check decoded string.
+                    fileData = y
+                else:
+                    print '\n     Failed on "BASE64" re-encode checking.\n'
+
+            except ValueError:
+                return '\n     Failed on "BASE64" decoding.\n'
+        else:
+            print '\n     Not "BASE64" contents, dump to file directly.'
+
+    try:
+        with open(filePath, 'wb+') as path_to_file:
+                path_to_file.write(fileData)
+
+    except IOError as err:
+        return '\n     %s.\n' % str(err)
+        # return '\n     Failed on operating: "' + filePath + '"\n'
+    except Exception:
+        return '\n     Unexpected error: %s.\n' % sys.exc_info()[0]
+
+    return '     Successfully saved to: "' + filePath + '"'
 
 
 def attachment():
@@ -654,20 +1161,21 @@ def attachment():
 
     theAttachmentS = ''
 
-    while True:
+    global inputShorts
 
+    for counter in range(1, 3):  # maximum 3 of attachments
         isImage = False
         theAttachment = ''
 
         while True:  # loops until valid path is entered
             filePath = userInput(
-                '\nPlease enter the path to the attachment or just the attachment name if in this folder.')
+                '\nPlease enter the path to the attachment or just the attachment name if in this folder[Max:180MB], %d/3 allowed.' % counter)
 
             try:
                 with open(filePath):
                     break
             except IOError:
-                print '\n     %s was not found on your filesystem or can not be opened.\n' % filePath
+                print '\n     Failed open file on: ', filePath + '\n'
 
         # print filesize, and encoding estimate with confirmation if file is over X size (1mb?)
         invSize = os.path.getsize(filePath)
@@ -675,26 +1183,22 @@ def attachment():
         round(invSize, 2)  # Rounds to two decimal places
 
         if invSize > 500.0:  # If over 500KB
-            print ''.join([
-                '\n     WARNING:The file that you are trying to attach is ',
-                invSize,
-                'KB and will take considerable time to send.\n'
-            ])
-            uInput = userInput('Are you sure you still want to attach it, (Y)es or (N)o?').lower()
+            print '\n     WARNING:The file that you are trying to attach is %d(KB) and will take considerable time to send.\n' % invSize
+            uInput = userInput('Are you sure you still want to attach it, (y)es or (N)o?').lower()
 
-            if uInput != "y":
-                print '\n     Attachment discarded.\n'
-                return ''
+            if uInput not in inputShorts['yes']:
+                return '\n     Attachment discarded.'
+
         elif invSize > 184320.0:  # If larger than 180MB, discard.
-            print '\n     Attachment too big, maximum allowed size:180MB\n'
-            main()
+            return '\n     Attachment too big, maximum allowed size:180MB\n'
 
         pathLen = len(str(ntpath.basename(filePath)))  # Gets the length of the filepath excluding the filename
         fileName = filePath[(len(str(filePath)) - pathLen):]  # reads the filename
 
         filetype = imghdr.what(filePath)  # Tests if it is an image file
         if filetype is not None:
-            print '\n     ---------------------------------------------------'
+            print
+            print '     ---------------------------------------------------'
             print '     Attachment detected as an Image.'
             print '     <img> tags will automatically be included,'
             print '     allowing the recipient to view the image'
@@ -704,7 +1208,7 @@ def attachment():
             time.sleep(2)
 
         # Alert the user that the encoding process may take some time.
-        print '\n     Encoding Attachment, Please Wait ...\n'
+        print '     Encoding Attachment, Please Wait ...'
 
         with open(filePath, 'rb') as f:  # Begin the actual encoding
             data = f.read(188743680)  # Reads files up to 180MB, the maximum size for Bitmessage.
@@ -713,81 +1217,67 @@ def attachment():
         if isImage:  # If it is an image, include image tags in the message
             theAttachment = """
 <!-- Note: Image attachment below. Please use the right click "View HTML code ..." option to view it. -->
-<!-- Sent using Bitmessage Daemon. https://github.com/Dokument/PyBitmessage-Daemon -->
+<!-- Sent using Bitmessage Daemon. https://github.com/BitMessage/PyBitmessage -->
 
-Filename:%s
-Filesize:%sKB
-Encoding:base64
+Filename: %s
+Filesize: %sKB
+Encoding: base64
 
 <center>
     <div id="image">
-        <img alt = "%s" src='data:image/%s;base64, %s' />
+        <img alt="%s" src="data:image/%s;base64, %s"/>
     </div>
 </center>""" % (fileName, invSize, fileName, filetype, data)
         else:  # Else it is not an image so do not include the embedded image code.
             theAttachment = """
 <!-- Note: File attachment below. Please use a base64 decoder, or Daemon, to save it. -->
-<!-- Sent using Bitmessage Daemon. https://github.com/Dokument/PyBitmessage-Daemon -->
+<!-- Sent using Bitmessage Daemon. https://github.com/BitMessage/PyBitmessage -->
 
 Filename:%s
 Filesize:%sKB
 Encoding:base64
 
-<attachment alt = "%s" src='data:file/%s;base64, %s' />""" % (fileName, invSize, fileName, fileName, data)
+<attachment alt="%s" src="data:file/%s;base64, %s"/>""" % (fileName, invSize, fileName, fileName, data)
 
-        uInput = userInput('Would you like to add another attachment, (Y)es or (N)o?').lower()
+        uInput = userInput('Would you like to add another attachment, (y)es or (N)o?').lower()
 
-        if uInput == 'y' or uInput == 'yes':  # Allows multiple attachments to be added to one message
+        if uInput in inputShorts['yes']:  # Allows multiple attachments to be added to one message
             theAttachmentS = str(theAttachmentS) + str(theAttachment) + '\n\n'
-        elif uInput == 'n' or uInput == 'no':
+        else:
             break
 
     theAttachmentS = theAttachmentS + theAttachment
     return theAttachmentS
 
 
-def sendMsg(toAddress, fromAddress, subject, message):
+def sendMsg(toAddress, fromAddress, subject=None, message=None):
     """
     With no arguments sent, sendMsg fills in the blanks.
     subject and message must be encoded before they are passed.
     """
 
-    global usrPrompt
-    if validAddress(toAddress) is False:
-        while True:
-            toAddress = userInput("What is the To Address?")
+    global retStrings, inputShorts
 
-            if toAddress == "c":
-                usrPrompt = 1
-                print ' '
-                main()
-            elif validAddress(toAddress) is False:
-                print '\n     Invalid Address. "c" to cancel. Please try again.\n'
-            else:
-                break
+    if validAddress(toAddress) is False:
+        toAddress = inputAddress("What is the To Address indeed?")
 
     if validAddress(fromAddress) is False:
-        try:
-            jsonAddresses = json.loads(api.listAddresses())
-            numAddresses = len(jsonAddresses['addresses'])  # Number of addresses
-        except:
-            print '\n     Connection Error\n'
-            usrPrompt = 0
-            main()
+        print '     Sender retrieving...', fromAddress
+        response = api.listAddresses()
+        if response['error'] != 0:
+            return response['errormsg']
+
+        jsonAddresses = response['result']
+        numAddresses = len(jsonAddresses)  # Number of addresses
 
         if numAddresses > 1:  # Ask what address to send from if multiple addresses
             found = False
             while True:
-                print ' '
-                fromAddress = userInput("Enter an Address or Address Label to send from.")
-
-                if fromAddress == "exit":
-                    usrPrompt = 1
-                    main()
+                fromAddress = userInput('Enter an Address or Address Label to send from.')
 
                 for addNum in range(0, numAddresses):  # processes all of the addresses
-                    label = jsonAddresses['addresses'][addNum]['label']
-                    address = jsonAddresses['addresses'][addNum]['address']
+                    label = jsonAddresses[addNum]['label']
+                    address = jsonAddresses[addNum]['address']
                     if fromAddress == label:  # address entered was a label and is found
                         fromAddress = address
                         found = True
@@ -799,7 +1289,7 @@ def sendMsg(toAddress, fromAddress, subject, message):
 
                     else:
                         for addNum in range(0, numAddresses):  # processes all of the addresses
-                            address = jsonAddresses['addresses'][addNum]['address']
+                            address = jsonAddresses[addNum]['address']
                             if fromAddress == address:  # address entered was a found in our addressbook.
                                 found = True
                                 break
@@ -812,55 +1302,70 @@ def sendMsg(toAddress, fromAddress, subject, message):
 
         else:  # Only one address in address book
             print '\n     Using the only address in the addressbook to send from.\n'
-            fromAddress = jsonAddresses['addresses'][0]['address']
+            fromAddress = jsonAddresses[0]['address']
 
-    if subject == '':
-        subject = userInput("Enter your Subject.")
+    if subject is None:
+        subject = userInput('Enter your Subject.')
         subject = subject.encode('base64')
-    if message == '':
-        message = userInput("Enter your Message.")
 
-        uInput = userInput('Would you like to add an attachment, (Y)es or (N)o?').lower()
-        if uInput == "y":
+    if message is None:
+        while True:
+            try:
+                message += '\n' + raw_input('Continue enter your message line by line, end with <CTL-D>.\n>')
+            except EOFError:
+                break
+
+        uInput = userInput('Would you like to add an attachment, (y)es or (N)o?').lower()
+        if uInput in inputShorts['yes']:
             message = message + '\n\n' + attachment()
 
         message = message.encode('base64')
 
-    try:
+    while True:
+        print '     Message sending...', subject.decode('base64')
         ackData = api.sendMessage(toAddress, fromAddress, subject, message)
-        print '\n     Message Status:', api.getStatus(ackData), '\n'
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+        if ackData['error'] == 1:
+            return ackData['errormsg']
+        elif ackData['error'] != 0:
+            print ackData['errormsg']
+            uInput = userInput('Would you like to try again, (n)o or (Y)es?').lower()
+            if uInput in inputShorts['no']:
+                break
+
+    if ackData['error'] == 0:
+        print '     Fetching send status...'
+        status = api.getStatus(ackData['result'])
+        if status['error'] == 1:
+            return status['errormsg']
+        elif status['error'] != 0:
+            print status['errormsg']
+        else:
+            return '     Message Status:' + status['result']
+
+    return ''
 
 
-def sendBrd(fromAddress, subject, message):
+def sendBrd(fromAddress=None, subject=None, message=None):
     """Send a broadcast"""
 
-    global usrPrompt
-    if fromAddress == '':
+    global inputShorts
+    if fromAddress is None:
+        print '     Retrieving...', 'Senders'
+        response = api.listAddresses()
+        if response['error'] != 0:
+            return response['errormsg']
 
-        try:
-            jsonAddresses = json.loads(api.listAddresses())
-            numAddresses = len(jsonAddresses['addresses'])  # Number of addresses
-        except:
-            print '\n     Connection Error\n'
-            usrPrompt = 0
-            main()
+        jsonAddresses = response['result']
+        numAddresses = len(jsonAddresses)  # Number of addresses
 
         if numAddresses > 1:  # Ask what address to send from if multiple addresses
             found = False
             while True:
-                fromAddress = userInput("\nEnter an Address or Address Label to send from.")
-
-                if fromAddress == "exit":
-                    usrPrompt = 1
-                    main()
+                fromAddress = userInput('Enter an Address or Address Label to send from.')
 
                 for addNum in range(0, numAddresses):  # processes all of the addresses
-                    label = jsonAddresses['addresses'][addNum]['label']
-                    address = jsonAddresses['addresses'][addNum]['address']
+                    label = jsonAddresses[addNum]['label']
+                    address = jsonAddresses[addNum]['address']
                     if fromAddress == label:  # address entered was a label and is found
                         fromAddress = address
                         found = True
@@ -872,7 +1377,7 @@ def sendBrd(fromAddress, subject, message):
 
                     else:
                         for addNum in range(0, numAddresses):  # processes all of the addresses
-                            address = jsonAddresses['addresses'][addNum]['address']
+                            address = jsonAddresses[addNum]['address']
                             if fromAddress == address:  # address entered was a found in our addressbook.
                                 found = True
                                 break
@@ -884,432 +1389,744 @@ def sendBrd(fromAddress, subject, message):
                     break  # Address was found
 
         else:  # Only one address in address book
-            print '\n     Using the only address in the addressbook to send from.\n'
-            fromAddress = jsonAddresses['addresses'][0]['address']
+            print '     Using the only address in the addressbook to send from.\n'
+            fromAddress = jsonAddresses[0]['address']
 
-    if subject == '':
-        subject = userInput("Enter your Subject.")
-        subject = subject.encode('base64')
-    if message == '':
-        message = userInput("Enter your Message.")
+    if subject is None:
+        subject = userInput('Enter your Subject.')
+    subject = subject.encode('base64')
+    if message is None:
+        while True:
+            try:
+                message += '\n' + raw_input('Continue enter your message line by line, end with <CTL-D>.\n>')
+            except EOFError:
+                break
 
-        uInput = userInput('Would you like to add an attachment, (Y)es or (N)o?').lower()
-        if uInput == "y":
+        uInput = userInput('Would you like to add an attachment, (y)es or (N)o?').lower()
+        if uInput in inputShorts['yes']:
             message = message + '\n\n' + attachment()
 
         message = message.encode('base64')
 
-    try:
+    while True:
+        print '     Broadcast message sending...'
         ackData = api.sendBroadcast(fromAddress, subject, message)
-        print '\n     Message Status:', api.getStatus(ackData), '\n'
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+        if ackData['error'] == 1:
+            return ackData['errormsg']
+        elif status['error'] != 0:
+            print '\n     %s.\n' % str(err)
+            uInput = userInput('Would you like to try again, no or (Y)es?').lower()
+            if uInput in inputShorts['no']:
+                break
+
+    if ackData['error'] == 0:
+        print '     Fetching send status...'
+        status = api.getStatus(ackData['result'])
+        if status['error'] == 1:
+            return status['errormsg']
+        elif status['error'] != 0:
+            print status['errormsg']
+        else:
+            return '     Message Status:' + status['result']
+
+    return ''
 
 
-def inbox(unreadOnly=False):
-    """Lists the messages by: Message Number, To Address Label, From Address Label, Subject, Received Time)"""
+def inbox(unreadOnly=False, pageNum=20):
+    """Lists the messages by: message index, To Address Label, From Address Label, Subject, Received Time)"""
 
-    global usrPrompt
-    try:
-        inboxMessages = json.loads(api.getAllInboxMessages())
-        numMessages = len(inboxMessages['inboxMessages'])
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    print '     Inbox index fetching...'
+    response = api.getAllInboxMessageIDs()
+    if response['error'] != 0:
+        return response['errormsg']
 
+    messageIds = response['result']
+    numMessages = len(messageIds)
     messagesPrinted = 0
     messagesUnread = 0
-    for msgNum in range(0, numMessages):  # processes all of the messages in the inbox
-        message = inboxMessages['inboxMessages'][msgNum]
-        # if we are displaying all messages or if this message is unread then display it
-        if not unreadOnly or not message['read']:
-            print '     -----------------------------------\n'
-            print '     Message Number:', msgNum  # Message Number
-            print '     To:', getLabelForAddress(message['toAddress'])  # Get the to address
-            print '     From:', getLabelForAddress(message['fromAddress'])  # Get the from address
-            print '     Subject:', message['subject'].decode('base64')  # Get the subject
-            print ''.join([
-                '     Received:',
-                datetime.datetime.fromtimestamp(
-                    float(message['receivedTime'])).strftime('%Y-%m-%d %H:%M:%S'),
-            ])
-            messagesPrinted += 1
-            if not message['read']:
-                messagesUnread += 1
+    for msgNum in range(numMessages - 1, -1, -1):  # processes all of the messages in the inbox
+        messageID = messageIds[msgNum]['msgid']
+        print '     -----------------------------------'
+        print '     Inbox message retrieving...', messageID
+        response = api.getInboxMessageByID(messageID)
+        if response['error'] == 1:
+            return response['errormsg']
+        elif response['error'] != 0:
+            print '\n     Retrieve failed on:', msgNum, messageID
+            print response['errormsg']
+        else:
+            message = response['result'][0]
+            # if we are displaying all messages or if this message is unread then display it
+            if not unreadOnly or not message['read']:
+                print '     -----------------------------------'
+                print '     Inbox index: %d/%d' % (msgNum, numMessages - 1)  # message index
+                print '     Message ID:', message['msgid']
+                print '     Read:', message['read']
+                print '     To:', getLabelForAddress(message['toAddress'])  # Get the to address
+                print '     From:', getLabelForAddress(message['fromAddress'])  # Get the from address
+                print '     Subject:', message['subject'].decode('base64')  # Get the subject
+                print '     Received:', datetime.datetime.fromtimestamp(float(message['receivedTime'])).strftime('%Y-%m-%d %H:%M:%S')
+                print '     Base64Len:', str(len(message['message']))
+                messagesPrinted += 1
+                if not message['read']:
+                    messagesUnread += 1
 
-        if messagesPrinted % 20 == 0 and messagesPrinted != 0:
-            userInput('(Press Enter to continue or type (Exit) to return to the main menu.)').lower()  # uInput =
+                if messagesPrinted % pageNum == 0 and messagesPrinted != 0:
+                    try:
+                        uInput = userInput('Paused on %d/%d, next [%d],' % (msgNum, numMessages - 1, msgNum - pageNum if msgNum > pageNum else 0))
 
-    print '\n     -----------------------------------'
+                    except InputException as err:
+                        raise InputException(str(err))
+
+    print '     -----------------------------------'
     print '     There are %d unread messages of %d messages in the inbox.' % (messagesUnread, numMessages)
-    print '     -----------------------------------\n'
+    print '     -----------------------------------'
+
+    return ''
 
 
-def outbox():
+def outbox(pageNum=20):
     """TBC"""
 
-    global usrPrompt
-    try:
-        outboxMessages = json.loads(api.getAllSentMessages())
-        numMessages = len(outboxMessages['sentMessages'])
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    print '     All outbox messages downloading...'
+    response = api.getAllSentMessages()
+    if response['error'] != 0:
+        return response['errormsg']
 
-    for msgNum in range(0, numMessages):  # processes all of the messages in the outbox
-        print '\n     -----------------------------------\n'
-        print '     Message Number:', msgNum  # Message Number
-        # print '     Message ID:', outboxMessages['sentMessages'][msgNum]['msgid']
-        print '     To:', getLabelForAddress(outboxMessages['sentMessages'][msgNum]['toAddress'])  # Get the to address
+    outboxMessages = response['result']
+    numMessages = len(outboxMessages)
+    for msgNum in range(numMessages - 1, -1, -1):  # processes all of the messages in the outbox
+        message = outboxMessages[msgNum]
+        print '     -----------------------------------'
+        print '     Outbox index: %d/%d' % (msgNum, numMessages - 1)  # message index
+        print '     Message ID:', message['msgid']
+        print '     To:', getLabelForAddress(message['toAddress'])  # Get the to address
         # Get the from address
-        print '     From:', getLabelForAddress(outboxMessages['sentMessages'][msgNum]['fromAddress'])
-        print '     Subject:', outboxMessages['sentMessages'][msgNum]['subject'].decode('base64')  # Get the subject
-        print '     Status:', outboxMessages['sentMessages'][msgNum]['status']  # Get the subject
+        print '     From:', getLabelForAddress(message['fromAddress'])
+        print '     Subject:', message['subject'].decode('base64')  # Get the subject
+        print '     Status:', message['status']  # Get the status
+        print '     Ack:', message['ackData']  # Get the ackData
+        print '     Last Action Time:', datetime.datetime.fromtimestamp(float(message['lastActionTime'])).strftime('%Y-%m-%d %H:%M:%S')
+        print '     Base64Len:', str(len(message['message']))
 
-        print ''.join([
-            '     Last Action Time:',
-            datetime.datetime.fromtimestamp(
-                float(outboxMessages['sentMessages'][msgNum]['lastActionTime'])).strftime('%Y-%m-%d %H:%M:%S'),
-        ])
+        if msgNum % pageNum == 0 and msgNum != 0:
+            uInput = userInput('Paused on %d/%d, next [%d],' % (msgNum, numMessages - 1, msgNum - pageNum if msgNum > pageNum else 0))
 
-        if msgNum % 20 == 0 and msgNum != 0:
-            userInput('(Press Enter to continue or type (Exit) to return to the main menu.)').lower()  # uInput =
-
-    print '\n     -----------------------------------'
+    print '     -----------------------------------'
     print '     There are ', numMessages, ' messages in the outbox.'
     print '     -----------------------------------\n'
 
+    return ''
 
-def readSentMsg(msgNum):
+
+def attDetect(content=None, textmsg=None, attPrefix=None, askSave=True):
+
+    global inputShorts
+
+    attPos = msgPos = 0
+    # Hard way search attachments
+    for counter in range(1, 3):  # Allows maximum 3 of attachments to be downloaded/saved
+        try:
+            attPos = content.index(';base64,', attPos) + 9  # Finds the attachment position
+            attEndPos = content.index('/>', attPos) - 1  # Finds the end of the attachment
+
+            attPre = attPos - 9  # back for ;base64, | <img src=";base64, | <attachment src=";base64,
+            # try remove prefix <xxxx | <xxxxxxxxxxx
+            pBack = 0
+            if attPre >= (msgPos + 12):
+                if '<' == content[attPre - 12]:
+                    pBack = 12
+            elif attPre - msgPos + 5 >= 0:
+                if '<' == content[attPre - 5]:
+                    pBack = 5
+            attPre = attPre - pBack
+
+            try:
+                fnPos = content.index('alt="', msgPos, attPos) + 5  # Finds position of the filename
+                fnEndPos = content.index('" src=', msgPos, attPos)  # Finds the end position
+                # fnLen = fnEndPos - fnPos #Finds the length of the filename
+                fn = content[fnPos:fnEndPos]
+
+                attPre = fnPos - 5  # back for alt=" | <img alt=" | <attachment alt="
+                # try remove prefix <xxxx | <xxxxxxxxxxx
+                pBack = 0
+                if attPre >= (msgPos + 12):
+                    if '<' == content[attPre - 12]:
+                        pBack = 12
+                elif attPre - msgPos + 5 >= 0:
+                    if '<' == content[attPre - 5]:
+                        pBack = 5
+                attPre = attPre - pBack
+
+            except ValueError:
+                fn = 'notdetected'
+            fn = '%d_attachment_%d_%s' % (attPrefix, attPos, fn)
+
+            this_attachment = content[attPos:attEndPos]
+            x = filter(lambda z: not re.match(r'^\s*$', z), this_attachment)
+            # x = x.replace('\n', '').strip()
+            trydecode = False
+            if len(x) % 4 == 0:  # check by length before decode.
+                trydecode = True
+            else:
+                print '\n'.join([
+                    '     -----------------------------------',
+                    '     Embeded mesaage seems not "BASE64" encoded. (base on length check)',
+                    '     Offset: %d, about: %d(bytes).' % (attPos, (int(len(x)*3/4)) - 2 if x[-2:] == '==' else 1 if x[-1] == '=' else 0),
+                    '     Start[%d] ~ Ends[%d].' % (x[:3], x[-3:]),
+                    '     FileName: "%s"' % fn,
+                ])
+                uInput = userInput('Try to decode anyway, (n)o or (Y)es?')
+                if uInput not in inputShorts['no']:
+                    trydecode = True
+            if trydecode is True:
+                try:
+                    y = x.decode('base64', 'strict')
+                    if x == y.encode('base64').replace('\n', ''):  # double check decoded string.
+                        print '     This embeded message decoded successfully:', fn
+                        if askSave is True:
+                            uInput = userInput('Download the "decoded" attachment, (y)es or (No)?\nName(%d): %s,' % (counter, fn)).lower()
+                            if uInput in inputShorts['yes']:
+                                src = dump2File(fn, y, True)
+                        else:
+                            src = dump2File(fn, y, True)
+
+                        print src
+                        attmsg = '\n'.join([
+                            '     -----------------------------------',
+                            '     Attachment: "%s"' % fn,
+                            '     Size: %d(bytes)' % getBase64Len(x),
+                            '     -----------------------------------',
+                            ])
+                        # remove base64 and '<att' prefix and suffix '/>' stuff
+                        textmsg = textmsg + content[msgPos:attPre] + attmsg
+                        attEndPos += 3
+                        msgPos = attEndPos
+                    else:
+                        print '\n     Failed on decode this embeded "BASE64" like message on re-encode check.\n'
+
+                except ValueError:
+                    pass
+                    print '\n     Failed on decode this emdeded "BASE64" encoded like message.\n'
+                except Exception:
+                    print '\n     Unexpected error: %s.\n' % sys.exc_info()[0]
+
+            else:
+                print '\n    Skiped a embeded "BASE64" encoded like message.'
+
+            if attEndPos != msgPos:
+                textmsg = textmsg + content[msgPos:attEndPos]
+                msgPos = attEndPos
+
+        except ValueError:
+            textmsg = textmsg + content[msgPos:]
+            break
+        except Exception:
+            print '\n     Unexpected error: %s.\n' % sys.exc_info()[0]
+
+    return textmsg
+
+
+def readSentMsg(cmd='read', msgNum=-1, messageID=None, trunck=380, withAtta=False):
     """Opens a sent message for reading"""
 
-    global usrPrompt
-    try:
-        outboxMessages = json.loads(api.getAllSentMessages())
-        numMessages = len(outboxMessages['sentMessages'])
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    print '     All outbox messages downloading...', str(msgNum)
+    if messageID is None:
+        response = api.getAllSentMessages()
+        if response['error'] != 0:
+            return response['errormsg']
 
-    print ' '
+        message = response['result'][msgNum]
+    else:
+        response = api.getSentMessageByID(messageID)
+        if response['error'] != 0:
+            return response['errormsg']
 
-    if msgNum >= numMessages:
-        print '\n     Invalid Message Number.\n'
-        main()
+        message = response['result'][0]
 
-    # Begin attachment detection
-    message = outboxMessages['sentMessages'][msgNum]['message'].decode('base64')
+    subject = message['subject'].decode('base64')
+    content = message['message'].decode('base64')
+    full = len(content)
+    textmsg = ''
+    textmsg = content if withAtta else attDetect(content, textmsg, 'outbox_' + subject, cmd != 'save')
 
-    while True:  # Allows multiple messages to be downloaded/saved
-        if ';base64,' in message:  # Found this text in the message, there is probably an attachment.
-            attPos = message.index(";base64,")  # Finds the attachment position
-            attEndPos = message.index("' />")  # Finds the end of the attachment
-            # attLen = attEndPos - attPos #Finds the length of the message
-
-            if 'alt = "' in message:  # We can get the filename too
-                fnPos = message.index('alt = "')  # Finds position of the filename
-                fnEndPos = message.index('" src=')  # Finds the end position
-                # fnLen = fnEndPos - fnPos #Finds the length of the filename
-
-                fileName = message[fnPos + 7:fnEndPos]
-            else:
-                fnPos = attPos
-                fileName = 'Attachment'
-
-            uInput = userInput(
-                '\n     Attachment Detected. Would you like to save the attachment, (Y)es or (N)o?').lower()
-            if uInput == "y" or uInput == 'yes':
-
-                this_attachment = message[attPos + 9:attEndPos]
-                saveFile(fileName, this_attachment)
-
-            message = message[:fnPos] + '~<Attachment data removed for easier viewing>~' + message[(attEndPos + 4):]
-
-        else:
-            break
-
-    # End attachment Detection
-
-    print '\n     To:', getLabelForAddress(outboxMessages['sentMessages'][msgNum]['toAddress'])  # Get the to address
+    print '    ', 74 * '-'
+    print '     Message index:', str(msgNum)  # message outdex
+    print '     Message ID:', message['msgid']
+    print '     To:', getLabelForAddress(message['toAddress'])  # Get the to address
     # Get the from address
-    print '     From:', getLabelForAddress(outboxMessages['sentMessages'][msgNum]['fromAddress'])
-    print '     Subject:', outboxMessages['sentMessages'][msgNum]['subject'].decode('base64')  # Get the subject
-    print '     Status:', outboxMessages['sentMessages'][msgNum]['status']  # Get the subject
-    print ''.join([
-        '     Last Action Time:',
-        datetime.datetime.fromtimestamp(
-            float(outboxMessages['sentMessages'][msgNum]['lastActionTime'])).strftime('%Y-%m-%d %H:%M:%S'),
-    ])
+    print '     From:', getLabelForAddress(message['fromAddress'])
+    print '     Subject:', subject  # Get the subject
+    print '     Status:', message['status']  # Get the status
+    print '     Ack:', message['ackData']  # Get the ackData
+
+    print '     Last Action Time:', datetime.datetime.fromtimestamp(float(message['lastActionTime'])).strftime('%Y-%m-%d %H:%M:%S')
+    print '     Length: %d/%d' % (trunck if trunck <= full else full, full)
     print '     Message:\n'
-    print message  # inboxMessages['inboxMessages'][msgNum]['message'].decode('base64')
-    print ' '
+    print textmsg if trunck < 0 or len(textmsg) <= trunck else textmsg[:trunck] + '\n\n     ~< MESSAGE TOO LONG TRUNCKED TO SHOW >~'
+    print '    ', 74 * '-'
+
+    if cmd == 'save':
+        ret = dump2File('outbox_' + subject, textmsg, withAtta)
+        print ret
+
+    return ''
 
 
-def readMsg(msgNum):
+def readMsg(cmd='read', msgNum=-1, messageID=None, trunck=380, withAtta=False):
     """Open a message for reading"""
-    global usrPrompt
-    try:
-        inboxMessages = json.loads(api.getAllInboxMessages())
-        numMessages = len(inboxMessages['inboxMessages'])
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
 
-    if msgNum >= numMessages:
-        print '\n     Invalid Message Number.\n'
-        main()
+    print '     Inbox message reading...', str(msgNum)
+    response = api.getInboxMessageByID(messageID, True)
+    if response['error'] != 0:
+        return response['errormsg']
 
-    # Begin attachment detection
-    message = inboxMessages['inboxMessages'][msgNum]['message'].decode('base64')
+    message = response['result'][0]
+    subject = message['subject'].decode('base64')
+    content = message['message'].decode('base64')  # Message that you are replying too.
+    full = len(content)
+    textmsg = ''
+    textmsg = content if withAtta else attDetect(content, textmsg, 'inbox_' + subject, cmd != 'save')
 
-    while True:  # Allows multiple messages to be downloaded/saved
-        if ';base64,' in message:  # Found this text in the message, there is probably an attachment.
-            attPos = message.index(";base64,")  # Finds the attachment position
-            attEndPos = message.index("' />")  # Finds the end of the attachment
-            # attLen = attEndPos - attPos #Finds the length of the message
-
-            if 'alt = "' in message:  # We can get the filename too
-                fnPos = message.index('alt = "')  # Finds position of the filename
-                fnEndPos = message.index('" src=')  # Finds the end position
-                # fnLen = fnEndPos - fnPos #Finds the length of the filename
-
-                fileName = message[fnPos + 7:fnEndPos]
-            else:
-                fnPos = attPos
-                fileName = 'Attachment'
-
-            uInput = userInput(
-                '\n     Attachment Detected. Would you like to save the attachment, (Y)es or (N)o?').lower()
-            if uInput == "y" or uInput == 'yes':
-
-                this_attachment = message[attPos + 9:attEndPos]
-                saveFile(fileName, this_attachment)
-
-            message = message[:fnPos] + '~<Attachment data removed for easier viewing>~' + message[attEndPos + 4:]
-
-        else:
-            break
-
-    # End attachment Detection
-    print '\n     To:', getLabelForAddress(inboxMessages['inboxMessages'][msgNum]['toAddress'])  # Get the to address
+    print '    ', 74 * '-'
+    print '     Inbox index :', msgNum  # message index
+    print '     Message ID:', message['msgid']
+    print '     Read:', message['read']
+    print '     To:', getLabelForAddress(message['toAddress'])  # Get the to address
     # Get the from address
-    print '     From:', getLabelForAddress(inboxMessages['inboxMessages'][msgNum]['fromAddress'])
-    print '     Subject:', inboxMessages['inboxMessages'][msgNum]['subject'].decode('base64')  # Get the subject
-    print ''.join([
-        '     Received:', datetime.datetime.fromtimestamp(
-            float(inboxMessages['inboxMessages'][msgNum]['receivedTime'])).strftime('%Y-%m-%d %H:%M:%S'),
-    ])
+    print '     From:', getLabelForAddress(message['fromAddress'])
+    print '     Subject:', subject  # Get the subject
+    print '     Received:', datetime.datetime.fromtimestamp(float(message['receivedTime'])).strftime('%Y-%m-%d %H:%M:%S')
+    print '     Length: %d/%d' % (trunck if trunck <= full else full, full)
     print '     Message:\n'
-    print message  # inboxMessages['inboxMessages'][msgNum]['message'].decode('base64')
-    print ' '
-    return inboxMessages['inboxMessages'][msgNum]['msgid']
+    print textmsg if trunck < 0 or len(textmsg) <= trunck else textmsg[:trunck] + '\n\n     ~< MESSAGE TOO LONG TRUNCKED TO SHOW >~'
+    print '    ', 74 * '-'
+
+    if cmd == 'save':
+        ret = dump2File('inbox_' + subject + str(full), textmsg, withAtta)
+        print ret
+
+    return ''
 
 
-def replyMsg(msgNum, forwardORreply):
+def replyMsg(msgNum=-1, messageID=None, forwardORreply=None):
     """Allows you to reply to the message you are currently on. Saves typing in the addresses and subject."""
 
-    global usrPrompt
+    global inputShorts, retStrings
+
     forwardORreply = forwardORreply.lower()  # makes it lowercase
-    try:
-        inboxMessages = json.loads(api.getAllInboxMessages())
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    print '     Inbox message %s... %d' % (forwardORreply, msgNum)
+    response = api.getInboxMessageByID(messageID, True)
+    if response['error'] != 0:
+        return response['errormsg']
 
-    fromAdd = inboxMessages['inboxMessages'][msgNum]['toAddress']  # Address it was sent To, now the From address
-    message = inboxMessages['inboxMessages'][msgNum]['message'].decode('base64')  # Message that you are replying too.
+    message = response['result'][0]
+    subject = message['subject'].decode('base64')
+    content = message['message'].decode('base64')  # Message that you are replying too.
+    full = len(content)
+    textmsg = ''
+    textmsg = attDetect(content, textmsg, subject, True)
 
-    subject = inboxMessages['inboxMessages'][msgNum]['subject']
-    subject = subject.decode('base64')
+    if forwardORreply == 'forward':
+        attachMessage = '\n'.join([
+            '> To: ', fwdFrom,
+            '> From: ', fromAdd,
+            '> Subject: ', subject,
+            '> Received: ', recvTime,
+            '> Message:',
+            ])
+    else:
+        attachMessage = ''
+    for line in textmsg.splitlines():
+        attachMessage = attachMessage + '> ' + line + '\n'
+
+    fromAdd = message['toAddress']  # Address it was sent To, now the From address
+    fwdFrom = message['fromAddress']  # Address it was sent To, will attached to fwd
+    recvTime = datetime.datetime.fromtimestamp(float(message['receivedTime'])).strftime('%Y-%m-%d %H:%M:%S')
 
     if forwardORreply == 'reply':
-        toAdd = inboxMessages['inboxMessages'][msgNum]['fromAddress']  # Address it was From, now the To address
-        subject = "Re: " + subject
+        toAdd = message['fromAddress']  # Address it was From, now the To address
+        subject = "Re: " + re.sub('^Re: *', '', subject)
 
     elif forwardORreply == 'forward':
-        subject = "Fwd: " + subject
+        subject = "Fwd: " + re.sub('^Fwd: *', '', subject)
+        toAdd = inputAddress("What is the To Address?")
 
-        while True:
-            toAdd = userInput("What is the To Address?")
-
-            if toAdd == "c":
-                usrPrompt = 1
-                print ' '
-                main()
-            elif validAddress(toAdd) is False:
-                print '\n     Invalid Address. "c" to cancel. Please try again.\n'
-            else:
-                break
     else:
-        print '\n     Invalid Selection. Reply or Forward only'
-        usrPrompt = 0
-        main()
+        return '\n     Invalid Selection. Reply or Forward only'
 
     subject = subject.encode('base64')
 
-    newMessage = userInput("Enter your Message.")
+    message = ''
+    while True:
+        try:
+            print '\n'.join([
+                '     Drafting:',
+                message,
+                '     -----------------------------------',
+                ])
+            message += '\n' + raw_input('Continue enter your message line by line, end with <CTL-D>.\n>')
+        except EOFError:
+            break
 
-    uInput = userInput('Would you like to add an attachment, (Y)es or (N)o?').lower()
-    if uInput == "y":
-        newMessage = newMessage + '\n\n' + attachment()
+    src = retStrings['usercancel']
+    uInput = userInput('Would you like to add an attachment, (y)es or (N)o?').lower()
+    if uInput in inputShorts['yes']:
+        message = message + '\n\n' + attachment()
 
-    newMessage = newMessage + '\n\n------------------------------------------------------\n'
-    newMessage = newMessage + message
-    newMessage = newMessage.encode('base64')
+    message = message + '\n\n------------------------------------------------------\n'
+    message = message + attachMessage
+    message = message.encode('base64')
 
-    sendMsg(toAdd, fromAdd, subject, newMessage)
+    print message
+    uInput = userInput('Realy want to send upper message, (n)o or (Y)es?').lower()
+    if uInput not in inputShorts['no']:
+        src = sendMsg(toAdd, fromAdd, subject, message)
 
-    main()
+    return src
 
 
-def delMsg(msgNum):
+def delMsg(msgNum=-1, messageID=None):
     """Deletes a specified message from the inbox"""
 
-    global usrPrompt
-    try:
-        inboxMessages = json.loads(api.getAllInboxMessages())
-        # gets the message ID via the message index number
-        msgId = inboxMessages['inboxMessages'][int(msgNum)]['msgid']
+    print '     Inbox message deleting...', messageID
+    response = api.trashMessage(messageID)
+    if response['error'] != 0:
+        return response['errormsg']
 
-        msgAck = api.trashMessage(msgId)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
-
-    return msgAck
+    return '\n     ' + response['result']
 
 
-def delSentMsg(msgNum):
+def delSentMsg(msgNum=-1, messageID=None):
     """Deletes a specified message from the outbox"""
 
-    global usrPrompt
-    try:
-        outboxMessages = json.loads(api.getAllSentMessages())
-        # gets the message ID via the message index number
-        msgId = outboxMessages['sentMessages'][int(msgNum)]['msgid']
-        msgAck = api.trashSentMessage(msgId)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    if messageID is None:
+        print '     All outbox messages downloading...', str(msgNum)
+        response = api.getAllSentMessages()
+        if response['error'] != 0:
+            return response['errormsg']
 
-    return msgAck
+        outboxMessages = response['result']
+        # gets the message ackData via the message index number
+        ackData = outboxMessages[msgNum]['ackData']
+        print '     Outbox message deleting...', ackData
+        response = api.trashSentMessageByAckData(ackData)
+        if response['error'] != 0:
+            return response['errormsg']
+    else:
+        print '     Outbox message deleting...', messageID
+        response = api.trashSentMessage(messageID)
+        if response['error'] != 0:
+            return response['errormsg']
+
+    return '\n     ' + response['result']
+
+
+def toReadInbox(cmd='read', trunck=380, withAtta=False):
+
+    global inputShorts, retStrings
+
+    numMessages = 0
+    print '     Inbox index fetching...'
+    response = api.getAllInboxMessageIDs()
+    if response['error'] != 0:
+        return response['errormsg']
+
+    messageIds = response['result']
+    numMessages = len(messageIds)
+    if numMessages < 1:
+        return '     Zero message found.\n'
+
+    src = retStrings['usercancel']
+    if cmd != 'delete':
+        msgNum = int(inputIndex('Input the index of the message to %s [0-%d]: ' % (cmd, numMessages - 1), numMessages - 1))
+
+        nextNum = msgNum
+        ret = ''
+        while msgNum >= 0:  # save, read
+            nextNum += 1
+            messageID = messageIds[msgNum]['msgid']
+            if cmd == 'save':
+                ret = readMsg(cmd, msgNum, messageID, trunck, withAtta)
+                return ret
+
+            else:
+                ret = readMsg(cmd, msgNum, messageID)
+            print ret
+
+            uInput = userInput('Would you like to set this message to unread, (y)es or (N)o?').lower()
+            if uInput in inputShorts['yes']:
+                ret = markMessageReadbit(msgNum, messageID, False)
+
+            else:
+                uInput = userInput('Would you like to (f)orward, (r)eply, (s)ave, (d)ump or Delete this message?').lower()
+
+                if uInput in inputShorts['reply']:
+                    ret = replyMsg(msgNum, messageID, 'reply')
+
+                elif uInput in inputShorts['forward']:
+                    ret = replyMsg(msgNum, messageID, 'forward')
+
+                elif uInput in inputShorts['save']:
+                    ret = readMsg('save', msgNum, messageID, withAtta=False)
+
+                elif uInput in inputShorts['dump']:
+                    ret = readMsg('save', msgNum, messageID, withAtta=True)
+
+                else:
+                    uInput = userInput('Are you sure to delete, (y)es or (N)o?').lower()  # Prevent accidental deletion
+                    if uInput in inputShorts['yes']:
+                        # nextNum -= 1
+                        # numMessages -= 1
+                        ret = delMsg(msgNum, messageID)
+
+            print ret
+            if nextNum < numMessages:
+                uInput = userInput('Next message, (n)o or (Y)es?').lower()  # Prevent
+                msgNum = nextNum if uInput not in inputShorts['no'] else -1
+
+            else:
+                msgNum = -1
+                src = retStrings['indexoutofbound']
+
+    else:
+        uInput = inputIndex('Input the index of the message you wish to delete or (A)ll to empty the inbox [0-%d]: ' % (numMessages - 1), numMessages - 1, inputShorts['all'][0]).lower()
+
+        if uInput in inputShorts['all']:
+            ret = inbox(False)
+            print ret
+            uInput = userInput('Are you sure to delete all this %d message(s), (y)es or (N)o?' % numMessages).lower()  # Prevent accidental deletion
+            if uInput in inputShorts['yes']:
+                for msgNum in range(0, numMessages):  # processes all of the messages in the outbox
+                    ret = delMsg(msgNum, messageIds[msgNum]['msgid'])
+                    print ret
+                src = ''
+
+        else:
+            nextNum = msgNum = int(uInput)
+            while msgNum >= 0:  # save, read
+                nextNum += 1
+                messageID = messageIds[msgNum]['msgid']
+                ret = readMsg(cmd, msgNum, messageID)
+                print ret
+
+                uInput = userInput('Are you sure to delete, (y)es or (N)o?').lower()  # Prevent accidental deletion
+                if uInput in inputShorts['yes']:
+                    # nextNum -= 1
+                    # numMessages -= 1
+                    ret = delMsg(msgNum, messageID)
+                    print ret
+
+                if nextNum < numMessages:
+                    uInput = userInput('Next message, (n)o or (Y)es?').lower()  # Prevent
+                    msgNum = nextNum if uInput not in inputShorts['no'] else -1
+
+                else:
+                    msgNum = -1
+                    src = retStrings['indexoutofbound']
+
+    return src
+
+
+def toReadOutbox(cmd='read', trunck=380, withAtta=False):
+
+    global inputShorts, retStrings
+
+    print '     Outbox index fetching...'
+    response = api.getAllSentMessageIDs()
+    if response['error'] != 0:
+        return response['errormsg']
+
+    messageIds = response['result']
+    numMessages = len(messageIds)
+    if numMessages < 1:
+        return '     Zero message found.\n'
+
+    src = retStrings['usercancel']
+    if cmd != 'delete':
+        msgNum = int(inputIndex('Input the index of the message open [0-%d]: ' % (numMessages - 1), numMessages - 1))
+
+        nextNum = msgNum
+        ret = ''
+        while msgNum >= 0:  # save, read
+            nextNum += 1
+            messageID = messageIds[msgNum]['msgid']
+            if cmd == 'save':
+                ret = readSentMsg(cmd, msgNum, messageID, trunck, withAtta)
+                return ret
+
+            else:
+                ret = readSentMsg(cmd, msgNum, messageID)
+
+            print ret
+            # Gives the user the option to delete the message
+            uInput = userInput('Would you like to (s)ave, (d)ump or Delete this message directly?').lower()
+
+            if uInput in inputShorts['save']:
+                ret = readSentMsg('save', msgNum, messageID, withAtta=False)
+
+            elif uInput in inputShorts['dump']:
+                ret = readSentMsg('save', msgNum, messageID, withAtta=True)
+
+            else:
+                uInput = userInput('Are you sure to delete, (y)es or (N)o?').lower()  # Prevent accidental deletion
+                if uInput in inputShorts['yes']:
+                    nextNum -= 1
+                    numMessages -= 1
+                    ret = delSentMsg(msgNum, messageID)
+
+            print ret
+            if nextNum < numMessages:
+                uInput = userInput('Next message, (n)o or (Y)es?').lower()  # Prevent
+                msgNum = nextNum if uInput not in inputShorts['no'] else -1
+
+            else:
+                msgNum = -1
+                src = retStrings['indexoutofbound']
+
+    else:
+        uInput = inputIndex('Input the index of the message you wish to delete or (A)ll to empty the outbox [0-%d]: ' % (numMessages - 1), numMessages - 1, inputShorts['all'][0]).lower()
+
+        if uInput in inputShorts['all']:
+            ret = outbox()
+            print ret
+            uInput = userInput('Are you sure to delete all this %d message(s), (y)es or (N)o?' % numMessages).lower()  # Prevent accidental deletion
+            if uInput in inputShorts['yes']:
+                for msgNum in range(0, numMessages):  # processes all of the messages in the outbox
+                    ret = delSentMsg(msgNum, messageIds[msgNum]['msgid'])
+                    print ret
+                src = ''
+
+        else:
+            nextNum = msgNum = int(uInput)
+            while msgNum >= 0:  # save, read
+                nextNum += 1
+
+                messageID = messageIds[msgNum]['msgid']
+                ret = readSentMsg(cmd, msgNum, messageID)
+                print ret
+
+                uInput = userInput('Are you sure to delete this message, (y)es or (N)o?').lower()  # Prevent accidental deletion
+                if uInput in inputShorts['yes']:
+                    nextNum -= 1
+                    numMessages -= 1
+                    ret = delSentMsg(msgNum, messageID)
+                    print ret
+
+                if nextNum < numMessages:
+                    uInput = userInput('Next message, (n)o or (Y)es?').lower()  # Prevent
+                    msgNum = nextNum if uInput not in inputShorts['no'] else -1
+
+                else:
+                    msgNum = -1
+                    src = retStrings['indexoutofbound']
+
+    return src
 
 
 def getLabelForAddress(address):
     """Get label for an address"""
 
-    if address in knownAddresses:
-        return knownAddresses[address]
-    else:
-        buildKnownAddresses()
-        if address in knownAddresses:
-            return knownAddresses[address]
+    for entry in knownAddresses['addresses']:
+        if entry['address'] == address:
+            return "%s (%s)" % (entry['label'], entry['address'])
 
     return address
 
 
-def buildKnownAddresses():
+def getLabel():
     """Build known addresses"""
 
-    global usrPrompt
-
     # add from address book
-    try:
-        response = api.listAddressBookEntries()
-        # if api is too old then fail
-        if "API Error 0020" in response:
-            return
-        addressBook = json.loads(response)
-        for entry in addressBook['addresses']:
-            if entry['address'] not in knownAddresses:
-                knownAddresses[entry['address']] = "%s (%s)" % (entry['label'].decode('base64'), entry['address'])
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    errors = ''
+    newentry = []
+    print '     Retrieving...', 'Contacts'
+    addresses = api.listAddressBookEntries()
+    if addresses['error'] != 0:
+        print addresses['errormsg']
+    else:
+        for entry in addresses['result']:
+            isnew = True
+            for old in knownAddresses['addresses']:
+                if entry['address'] == old['address']:
+                    isnew = False
+                    break
+            if isnew is True:
+                newentry.append({'label': entry['label'].decode('base64').encode('utf-8'), 'address': entry['address']})
+        if any(newentry):
+            for new in newentry:
+                knownAddresses['addresses'].append(new)
 
-    # add from my addresses
-    try:
-        response = api.listAddresses2()
-        # if api is too old just return then fail
-        if "API Error 0020" in response:
-            return
-        addresses = json.loads(response)
-        for entry in addresses['addresses']:
-            if entry['address'] not in knownAddresses:
-                knownAddresses[entry['address']] = "%s (%s)" % (entry['label'].decode('base64'), entry['address'])
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    newentry = []
+    print '     Retrieving...', 'Senders'
+    addresses = api.listAddresses()
+    if addresses['error'] != 0:
+        print addresses['errormsg']
+    else:
+        for entry in addresses['result']:
+            isnew = True
+            for old in knownAddresses['addresses']:
+                if entry['address'] == old['address']:
+                    isnew = False
+                    break
+            if isnew is True:
+                newentry.append({'label': entry['label'].encode('utf-8'), 'address': entry['address']})
+        if any(newentry):
+            for new in newentry:
+                knownAddresses['addresses'].append(new)
+
+    return ''
 
 
-def listAddressBookEntries():
+def listAddressBK(printKnown=False):
     """List addressbook entries"""
 
-    global usrPrompt
-
-    try:
+    if not printKnown:
+        print '     Retrieving...', 'Contacts'
         response = api.listAddressBookEntries()
-        if "API Error" in response:
-            return getAPIErrorCode(response)
-        addressBook = json.loads(response)
-        print
-        print '     --------------------------------------------------------------'
-        print '     |        Label       |                Address                |'
-        print '     |--------------------|---------------------------------------|'
-        for entry in addressBook['addresses']:
-            label = entry['label'].decode('base64')
-            address = entry['address']
-            if len(label) > 19:
-                label = label[:16] + '...'
-            print '     | ' + label.ljust(19) + '| ' + address.ljust(37) + ' |'
-        print '     --------------------------------------------------------------'
-        print
+        if response['error'] != 0:
+            return response['errormsg']
+        addressBook = response['result']
+    else:
+        addressBook = knownAddresses['addresses']
 
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    numAddresses = len(addressBook)
+    print
+    print '     ------------------------------------------------------------------'
+    print '     | #  |       Label        |               Address                |'
+    print '     |----|--------------------|--------------------------------------|'
+    for addNum in range(0, numAddresses):  # processes all of the addresses and lists them out
+        entry = addressBook[addNum]
+        label = entry['label'].decode('base64').encode('utf-8') if not printKnown else entry['label']
+        address = entry['address']
+        if len(label) > 19:
+            label = label[:16] + '...'
+        print '| '.join(['     ', str(addNum).ljust(3), label.ljust(19), address.ljust(37), '', ])
+    print ''.join(['     ', 66 * '-', '\n', ])
+
+    return ''
 
 
 def addAddressToAddressBook(address, label):
     """Add an address to an addressbook"""
 
-    global usrPrompt
+    print '     Adding...', label
+    response = api.addAddressBK(address, label.encode('base64'))
+    if response['error'] != 0:
+        return response['errormsg']
 
-    try:
-        response = api.addAddressBookEntry(address, label.encode('base64'))
-        if "API Error" in response:
-            return getAPIErrorCode(response)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    return '\n     ' + response['result']
 
 
 def deleteAddressFromAddressBook(address):
     """Delete an address from an addressbook"""
 
-    global usrPrompt
+    print '     Deleting...', address
+    response = api.delAddressBK(address)
+    if response['error'] != 0:
+        return response['errormsg']
 
-    try:
-        response = api.deleteAddressBookEntry(address)
-        if "API Error" in response:
-            return getAPIErrorCode(response)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    return '\n     ' + response['result']
 
 
 def getAPIErrorCode(response):
@@ -1321,563 +2138,423 @@ def getAPIErrorCode(response):
         return int(response.split()[2][:-1])
 
 
-def markMessageRead(messageID):
-    """Mark a message as read"""
+def markMessageReadbit(msgNum=-1, messageID=None, read=False):
+    """Mark a mesasge as unread/read"""
 
-    global usrPrompt
+    print '     Marking...', str(msgNum),
+    response = api.getInboxMessageByID(messageID, read)
+    if response['error'] != 0:
+        print 'Failed.'
+        return response['errormsg']
 
-    try:
-        response = api.getInboxMessageByID(messageID, True)
-        if "API Error" in response:
-            return getAPIErrorCode(response)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    print 'OK.'
+    return ''
 
 
-def markMessageUnread(messageID):
-    """Mark a mesasge as unread"""
+def markAllMessagesReadbit(read=False):
+    """Mark all messages as unread/read"""
 
-    global usrPrompt
+    print '     Inbox index fetching...', 'mark'
+    response = api.getAllInboxMessageIDs()
+    if response['error'] != 0:
+        return response['errormsg']
 
-    try:
-        response = api.getInboxMessageByID(messageID, False)
-        if "API Error" in response:
-            return getAPIErrorCode(response)
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    messageIds = response['result']
+    numMessages = len(messageIds)
+    if numMessages < 1:
+        return '     Zero message found.\n'
 
+    for msgNum in range(0, numMessages):  # processes all of the messages in the inbox
+        src = markMessageReadbit(msgNum, messageIds[msgNum]['msgid'], read)
+        print src
 
-def markAllMessagesRead():
-    """Mark all messages as read"""
-
-    global usrPrompt
-
-    try:
-        inboxMessages = json.loads(api.getAllInboxMessages())['inboxMessages']
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
-    for message in inboxMessages:
-        if not message['read']:
-            markMessageRead(message['msgid'])
+    return ''
 
 
-def markAllMessagesUnread():
-    """Mark all messages as unread"""
+def addInfo(address):
 
-    global usrPrompt
+    print '     Address decoding...', address
+    response = api.decodeAddress(address)
+    if response['error'] != 0:
+        return response['errormsg']
 
-    try:
-        inboxMessages = json.loads(api.getAllInboxMessages())['inboxMessages']
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
-    for message in inboxMessages:
-        if message['read']:
-            markMessageUnread(message['msgid'])
+    addinfo = response['result']
+    print '     ------------------------------'
+    if 'success' in addinfo['status'].lower():
+        print '     Valid Address'
+        print '     Address Version: %s' % str(addinfo['addressVersion'])
+        print '     Stream Number: %s\n' % str(addinfo['streamNumber'])
+    else:
+        print '\n     Invalid Address !\n'
+
+    return ''
 
 
 def clientStatus():
     """Print the client status"""
 
-    global usrPrompt
+    print '     Client status fetching...'
+    print '     ------------------------------'
 
-    try:
-        client_status = json.loads(api.clientStatus())
-    except:
-        print '\n     Connection Error\n'
-        usrPrompt = 0
-        main()
+    response = api.clientStatus()
+    if response['error'] == 0:
+        client_status = response['result']
+        for key in client_status.keys():
+            print '    ', key, ':', str(client_status[key])
+    else:
+        print response['errormsg']
 
-    print "\nnetworkStatus: " + client_status['networkStatus'] + "\n"
-    print "\nnetworkConnections: " + str(client_status['networkConnections']) + "\n"
-    print "\nnumberOfPubkeysProcessed: " + str(client_status['numberOfPubkeysProcessed']) + "\n"
-    print "\nnumberOfMessagesProcessed: " + str(client_status['numberOfMessagesProcessed']) + "\n"
-    print "\nnumberOfBroadcastsProcessed: " + str(client_status['numberOfBroadcastsProcessed']) + "\n"
+    response = api.getAllInboxMessageIDs()
+    if response['error'] == 0:
+        inboxMessageIds = response['result']
+        inumMessages = len(inboxMessageIds)
+        print '     InboxMessages:', str(inumMessages)
+    else:
+        print response['errormsg']
+
+    response = api.getAllSentMessageIDs()
+    if response['error'] == 0:
+        outboxMessageIds = response['result']
+        onumMessages = len(outboxMessageIds)
+        print '     OutboxMessages:', str(onumMessages)
+    else:
+        print response['errormsg']
+    # print '     Message.dat:', str(boxSize)
+    # print '     knownNodes.dat:', str(knownNodes)
+    # print '     debug.log:', str(debugSize)
+
+    print '     ------------------------------'
+
+    return ''
 
 
 def shutdown():
     """Shutdown the API"""
 
-    try:
-        api.shutdown()
-    except socket.error:
-        pass
-    print "\nShutdown command relayed\n"
+    print '     Shutdown command sending...'
+    response = api.shutdown()
+    if response['error'] != 0:
+        return response['errormsg']
+
+    return '\n     ' + response['result']
 
 
-def UI(usrInput):
+def start_daemon(uri=''):
+
+    start_dir = os.path.dirname(os.path.abspath(__file__))
+    mainfile = os.path.join(start_dir, 'bitmessagemain.py')
+    print "     Try to start daemon: %s..." % uri
+    if os.path.isfile(mainfile):
+        cmd = ' '.join([sys.executable, mainfile, '--daemon'])
+        print '\n     Exec:', cmd, uri
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+        out, err = p.communicate()
+        result = out.split('\n')
+        for line in result:
+            print '     ' + line
+    else:
+        print '     ' + retStrings['nomain']
+
+
+def UI(cmdInput=None):
     """Main user menu"""
 
-    global usrPrompt
+    global usrPrompt, inputShorts, cmdShorts, retStrings, bms_allow
 
-    if usrInput == "help" or usrInput == "h" or usrInput == "?":
-        print ' '
-        print '     -------------------------------------------------------------------------'
-        print '     |        https://github.com/Dokument/PyBitmessage-Daemon                |'
-        print '     |-----------------------------------------------------------------------|'
-        print '     | Command                | Description                                  |'
-        print '     |------------------------|----------------------------------------------|'
-        print '     | help                   | This help file.                              |'
-        print '     | apiTest                | Tests the API                                |'
-        print '     | addInfo                | Returns address information (If valid)       |'
-        print '     | bmSettings             | BitMessage settings                          |'
-        print '     | exit                   | Use anytime to return to main menu           |'
-        print '     | quit                   | Quits the program                            |'
-        print '     |------------------------|----------------------------------------------|'
-        print '     | listAddresses          | Lists all of the users addresses             |'
-        print '     | generateAddress        | Generates a new address                      |'
-        print '     | getAddress             | Get determinist address from passphrase      |'
-        print '     |------------------------|----------------------------------------------|'
-        print '     | listAddressBookEntries | Lists entries from the Address Book          |'
-        print '     | addAddressBookEntry    | Add address to the Address Book              |'
-        print '     | deleteAddressBookEntry | Deletes address from the Address Book        |'
-        print '     |------------------------|----------------------------------------------|'
-        print '     | subscribe              | Subscribes to an address                     |'
-        print '     | unsubscribe            | Unsubscribes from an address                 |'
-        print '     |------------------------|----------------------------------------------|'
-        print '     | create                 | Creates a channel                            |'
-        print '     | join                   | Joins a channel                              |'
-        print '     | leave                  | Leaves a channel                             |'
-        print '     |------------------------|----------------------------------------------|'
-        print '     | inbox                  | Lists the message information for the inbox  |'
-        print '     | outbox                 | Lists the message information for the outbox |'
-        print '     | send                   | Send a new message or broadcast              |'
-        print '     | unread                 | Lists all unread inbox messages              |'
-        print '     | read                   | Reads a message from the inbox or outbox     |'
-        print '     | save                   | Saves message to text file                   |'
-        print '     | delete                 | Deletes a message or all messages            |'
-        print '     -------------------------------------------------------------------------'
-        print ' '
-        main()
+    src = 'MUST WRONG'
+    uInput = ''
 
-    elif usrInput == "apitest":  # tests the API Connection.
-        if apiTest():
-            print '\n     API connection test has: PASSED\n'
+    if not any(cmdShorts):
+        if not cmdGuess():
+            raise SystemExit('\n     Bye\n')
+
+    if cmdInput in cmdShorts['help']:
+        src = showCmdTbl()
+
+    elif cmdInput in cmdShorts['daemon']:
+        src = start_daemon(getattr(config, 'start_daemon', ''))
+
+    elif cmdInput in cmdShorts['apiTest']:  # tests the API Connection.
+        print '     API connection test has:',
+        print 'PASSED' if apiTest() else 'FAILED\n'
+        src = ''
+
+    elif cmdInput in cmdShorts['addInfo']:
+        while uInput == '':
+            uInput = userInput('Input the Bitmessage Address.')
+        src = addInfo(uInput)
+
+    elif cmdInput in cmdShorts['bmSettings']:  # tests the API Connection.
+        if bms_allow is True:
+            if hasattr(conninit, 'main') and hasattr(conninit, 'bmSettings'):
+                src = conninit.bmSettings()
+            else:
+                src = '\n     Depends moudle changed, calling dismissed.'
         else:
-            print '\n     API connection test has: FAILED\n'
-        main()
+            src = '     ' + retStrings['bmsnotallow']
 
-    elif usrInput == "addinfo":
-        tmp_address = userInput('\nEnter the Bitmessage Address.')
-        address_information = json.loads(api.decodeAddress(tmp_address))
+    elif cmdInput in cmdShorts['quit']:  # Quits the application
+        raise SystemExit('\n     Bye\n')
 
-        print '\n------------------------------'
+    elif cmdInput in cmdShorts['listAddresses']:  # Lists all of the identities in the addressbook
+        src = listAdd()
 
-        if 'success' in str(address_information['status']).lower():
-            print ' Valid Address'
-            print ' Address Version: %s' % str(address_information['addressVersion'])
-            print ' Stream Number: %s' % str(address_information['streamNumber'])
-        else:
-            print ' Invalid Address !'
+    elif cmdInput in cmdShorts['newAddress']:  # Generates a new address
+        uInput = userInput('Would you like to create a (d)eterministic or (R)andom address?').lower()
 
-        print '------------------------------\n'
-        main()
-
-    elif usrInput == "bmsettings":  # tests the API Connection.
-        bmSettings()
-        print ' '
-        main()
-
-    elif usrInput == "quit":  # Quits the application
-        print '\n     Bye\n'
-        sys.exit(0)
-
-    elif usrInput == "listaddresses":  # Lists all of the identities in the addressbook
-        listAdd()
-        main()
-
-    elif usrInput == "generateaddress":  # Generates a new address
-        uInput = userInput('\nWould you like to create a (D)eterministic or (R)andom address?').lower()
-
-        if uInput in ["d", "deterministic"]:  # Creates a deterministic address
+        if uInput in inputShorts['deterministic']:  # Creates a deterministic address
             deterministic = True
 
             lbl = ''
-            passphrase = userInput('Enter the Passphrase.')  # .encode('base64')
+            passphrase = userInput('Input the Passphrase.')  # .encode('base64')
             numOfAdd = int(userInput('How many addresses would you like to generate?'))
             addVNum = 3
             streamNum = 1
-            isRipe = userInput('Shorten the address, (Y)es or (N)o?').lower()
+            isRipe = userInput('Shorten the address, (Y)es or no?').lower()
 
-            if isRipe == "y":
+            if isRipe in inputShorts['yes']:
                 ripe = True
-                print genAdd(lbl, deterministic, passphrase, numOfAdd, addVNum, streamNum, ripe)
-                main()
-            elif isRipe == "n":
+                src = genAdd(lbl, deterministic, passphrase, numOfAdd, addVNum, streamNum, ripe)
+
+            else:
                 ripe = False
-                print genAdd(lbl, deterministic, passphrase, numOfAdd, addVNum, streamNum, ripe)
-                main()
-            elif isRipe == "exit":
-                usrPrompt = 1
-                main()
-            else:
-                print '\n     Invalid input\n'
-                main()
+                src = genAdd(lbl, deterministic, passphrase, numOfAdd, addVNum, streamNum, ripe)
 
-        elif uInput == "r" or uInput == "random":  # Creates a random address with user-defined label
+        else:  # Creates a random address with user-defined label
             deterministic = False
-            null = ''
-            lbl = userInput('Enter the label for the new address.')
+            lbl = null = None
+            while lbl is None:
+                lbl = userInput('Input the label for the new address.')
+            src = genAdd(lbl, deterministic, null, null, null, null, null)
 
-            print genAdd(lbl, deterministic, null, null, null, null, null)
-            main()
+    elif cmdInput in cmdShorts['getAddress']:  # Gets the address for/from a passphrase
+        while len(uInput) < 6:
+            uInput = userInput('Input a strong address passphrase.[6-]')
+        src = getAddress(uInput, 4, 1)
+
+    elif cmdInput in cmdShorts['subscribe']:  # Subsribe to an address
+        address = inputAddress('What address would you like to subscribe?')
+        while uInput == '':
+            uInput = userInput('Enter a label for this address.')
+        src = subscribe(address, uInput)
+
+    elif cmdInput in cmdShorts['unsubscribe']:  # Unsubscribe from an address
+        address = inputAddress("What address would you like to unsubscribe from?")
+        uInput = userInput('Are you sure to unsubscribe: [%s]?' % address)
+        if uInput in inputShorts['yes']:
+            src = unsubscribe(address)
+
+    elif cmdInput in cmdShorts['listsubscrips']:  # Unsubscribe from an address
+        src = listSubscriptions()
+
+    elif cmdInput in cmdShorts['create']:
+        while uInput == '':
+            uInput = userInput('Enter channel name')
+        src = createChan(uInput)
+
+    elif cmdInput in cmdShorts['join']:
+        src = joinChan()
+
+    elif cmdInput in cmdShorts['leave']:
+        src = leaveChan()
+
+    elif cmdInput in cmdShorts['getLabel']:  # Retrieve all of the addressbooks
+        src = getLabel()
+        print src,
+        src = listAddressBK(True)
+
+    elif cmdInput in cmdShorts['inbox']:
+        src = inbox(False)
+
+    elif cmdInput in cmdShorts['news']:
+        src = inbox(True)
+
+    elif cmdInput in cmdShorts['outbox']:
+        src = outbox()
+
+    elif cmdInput in cmdShorts['send']:  # Sends a message or broadcast
+        uInput = userInput('Would you like to send a (b)roadcast or (M)essage?').lower()
+        null = ''
+        if uInput in inputShorts['broadcast']:
+            src = sendBrd(null, null, null)
+        else:
+            src = sendMsg(null, null, null, null)
+
+    elif cmdInput in cmdShorts['delete']:
+        withAtta = True
+        uInput = userInput('Would you like to delete message(s) from the (i)nbox or (O)utbox?').lower()
+
+        if uInput in inputShorts['inbox']:
+            src = toReadInbox(cmd='delete', withAtta=withAtta)
 
         else:
-            print '\n     Invalid input\n'
-            main()
+            src = toReadOutbox(cmd='delete', withAtta=withAtta)
 
-    elif usrInput == "getaddress":  # Gets the address for/from a passphrase
-        phrase = userInput("Enter the address passphrase.")
-        print '\n     Working...\n'
-        address = getAddress(phrase, 4, 1)  # ,vNumber,sNumber)
-        print '\n     Address: ' + address + '\n'
-        usrPrompt = 1
-        main()
+    elif cmdInput in cmdShorts['read']:  # Opens a message from the inbox for viewing.
+        withAtta = False
+        uInput = userInput('Would you like to read a message from the (i)nbox or (O)utbox?').lower()
 
-    elif usrInput == "subscribe":  # Subsribe to an address
-        subscribe()
-        usrPrompt = 1
-        main()
+        if uInput in inputShorts['inbox']:
+            src = toReadInbox(cmd='read', withAtta=withAtta)
 
-    elif usrInput == "unsubscribe":  # Unsubscribe from an address
-        unsubscribe()
-        usrPrompt = 1
-        main()
-
-    elif usrInput == "listsubscriptions":  # Unsubscribe from an address
-        listSubscriptions()
-        usrPrompt = 1
-        main()
-
-    elif usrInput == "create":
-        createChan()
-        usrPrompt = 1
-        main()
-
-    elif usrInput == "join":
-        joinChan()
-        usrPrompt = 1
-        main()
-
-    elif usrInput == "leave":
-        leaveChan()
-        usrPrompt = 1
-        main()
-
-    elif usrInput == "inbox":
-        print '\n     Loading...\n'
-        inbox()
-        main()
-
-    elif usrInput == "unread":
-        print '\n     Loading...\n'
-        inbox(True)
-        main()
-
-    elif usrInput == "outbox":
-        print '\n     Loading...\n'
-        outbox()
-        main()
-
-    elif usrInput == 'send':  # Sends a message or broadcast
-        uInput = userInput('Would you like to send a (M)essage or (B)roadcast?').lower()
-
-        if (uInput == 'm' or uInput == 'message'):
-            null = ''
-            sendMsg(null, null, null, null)
-            main()
-        elif (uInput == 'b' or uInput == 'broadcast'):
-            null = ''
-            sendBrd(null, null, null)
-            main()
-
-    elif usrInput == "read":  # Opens a message from the inbox for viewing.
-
-        uInput = userInput("Would you like to read a message from the (I)nbox or (O)utbox?").lower()
-
-        if (uInput != 'i' and uInput != 'inbox' and uInput != 'o' and uInput != 'outbox'):
-            print '\n     Invalid Input.\n'
-            usrPrompt = 1
-            main()
-
-        msgNum = int(userInput("What is the number of the message you wish to open?"))
-
-        if (uInput == 'i' or uInput == 'inbox'):
-            print '\n     Loading...\n'
-            messageID = readMsg(msgNum)
-
-            uInput = userInput("\nWould you like to keep this message unread, (Y)es or (N)o?").lower()
-
-            if not (uInput == 'y' or uInput == 'yes'):
-                markMessageRead(messageID)
-                usrPrompt = 1
-
-            uInput = userInput("\nWould you like to (D)elete, (F)orward, (R)eply to, or (Exit) this message?").lower()
-
-            if uInput in ['r', 'reply']:
-                print '\n     Loading...\n'
-                print ' '
-                replyMsg(msgNum, 'reply')
-                usrPrompt = 1
-
-            elif uInput == 'f' or uInput == 'forward':
-                print '\n     Loading...\n'
-                print ' '
-                replyMsg(msgNum, 'forward')
-                usrPrompt = 1
-
-            elif uInput in ["d", 'delete']:
-                uInput = userInput("Are you sure, (Y)es or (N)o?").lower()  # Prevent accidental deletion
-
-                if uInput == "y":
-                    delMsg(msgNum)
-                    print '\n     Message Deleted.\n'
-                    usrPrompt = 1
-                else:
-                    usrPrompt = 1
-            else:
-                print '\n     Invalid entry\n'
-                usrPrompt = 1
-
-        elif (uInput == 'o' or uInput == 'outbox'):
-            readSentMsg(msgNum)
-
-            # Gives the user the option to delete the message
-            uInput = userInput("Would you like to (D)elete, or (Exit) this message?").lower()
-
-            if (uInput == "d" or uInput == 'delete'):
-                uInput = userInput('Are you sure, (Y)es or (N)o?').lower()  # Prevent accidental deletion
-
-                if uInput == "y":
-                    delSentMsg(msgNum)
-                    print '\n     Message Deleted.\n'
-                    usrPrompt = 1
-                else:
-                    usrPrompt = 1
-            else:
-                print '\n     Invalid Entry\n'
-                usrPrompt = 1
-
-        main()
-
-    elif usrInput == "save":
-
-        uInput = userInput("Would you like to save a message from the (I)nbox or (O)utbox?").lower()
-
-        if uInput not in ['i', 'inbox', 'o', 'outbox']:
-            print '\n     Invalid Input.\n'
-            usrPrompt = 1
-            main()
-
-        if uInput in ['i', 'inbox']:
-            inboxMessages = json.loads(api.getAllInboxMessages())
-            numMessages = len(inboxMessages['inboxMessages'])
-
-            while True:
-                msgNum = int(userInput("What is the number of the message you wish to save?"))
-
-                if msgNum >= numMessages:
-                    print '\n     Invalid Message Number.\n'
-                else:
-                    break
-
-            subject = inboxMessages['inboxMessages'][msgNum]['subject'].decode('base64')
-            # Don't decode since it is done in the saveFile function
-            message = inboxMessages['inboxMessages'][msgNum]['message']
-
-        elif uInput == 'o' or uInput == 'outbox':
-            outboxMessages = json.loads(api.getAllSentMessages())
-            numMessages = len(outboxMessages['sentMessages'])
-
-            while True:
-                msgNum = int(userInput("What is the number of the message you wish to save?"))
-
-                if msgNum >= numMessages:
-                    print '\n     Invalid Message Number.\n'
-                else:
-                    break
-
-            subject = outboxMessages['sentMessages'][msgNum]['subject'].decode('base64')
-            # Don't decode since it is done in the saveFile function
-            message = outboxMessages['sentMessages'][msgNum]['message']
-
-        subject = subject + '.txt'
-        saveFile(subject, message)
-
-        usrPrompt = 1
-        main()
-
-    elif usrInput == "delete":  # will delete a message from the system, not reflected on the UI.
-
-        uInput = userInput("Would you like to delete a message from the (I)nbox or (O)utbox?").lower()
-
-        if uInput in ['i', 'inbox']:
-            inboxMessages = json.loads(api.getAllInboxMessages())
-            numMessages = len(inboxMessages['inboxMessages'])
-
-            while True:
-                msgNum = userInput(
-                    'Enter the number of the message you wish to delete or (A)ll to empty the inbox.').lower()
-
-                if msgNum == 'a' or msgNum == 'all':
-                    break
-                elif int(msgNum) >= numMessages:
-                    print '\n     Invalid Message Number.\n'
-                else:
-                    break
-
-            uInput = userInput("Are you sure, (Y)es or (N)o?").lower()  # Prevent accidental deletion
-
-            if uInput == "y":
-                if msgNum in ['a', 'all']:
-                    print ' '
-                    for msgNum in range(0, numMessages):  # processes all of the messages in the inbox
-                        print '     Deleting message ', msgNum + 1, ' of ', numMessages
-                        delMsg(0)
-
-                    print '\n     Inbox is empty.'
-                    usrPrompt = 1
-                else:
-                    delMsg(int(msgNum))
-
-                print '\n     Notice: Message numbers may have changed.\n'
-                main()
-            else:
-                usrPrompt = 1
-
-        elif uInput in ['o', 'outbox']:
-            outboxMessages = json.loads(api.getAllSentMessages())
-            numMessages = len(outboxMessages['sentMessages'])
-
-            while True:
-                msgNum = userInput(
-                    'Enter the number of the message you wish to delete or (A)ll to empty the inbox.').lower()
-
-                if msgNum in ['a', 'all']:
-                    break
-                elif int(msgNum) >= numMessages:
-                    print '\n     Invalid Message Number.\n'
-                else:
-                    break
-
-            uInput = userInput("Are you sure, (Y)es or (N)o?").lower()  # Prevent accidental deletion
-
-            if uInput == "y":
-                if msgNum in ['a', 'all']:
-                    print ' '
-                    for msgNum in range(0, numMessages):  # processes all of the messages in the outbox
-                        print '     Deleting message ', msgNum + 1, ' of ', numMessages
-                        delSentMsg(0)
-
-                    print '\n     Outbox is empty.'
-                    usrPrompt = 1
-                else:
-                    delSentMsg(int(msgNum))
-                print '\n     Notice: Message numbers may have changed.\n'
-                main()
-            else:
-                usrPrompt = 1
         else:
-            print '\n     Invalid Entry.\n'
-            usrPrompt = 1
-            main()
+            src = toReadOutbox(cmd='read', withAtta=withAtta)
 
-    elif usrInput == "exit":
-        print '\n     You are already at the main menu. Use "quit" to quit.\n'
-        usrPrompt = 1
-        main()
+    elif cmdInput in cmdShorts['save']:
+        uInput = userInput('Would you like to save a message from the (i)nbox or (O)utbox?').lower()
 
-    elif usrInput == "listaddressbookentries":
-        res = listAddressBookEntries()
-        if res == 20:
-            print '\n     Error: API function not supported.\n'
-        usrPrompt = 1
-        main()
+        if uInput in inputShorts['inbox']:
+            withAtta = True
+            uInput = userInput('Would you like to decode and (s)ave or (D)ump directly?').lower()
+            if uInput in inputShorts['save']:
+                withAtta = False
+            src = toReadInbox(cmd='save', trunck=-1, withAtta=withAtta)
 
-    elif usrInput == "addaddressbookentry":
-        address = userInput('Enter address')
-        label = userInput('Enter label')
-        res = addAddressToAddressBook(address, label)
-        if res == 16:
-            print '\n     Error: Address already exists in Address Book.\n'
-        if res == 20:
-            print '\n     Error: API function not supported.\n'
-        usrPrompt = 1
-        main()
+        else:
+            withAtta = True
+            uInput = userInput('Would you like to decode and (s)ave or (D)ump directly?').lower()
+            if uInput in inputShorts['save']:
+                withAtta = False
 
-    elif usrInput == "deleteaddressbookentry":
-        address = userInput('Enter address')
-        res = deleteAddressFromAddressBook(address)
-        if res == 20:
-            print '\n     Error: API function not supported.\n'
-        usrPrompt = 1
-        main()
+            src = toReadOutbox(cmd='save', trunck=-1, withAtta=withAtta)
 
-    elif usrInput == "markallmessagesread":
-        markAllMessagesRead()
-        usrPrompt = 1
-        main()
+    elif cmdInput in cmdShorts['quit']:
+        src = '\n     You are already at the main menu. Use "quit" to quit.\n'
 
-    elif usrInput == "markallmessagesunread":
-        markAllMessagesUnread()
-        usrPrompt = 1
-        main()
+    elif cmdInput in cmdShorts['listAddressBK']:
+        src = listAddressBK()
 
-    elif usrInput == "status":
-        clientStatus()
-        usrPrompt = 1
-        main()
+    elif cmdInput in cmdShorts['addAddressBK']:
+        label = ''
+        while uInput == '':
+            uInput = userInput('Enter address to add.')
+        while label == '':
+            label = userInput('Enter label')
+        src = addAddressToAddressBook(uInput, label)
 
-    elif usrInput == "shutdown":
-        shutdown()
-        usrPrompt = 1
-        main()
+    elif cmdInput in cmdShorts['delAddressBK']:
+        while uInput == '':
+            uInput = userInput('Enter address to delete.')
+        src = deleteAddressFromAddressBook(uInput)
+
+    elif cmdInput in cmdShorts['readAll']:
+        src = markAllMessagesReadbit(True)
+
+    elif cmdInput in cmdShorts['unreadAll']:
+        src = markAllMessagesReadbit(False)
+
+    elif cmdInput in cmdShorts['status']:
+        src = clientStatus()
+
+    elif cmdInput in cmdShorts['shutdown']:
+        src = shutdown()
 
     else:
-        print '\n     "', usrInput, '" is not a command.\n'
+        src = '\n     "' + cmdInput + '" is not a command.\n'
+
+    if src is None or src == '':
+        src = retStrings['none']
         usrPrompt = 1
-        main()
+    elif 'Connection' in src or 'ProtocolError' in src:
+        usrPrompt = 0
+    else:
+        usrPrompt = 1
+
+    print src
 
 
-def main():
+def CLI():
     """Entrypoint for the CLI app"""
 
-    global api
-    global usrPrompt
+    global usrPrompt, config, api, cmdStr
 
     if usrPrompt == 0:
-        print '\n     ------------------------------'
-        print '     | Bitmessage Daemon by .dok  |'
-        print '     | Version 0.3.1 for BM 0.6.2 |'
-        print '     ------------------------------'
-        api = xmlrpclib.ServerProxy(apiData())  # Connect to BitMessage using these api credentials
+        if config.conn:
+            api = BMAPIWrapper(config.conn, config.proxy)
+            # api.set_proxy(config.proxy)
+            if apiTest() is False:
+                print
+                print '     ****************************************************************'
+                print '        WARNING: You are not connected to the Bitmessage API service.'
+                print '     Either Bitmessage is not running or your settings are incorrect.'
+                print '     Use the command "apiTest" or "bmSettings" to resolve this issue.'
+                print '     ****************************************************************\n'
 
-        if apiTest() is False:
-            print '\n     ****************************************************************'
-            print '        WARNING: You are not connected to the Bitmessage client.'
-            print '     Either Bitmessage is not running or your settings are incorrect.'
-            print '     Use the command "apiTest" or "bmSettings" to resolve this issue.'
-            print '     ****************************************************************\n'
-
-        print 'Type (H)elp for a list of commands.'  # Startup message
-        usrPrompt = 2
+            print '\nType (H)elp for a list of commands.\nPress Enter for default cmd [%s]: ' % cmdStr  # Startup message
+            usrPrompt = 2
+        else:
+            print
+            print '     *****************************************************'
+            print '        WARNING: API not functionable till you finish the'
+            print '     configuration.'
+            print '     *****************************************************\n'
+            print '\nType (H)elp for a list of commands.\nPress Enter for default cmd [%s]: ' % cmdStr  # Startup message
+            usrPrompt = 0
 
     elif usrPrompt == 1:
-        print '\nType (H)elp for a list of commands.'  # Startup message
+        print '\nType (H)elp for a list of commands.\nPress Enter for default cmd [%s]: ' % cmdStr  # Startup message
         usrPrompt = 2
 
     try:
-        UI((raw_input('>').lower()).replace(" ", ""))
+        cmdInput = raw_input('>').lower().replace(" ", "")
+        if cmdInput != '':
+            cmdStr = cmdInput  # save as last cmd for replay
+        UI(cmdStr)
+
     except EOFError:
         UI("quit")
 
 
 if __name__ == "__main__":
-    main()
+    config = Config(sys.argv)
+    config.parse()
+    bms_allow = False
+    socks_allow = False
+    if not config.arguments:  # Config parse failed, show the help screen and exit
+        config.parse()
+
+    if config.action == 'main':
+        try:
+            print '- Try to get API connect uri from BMs setting file "keys.dat"...'
+            import bmsettings as conninit
+            bms_allow = True
+            if hasattr(conninit, 'apiData'):
+                config.conn = conninit.apiData()
+                print '     BMs host uri:', config.conn, '\n'
+        except Exception as err:
+            print '     Depends check failed, command "bmSettings" disabled. (%s)' % err
+            pass
+
+        try:
+            print '- Try to get socks module for proxied...'
+            from socks import ProxyError, GeneralProxyError, Socks5AuthError, Socks5Error, Socks4Error, HTTPError
+            import socks
+            if hasattr(socks, 'setdefaultproxy'):
+                socks_allow = True
+            else:
+                print '     Not the correct "socks" module imported.'
+        except ImportError as err:
+            print '     Depends check failed, "SOCKS" type proxy disabled. (%s)' % err
+
+    if getattr(config, 'start_daemon'):
+        start_daemon(getattr(config, 'start_daemon'))
+
+    socks_type = getattr(config, 'proxy_type', 'none')
+    proxy = dict()
+    if socks_type != 'none':
+        if socks_allow is False and 'SOCKS' in socks_type:
+            print '     Socks type proxy disabled.'
+        else:
+            for key in ['proxy_type', 'proxy_path', 'proxy_username', 'proxy_password', 'proxy_remotedns', 'proxy_timeout']:
+                proxy[key] = getattr(config, key)
+    config.proxy = proxy
+    if getattr(config, 'api_path', None):
+        if getattr(config, 'api_username', None) and getattr(config, 'api_password', None):
+            config.conn = '%s://%s:%s@%s/' % (config.api_type, config.api_username, config.api_password, config.api_path)
+        else:
+            config.conn = '%s://%s/' % (config.api_type, config.api_path)
+
+    actions = Actions()
+    start()
+    print 'bye'
+    sys.exit()

--- a/src/bitmessagecli.py
+++ b/src/bitmessagecli.py
@@ -230,7 +230,7 @@ class Config(object):
         self.argv = argv
         self.action = None
         self.config_file = "client.dat"  # for initial default value
-        self.conn = 'HTTP://127.0.0.1:8445/'  # default API uri
+        self.conn = 'HTTP://127.0.0.1:8442/'  # default API uri
         self.createParser()
         self.createArguments()
 
@@ -261,7 +261,7 @@ class Config(object):
         # action = self.subparsers.add_parser('api', help='Set API settings.')
         action.add_argument('--api_username', help='BMs API basic auth user name.', default=None, metavar='username')
         action.add_argument('--api_password', help='BMs API basic auth password.', default=None, metavar='password')
-        action.add_argument('--api_path', help='BMs API host address.', default='127.0.0.1:8445', metavar='ip:port')
+        action.add_argument('--api_path', help='BMs API host address.', default=None, metavar='ip:port')
         action.add_argument('--api_type', help='BMs API hosts type.', default='HTTP', choices=["HTTP", "HTTPS"])
 
         # proxy settings
@@ -2413,11 +2413,13 @@ if __name__ == "__main__":
             import bmsettings as conninit
             bms_allow = True
             if hasattr(conninit, 'apiData'):
-                config.conn = conninit.apiData()
-                print '     BMs host uri:', config.conn, '\n'
+                apiData = conninit.apiData()
+                print '     BMs host uri from "keys.dat":', apiData, '\n'
+                if apiData:
+                    config.conn = apiData
+
         except Exception as err:
             print '     Depends check failed, command "bmSettings" disabled. (%s)' % err
-            pass
 
         try:
             print '- Try to get socks module for proxied...'
@@ -2443,10 +2445,25 @@ if __name__ == "__main__":
                 proxy[key] = getattr(config, key)
     config.proxy = proxy
     if getattr(config, 'api_path', None):
+        print '- API settings from command line or overide by "client.dat".'
         if getattr(config, 'api_username', None) and getattr(config, 'api_password', None):
             config.conn = '%s://%s:%s@%s/' % (config.api_type, config.api_username, config.api_password, config.api_path)
         else:
             config.conn = '%s://%s/' % (config.api_type, config.api_path)
+    elif config.conn:  # default or from "keys.dat"
+        print '- API settings from BMs config file "keys.dat" or default.'
+        uri = config.conn
+        scheme, netloc, path, x, xx, xxx = urlparse(uri)
+        api_username = urlparse(uri).username
+        api_password = urlparse(uri).password
+        is_https = scheme == 'https'
+        config.api_type = 'HTTPS' if is_https else 'HTTP'
+        if api_username and api_password:
+            config.api_username = api_username
+            config.api_password = api_password
+            netloc = netloc.split('@')[1]
+
+        config.api_path = netloc
 
     actions = Actions()
     start()

--- a/src/bitmessagecli.py
+++ b/src/bitmessagecli.py
@@ -261,7 +261,7 @@ class Config(object):
         # action = self.subparsers.add_parser('api', help='Set API settings.')
         action.add_argument('--api_username', help='BMs API basic auth user name.', default=None, metavar='username')
         action.add_argument('--api_password', help='BMs API basic auth password.', default=None, metavar='password')
-        action.add_argument('--api_path', help='BMs API host address.', default=self.conn, metavar='ip:port')
+        action.add_argument('--api_path', help='BMs API host address.', default='127.0.0.1:8445', metavar='ip:port')
         action.add_argument('--api_type', help='BMs API hosts type.', default='HTTP', choices=["HTTP", "HTTPS"])
 
         # proxy settings
@@ -630,12 +630,12 @@ class Proxiedxmlrpclib(xmlrpclib.ServerProxy):
                  allow_none=0, use_datetime=0, timeout=None, proxy=None):
 
         scheme, netloc, path, x, xx, xxx = urlparse(uri)
-        api_username = unquote(urlparse(uri).username)
-        api_password = unquote(urlparse(uri).password)
+        api_username = urlparse(uri).username
+        api_password = urlparse(uri).password
         api_cred = None
         self.uri = uri
         if api_username and api_password:
-            api_cred = base64.encodestring('%s:%s' % (api_username, api_password)).strip()
+            api_cred = base64.encodestring('%s:%s' % (unquote(api_username), unquote(api_password))).strip()
             netloc = netloc.split('@')[1]
 
         if transport is None and (timeout or proxy):

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -33,7 +33,7 @@ from time import sleep
 from random import randint
 import getopt
 
-from api import MySimpleXMLRPCRequestHandler, StoppableXMLRPCServer
+from api import StoppableXMLRPCServer
 from helper_startup import (
     isOurOperatingSystemLimitedToHavingVeryFewHalfOpenConnections
 )
@@ -188,7 +188,9 @@ class singleAPI(threading.Thread, helper_threading.StoppableThread):
                     (BMConfigParser().get(
                         'bitmessagesettings', 'apiinterface'),
                      port),
-                    MySimpleXMLRPCRequestHandler, True, True)
+                    True, True)
+                sa = se.socket.getsockname()
+                print('Serving API on %s, port %d' % (sa[0], sa[1]))
             except socket.error as e:
                 if e.errno in (errno.EADDRINUSE, errno.WSAEADDRINUSE):
                     continue
@@ -198,7 +200,6 @@ class singleAPI(threading.Thread, helper_threading.StoppableThread):
                         "bitmessagesettings", "apiport", str(port))
                     BMConfigParser().save()
                 break
-        se.register_introspection_functions()
         se.serve_forever()
 
 
@@ -472,8 +473,8 @@ class Main:
         # signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     def usage(self):
-        print 'Usage: ' + sys.argv[0] + ' [OPTIONS]'
-        print '''
+        print('Usage: ' + sys.argv[0] + ' [OPTIONS]')
+        print('''
 Options:
   -h, --help            show this help message and exit
   -c, --curses          use curses (text mode) interface
@@ -481,7 +482,7 @@ Options:
   -t, --test            dryrun, make testing
 
 All parameters are optional.
-'''
+''')
 
     def stop(self):
         with shared.printLock:

--- a/src/bmsettings.py
+++ b/src/bmsettings.py
@@ -17,7 +17,12 @@ import sys
 import os
 
 from bmconfigparser import BMConfigParser
-import ConfigParser
+try:
+    import ConfigParser as ConfigParser
+    from urllib import quote
+except ImportError:
+    import configparser as ConfigParser
+    from urllib.parse import quote
 
 keysName = 'keys.dat'
 keysPath = 'keys.dat'
@@ -26,7 +31,7 @@ keysPath = 'keys.dat'
 def userInput(message):
     """Checks input for exit or quit. Also formats for input, etc"""
 
-    print message
+    print(message)
     uInput = raw_input('> ')
 
     return uInput
@@ -65,17 +70,17 @@ def configInit():
     with open(keysName, 'wb') as configfile:
         BMConfigParser().write(configfile)
 
-    print '     {0} Initalized in the same directory as this CLI.\n' \
-            '     You will now need to configure the {0} file.\n'.format(keysName)
+    print('     {0} Initalized in the same directory as this CLI.\n' \
+            '     You will now need to configure the {0} file.\n'.format(keysName))
 
 
 def restartBmNotify():
     """Prompt the user to restart Bitmessage"""
 
     print
-    print '     *******************************************************************'
-    print '     WARNING: If Bitmessage is running locally, you must restart it now.'
-    print '     *******************************************************************\n'
+    print('     *******************************************************************')
+    print('     WARNING: If Bitmessage is running locally, you must restart it now.')
+    print('     *******************************************************************\n')
 
 
 def apiInit(apiEnabled):
@@ -93,30 +98,30 @@ def apiInit(apiEnabled):
             with open(keysPath, 'wb') as configfile:
                 BMConfigParser().write(configfile)
 
-            print 'Done'
+            print('Done')
             restartBmNotify()
             isValid = True
 
         elif uInput == "n":
             print
-            print '     ************************************************************'
-            print '            Daemon will not work when the API is disabled.       '
-            print '     Please refer to the Bitmessage Wiki on how to setup the API.'
-            print '     ************************************************************\n'
+            print('     ************************************************************')
+            print('            Daemon will not work when the API is disabled.       ')
+            print('     Please refer to the Bitmessage Wiki on how to setup the API.')
+            print('     ************************************************************\n')
 
         else:
-            print '\n     Invalid Entry\n'
+            print('\n     Invalid Entry\n')
 
     elif apiEnabled:  # API correctly setup
         # Everything is as it should be
         isValid = True
 
     else:  # API information was not present.
-        print '\n     ' + str(keysPath) + ' not properly configured!\n'
+        print('\n     ' + str(keysPath) + ' not properly configured!\n')
         uInput = userInput('Would you like to do this now, (Y)es or (N)o?').lower()
 
         if uInput == "y":  # User said yes, initalize the api by writing these values to the keys.dat file
-            print ' '
+            print
 
             apiUsr = userInput("API Username")
             apiPwd = userInput("API Password")
@@ -125,7 +130,7 @@ def apiInit(apiEnabled):
             daemon = userInput("Daemon mode Enabled? (True) or (False)").lower()
 
             if (daemon != 'true' and daemon != 'false'):
-                print '\n     Invalid Entry for Daemon.\n'
+                print('\n     Invalid Entry for Daemon.\n')
 
             # sets the bitmessage port to stop the warning about the api not properly
             # being setup. This is in the event that the keys.dat is in a different
@@ -140,18 +145,18 @@ def apiInit(apiEnabled):
             with open(keysPath, 'wb') as configfile:
                 BMConfigParser().write(configfile)
 
-            print '     Finished configuring the keys.dat file with API information.\n'
+            print('     Finished configuring the keys.dat file with API information.\n')
             restartBmNotify()
             isValid = True
 
         elif uInput == "n":
             print
-            print '     ***********************************************************'
-            print '     Please refer to the Bitmessage Wiki on how to setup the API.'
-            print '     ***********************************************************\n'
+            print('     ***********************************************************')
+            print('     Please refer to the Bitmessage Wiki on how to setup the API.')
+            print('     ***********************************************************\n')
 
         else:
-            print '     \nInvalid entry\n'
+            print('     \nInvalid entry\n')
 
     return isValid
 
@@ -162,7 +167,7 @@ def apiData():
     global keysName
     global keysPath
 
-    print '\n     Configure file searching:', os.path.realpath(keysPath)
+    print('\n     Configure file searching: %s' % os.path.realpath(keysPath))
     BMConfigParser().read(keysPath)  # First try to load the config file (the keys.dat file) from the program directory
 
     try:
@@ -173,7 +178,7 @@ def apiData():
         # Could not load the keys.dat file in the program directory. Perhaps it is in the appdata directory.
         appDataFolder = lookupAppdataFolder()
         keysPath = appDataFolder + keysPath
-        print '\n     Configure file searching:', os.path.realpath(keysPath)
+        print('\n     Configure file searching: %s' % os.path.realpath(keysPath))
         BMConfigParser().read(keysPath)
 
         try:
@@ -181,10 +186,10 @@ def apiData():
         except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as err:
             # keys.dat was not there either, something is wrong.
             print
-            print '     *************************************************************'
-            print '        WARNING: There was a problem on accessing congfigure file.'
-            print '     Make sure that daemon is in the same directory as Bitmessage. '
-            print '     *************************************************************\n'
+            print('     *************************************************************')
+            print('        WARNING: There was a problem on accessing congfigure file.')
+            print('     Make sure that daemon is in the same directory as Bitmessage. ')
+            print('     *************************************************************\n')
 
             finalCheck = False
             uInput = userInput('Would you like to create a "keys.dat" file in current working directory, (Y)es or (N)o?').lower()
@@ -195,10 +200,10 @@ def apiData():
                 f = True
 
             elif (uInput == "n" or uInput == "no"):
-                print '\n     Trying Again.\n'
+                print('\n     Trying Again.\n')
 
             else:
-                print '\n     Invalid Input.\n'
+                print('\n     Invalid Input.\n')
 
             if not finalCheck:
                 return ''
@@ -212,7 +217,7 @@ def apiData():
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as err:
         isValid = apiInit("")  # Initalize the keys.dat file with API information
         if not isValid:
-            print '\n      Config file not valid.\n'
+            print('\n      Config file not valid.\n')
             return ''
 
     # keys.dat file was found or appropriately configured, allow information retrieval
@@ -226,8 +231,8 @@ def apiData():
     apiUsername = BMConfigParser().get('bitmessagesettings', 'apiusername')
     apiPassword = BMConfigParser().get('bitmessagesettings', 'apipassword')
 
-    ret = "http://" + apiUsername + ":" + apiPassword + "@" + apiInterface + ":" + str(apiPort) + "/"
-    print '\n     API data successfully imported.'
+    ret = "http://" + quote(apiUsername) + ":" + quote(apiPassword) + "@" + apiInterface + ":" + str(apiPort) + "/"
+    print('\n     API data successfully imported.')
 
     # Build the api credentials
     return ret
@@ -241,10 +246,10 @@ def bmSettings():
 
     BMConfigParser().read(keysPath)  # Read the keys.dat
     try:
-        print '     Configure file loading:', os.path.realpath(keysPath)
+        print('     Configure file loading: %s' % os.path.realpath(keysPath))
         port = BMConfigParser().get('bitmessagesettings', 'port')
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as err:
-        print '\n     File not found.\n'
+        print('\n     File not found.\n')
         return ''
 
     startonlogon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'startonlogon')
@@ -263,27 +268,27 @@ def bmSettings():
     sockspassword = BMConfigParser().get('bitmessagesettings', 'sockspassword')
 
     print
-    print '     -----------------------------------'
-    print '     |   Current Bitmessage Settings   |'
-    print '     -----------------------------------'
-    print '     port = ' + port
-    print '     startonlogon = ' + str(startonlogon)
-    print '     minimizetotray = ' + str(minimizetotray)
-    print '     showtraynotifications = ' + str(showtraynotifications)
-    print '     startintray = ' + str(startintray)
-    print '     defaultnoncetrialsperbyte = ' + defaultnoncetrialsperbyte
-    print '     defaultpayloadlengthextrabytes = ' + defaultpayloadlengthextrabytes
-    print '     daemon = ' + str(daemon)
-    print '     ------------------------------------'
-    print '     |   Current Connection Settings   |'
-    print '     -----------------------------------'
-    print '     socksproxytype = ' + socksproxytype
-    print '     sockshostname = ' + sockshostname
-    print '     socksport = ' + socksport
-    print '     socksauthentication = ' + str(socksauthentication)
-    print '     socksusername = ' + socksusername
-    print '     sockspassword = ' + sockspassword
-    print ' '
+    print('     -----------------------------------')
+    print('     |   Current Bitmessage Settings   |')
+    print('     -----------------------------------')
+    print('     port = ' + port)
+    print('     startonlogon = ' + str(startonlogon))
+    print('     minimizetotray = ' + str(minimizetotray))
+    print('     showtraynotifications = ' + str(showtraynotifications))
+    print('     startintray = ' + str(startintray))
+    print('     defaultnoncetrialsperbyte = ' + defaultnoncetrialsperbyte)
+    print('     defaultpayloadlengthextrabytes = ' + defaultpayloadlengthextrabytes)
+    print('     daemon = ' + str(daemon))
+    print('     ------------------------------------')
+    print('     |   Current Connection Settings   |')
+    print('     -----------------------------------')
+    print('     socksproxytype = ' + socksproxytype)
+    print('     sockshostname = ' + sockshostname)
+    print('     socksport = ' + socksport)
+    print('     socksauthentication = ' + str(socksauthentication))
+    print('     socksusername = ' + socksusername)
+    print('     sockspassword = ' + sockspassword)
+    print
 
     uInput = userInput('Would you like to modify any of these settings, (n)o or (Y)es?').lower()
 
@@ -291,67 +296,67 @@ def bmSettings():
         while True:  # loops if they mistype the setting name, they can exit the loop with 'exit'
             invalidInput = False
             uInput = userInput('What setting would you like to modify?').lower()
-            print ' '
+            print
 
             if uInput == "port":
-                print '     Current port number: ' + port
+                print('     Current port number: ' + port)
                 uInput = userInput("Input the new port number.")
                 BMConfigParser().set('bitmessagesettings', 'port', str(uInput))
             elif uInput == "startonlogon":
-                print '     Current status: ' + str(startonlogon)
+                print('     Current status: ' + str(startonlogon))
                 uInput = userInput("Input the new status.")
                 BMConfigParser().set('bitmessagesettings', 'startonlogon', str(uInput))
             elif uInput == "minimizetotray":
-                print '     Current status: ' + str(minimizetotray)
+                print('     Current status: ' + str(minimizetotray))
                 uInput = userInput("Input the new status.")
                 BMConfigParser().set('bitmessagesettings', 'minimizetotray', str(uInput))
             elif uInput == "showtraynotifications":
-                print '     Current status: ' + str(showtraynotifications)
+                print('     Current status: ' + str(showtraynotifications))
                 uInput = userInput("Input the new status.")
                 BMConfigParser().set('bitmessagesettings', 'showtraynotifications', str(uInput))
             elif uInput == "startintray":
-                print '     Current status: ' + str(startintray)
+                print('     Current status: ' + str(startintray))
                 uInput = userInput("Input the new status.")
                 BMConfigParser().set('bitmessagesettings', 'startintray', str(uInput))
             elif uInput == "defaultnoncetrialsperbyte":
-                print '     Current default nonce trials per byte: ' + defaultnoncetrialsperbyte
+                print('     Current default nonce trials per byte: ' + defaultnoncetrialsperbyte)
                 uInput = userInput("Input the new defaultnoncetrialsperbyte.")
                 BMConfigParser().set('bitmessagesettings', 'defaultnoncetrialsperbyte', str(uInput))
             elif uInput == "defaultpayloadlengthextrabytes":
-                print '     Current default payload length extra bytes: ' + defaultpayloadlengthextrabytes
+                print('     Current default payload length extra bytes: ' + defaultpayloadlengthextrabytes)
                 uInput = userInput("Input the new defaultpayloadlengthextrabytes.")
                 BMConfigParser().set('bitmessagesettings', 'defaultpayloadlengthextrabytes', str(uInput))
             elif uInput == "daemon":
-                print '     Current status: ' + str(daemon)
+                print('     Current status: ' + str(daemon))
                 uInput = userInput("Input the new status.").lower()
                 BMConfigParser().set('bitmessagesettings', 'daemon', str(uInput))
             elif uInput == "socksproxytype":
-                print '     Current socks proxy type: ' + socksproxytype
-                print "Possibilities: 'none', 'SOCKS4a', 'SOCKS5'."
+                print('     Current socks proxy type: ' + socksproxytype)
+                print("Possibilities: 'none', 'SOCKS4a', 'SOCKS5'.")
                 uInput = userInput("Input the new socksproxytype.")
                 BMConfigParser().set('bitmessagesettings', 'socksproxytype', str(uInput))
             elif uInput == "sockshostname":
-                print '     Current socks host name: ' + sockshostname
+                print('     Current socks host name: ' + sockshostname)
                 uInput = userInput("Input the new sockshostname.")
                 BMConfigParser().set('bitmessagesettings', 'sockshostname', str(uInput))
             elif uInput == "socksport":
-                print '     Current socks port number: ' + socksport
+                print('     Current socks port number: ' + socksport)
                 uInput = userInput("Input the new socksport.")
                 BMConfigParser().set('bitmessagesettings', 'socksport', str(uInput))
             elif uInput == "socksauthentication":
-                print '     Current status: ' + str(socksauthentication)
+                print('     Current status: ' + str(socksauthentication))
                 uInput = userInput("Input the new status.")
                 BMConfigParser().set('bitmessagesettings', 'socksauthentication', str(uInput))
             elif uInput == "socksusername":
-                print '     Current socks username: ' + socksusername
+                print('     Current socks username: ' + socksusername)
                 uInput = userInput("Input the new socksusername.")
                 BMConfigParser().set('bitmessagesettings', 'socksusername', str(uInput))
             elif uInput == "sockspassword":
-                print '     Current socks password: ' + sockspassword
+                print('     Current socks password: ' + sockspassword)
                 uInput = userInput("Input the new password.")
                 BMConfigParser().set('bitmessagesettings', 'sockspassword', str(uInput))
             else:
-                print "\n     Invalid field. Please try again.\n"
+                print("\n     Invalid field. Please try again.\n")
                 invalidInput = True
 
             if invalidInput is not True:  # don't prompt if they made a mistake.

--- a/src/bmsettings.py
+++ b/src/bmsettings.py
@@ -1,0 +1,373 @@
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-lines,global-statement,too-many-branches,too-many-statements,inconsistent-return-statements
+# pylint: disable=too-many-nested-blocks,too-many-locals,protected-access,too-many-arguments,too-many-function-args
+# pylint: disable=no-member
+"""
+Created by Adam Melton (.dok) referenceing https://bitmessage.org/wiki/API_Reference for API documentation
+Distributed under the MIT/X11 software license. See http://www.opensource.org/licenses/mit-license.php.
+
+This is an example of a daemon client for PyBitmessage 0.6.2, by .dok (Version 0.3.1) , modified
+
+TODO: fix the following (currently ignored) violations:
+
+"""
+
+import sys
+import os
+
+from bmconfigparser import BMConfigParser
+import ConfigParser
+
+keysName = 'keys.dat'
+keysPath = 'keys.dat'
+
+
+def userInput(message):
+    """Checks input for exit or quit. Also formats for input, etc"""
+
+    print message
+    uInput = raw_input('> ')
+
+    return uInput
+
+
+def lookupAppdataFolder():
+    """gets the appropriate folders for the .dat files depending on the OS. Taken from bitmessagemain.py"""
+
+    APPNAME = "PyBitmessage"
+    if sys.platform == 'darwin':
+        if "HOME" in os.environ:
+            dataFolder = os.path.join(os.environ["HOME"], "Library/Application support/", APPNAME) + '/'
+        else:
+            print(
+                '     Could not find home folder, please report '
+                'this message and your OS X version to the Daemon Github.')
+            sys.exit(1)
+
+    elif 'win32' in sys.platform or 'win64' in sys.platform:
+        dataFolder = os.path.join(os.environ['APPDATA'], APPNAME) + '\\'
+    else:
+        dataFolder = os.path.expanduser(os.path.join("~", ".config/" + APPNAME + "/"))
+    return dataFolder
+
+
+def configInit():
+    """Initialised the configuration"""
+
+    BMConfigParser().add_section('bitmessagesettings')
+    # Sets the bitmessage port to stop the warning about the api not properly
+    # being setup. This is in the event that the keys.dat is in a different
+    # directory or is created locally to connect to a machine remotely.
+    BMConfigParser().set('bitmessagesettings', 'port', '8444')
+    BMConfigParser().set('bitmessagesettings', 'apienabled', 'true')  # Sets apienabled to true in keys.dat
+
+    with open(keysName, 'wb') as configfile:
+        BMConfigParser().write(configfile)
+
+    print '     {0} Initalized in the same directory as this CLI.\n' \
+            '     You will now need to configure the {0} file.\n'.format(keysName)
+
+
+def restartBmNotify():
+    """Prompt the user to restart Bitmessage"""
+
+    print
+    print '     *******************************************************************'
+    print '     WARNING: If Bitmessage is running locally, you must restart it now.'
+    print '     *******************************************************************\n'
+
+
+def apiInit(apiEnabled):
+    """Initialise the API"""
+
+    global keysPath
+    BMConfigParser().read(keysPath)
+    isValid = False
+
+    if apiEnabled is False:  # API information there but the api is disabled.
+        uInput = userInput('The API is not enabled. Would you like to do that now, (Y)es or (N)o?').lower()
+
+        if uInput == "y":
+            BMConfigParser().set('bitmessagesettings', 'apienabled', 'true')  # Sets apienabled to true in keys.dat
+            with open(keysPath, 'wb') as configfile:
+                BMConfigParser().write(configfile)
+
+            print 'Done'
+            restartBmNotify()
+            isValid = True
+
+        elif uInput == "n":
+            print
+            print '     ************************************************************'
+            print '            Daemon will not work when the API is disabled.       '
+            print '     Please refer to the Bitmessage Wiki on how to setup the API.'
+            print '     ************************************************************\n'
+
+        else:
+            print '\n     Invalid Entry\n'
+
+    elif apiEnabled:  # API correctly setup
+        # Everything is as it should be
+        isValid = True
+
+    else:  # API information was not present.
+        print '\n     ' + str(keysPath) + ' not properly configured!\n'
+        uInput = userInput('Would you like to do this now, (Y)es or (N)o?').lower()
+
+        if uInput == "y":  # User said yes, initalize the api by writing these values to the keys.dat file
+            print ' '
+
+            apiUsr = userInput("API Username")
+            apiPwd = userInput("API Password")
+            apiPort = userInput("API Port")
+            apiEnabled = userInput("API Enabled? (True) or (False)").lower()
+            daemon = userInput("Daemon mode Enabled? (True) or (False)").lower()
+
+            if (daemon != 'true' and daemon != 'false'):
+                print '\n     Invalid Entry for Daemon.\n'
+
+            # sets the bitmessage port to stop the warning about the api not properly
+            # being setup. This is in the event that the keys.dat is in a different
+            # directory or is created locally to connect to a machine remotely.
+            BMConfigParser().set('bitmessagesettings', 'port', '8444')
+            BMConfigParser().set('bitmessagesettings', 'apienabled', 'true')
+            BMConfigParser().set('bitmessagesettings', 'apiport', apiPort)
+            BMConfigParser().set('bitmessagesettings', 'apiinterface', '127.0.0.1')
+            BMConfigParser().set('bitmessagesettings', 'apiusername', apiUsr)
+            BMConfigParser().set('bitmessagesettings', 'apipassword', apiPwd)
+            BMConfigParser().set('bitmessagesettings', 'daemon', daemon)
+            with open(keysPath, 'wb') as configfile:
+                BMConfigParser().write(configfile)
+
+            print '     Finished configuring the keys.dat file with API information.\n'
+            restartBmNotify()
+            isValid = True
+
+        elif uInput == "n":
+            print
+            print '     ***********************************************************'
+            print '     Please refer to the Bitmessage Wiki on how to setup the API.'
+            print '     ***********************************************************\n'
+
+        else:
+            print '     \nInvalid entry\n'
+
+    return isValid
+
+
+def apiData():
+    """TBC"""
+
+    global keysName
+    global keysPath
+
+    print '\n     Configure file searching:', os.path.realpath(keysPath)
+    BMConfigParser().read(keysPath)  # First try to load the config file (the keys.dat file) from the program directory
+
+    try:
+        BMConfigParser().get('bitmessagesettings', 'port')
+        appDataFolder = ''
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as err:
+        pass
+        # Could not load the keys.dat file in the program directory. Perhaps it is in the appdata directory.
+        appDataFolder = lookupAppdataFolder()
+        keysPath = appDataFolder + keysPath
+        print '\n     Configure file searching:', os.path.realpath(keysPath)
+        BMConfigParser().read(keysPath)
+
+        try:
+            BMConfigParser().get('bitmessagesettings', 'port')
+        except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as err:
+            # keys.dat was not there either, something is wrong.
+            print
+            print '     *************************************************************'
+            print '        WARNING: There was a problem on accessing congfigure file.'
+            print '     Make sure that daemon is in the same directory as Bitmessage. '
+            print '     *************************************************************\n'
+
+            finalCheck = False
+            uInput = userInput('Would you like to create a "keys.dat" file in current working directory, (Y)es or (N)o?').lower()
+
+            if (uInput == "y" or uInput == "yes"):
+                configInit()
+                keysPath = keysName
+                f = True
+
+            elif (uInput == "n" or uInput == "no"):
+                print '\n     Trying Again.\n'
+
+            else:
+                print '\n     Invalid Input.\n'
+
+            if not finalCheck:
+                return ''
+
+    try:  # checks to make sure that everyting is configured correctly. Excluding apiEnabled, it is checked after
+        BMConfigParser().get('bitmessagesettings', 'apiport')
+        BMConfigParser().get('bitmessagesettings', 'apiinterface')
+        BMConfigParser().get('bitmessagesettings', 'apiusername')
+        BMConfigParser().get('bitmessagesettings', 'apipassword')
+
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as err:
+        isValid = apiInit("")  # Initalize the keys.dat file with API information
+        if not isValid:
+            print '\n      Config file not valid.\n'
+            return ''
+
+    # keys.dat file was found or appropriately configured, allow information retrieval
+    # apiEnabled =
+    # apiInit(BMConfigParser().safeGetBoolean('bitmessagesettings','apienabled'))
+    # #if false it will prompt the user, if true it will return true
+
+    BMConfigParser().read(keysPath)  # read again since changes have been made
+    apiPort = int(BMConfigParser().get('bitmessagesettings', 'apiport'))
+    apiInterface = BMConfigParser().get('bitmessagesettings', 'apiinterface')
+    apiUsername = BMConfigParser().get('bitmessagesettings', 'apiusername')
+    apiPassword = BMConfigParser().get('bitmessagesettings', 'apipassword')
+
+    ret = "http://" + apiUsername + ":" + apiPassword + "@" + apiInterface + ":" + str(apiPort) + "/"
+    print '\n     API data successfully imported.'
+
+    # Build the api credentials
+    return ret
+
+
+def bmSettings():
+    """Allows the viewing and modification of keys.dat settings."""
+
+    global keysPath
+    global usrPrompt
+
+    BMConfigParser().read(keysPath)  # Read the keys.dat
+    try:
+        print '     Configure file loading:', os.path.realpath(keysPath)
+        port = BMConfigParser().get('bitmessagesettings', 'port')
+    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as err:
+        print '\n     File not found.\n'
+        return ''
+
+    startonlogon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'startonlogon')
+    minimizetotray = BMConfigParser().safeGetBoolean('bitmessagesettings', 'minimizetotray')
+    showtraynotifications = BMConfigParser().safeGetBoolean('bitmessagesettings', 'showtraynotifications')
+    startintray = BMConfigParser().safeGetBoolean('bitmessagesettings', 'startintray')
+    defaultnoncetrialsperbyte = BMConfigParser().get('bitmessagesettings', 'defaultnoncetrialsperbyte')
+    defaultpayloadlengthextrabytes = BMConfigParser().get('bitmessagesettings', 'defaultpayloadlengthextrabytes')
+    daemon = BMConfigParser().safeGetBoolean('bitmessagesettings', 'daemon')
+
+    socksproxytype = BMConfigParser().get('bitmessagesettings', 'socksproxytype')
+    sockshostname = BMConfigParser().get('bitmessagesettings', 'sockshostname')
+    socksport = BMConfigParser().get('bitmessagesettings', 'socksport')
+    socksauthentication = BMConfigParser().safeGetBoolean('bitmessagesettings', 'socksauthentication')
+    socksusername = BMConfigParser().get('bitmessagesettings', 'socksusername')
+    sockspassword = BMConfigParser().get('bitmessagesettings', 'sockspassword')
+
+    print
+    print '     -----------------------------------'
+    print '     |   Current Bitmessage Settings   |'
+    print '     -----------------------------------'
+    print '     port = ' + port
+    print '     startonlogon = ' + str(startonlogon)
+    print '     minimizetotray = ' + str(minimizetotray)
+    print '     showtraynotifications = ' + str(showtraynotifications)
+    print '     startintray = ' + str(startintray)
+    print '     defaultnoncetrialsperbyte = ' + defaultnoncetrialsperbyte
+    print '     defaultpayloadlengthextrabytes = ' + defaultpayloadlengthextrabytes
+    print '     daemon = ' + str(daemon)
+    print '     ------------------------------------'
+    print '     |   Current Connection Settings   |'
+    print '     -----------------------------------'
+    print '     socksproxytype = ' + socksproxytype
+    print '     sockshostname = ' + sockshostname
+    print '     socksport = ' + socksport
+    print '     socksauthentication = ' + str(socksauthentication)
+    print '     socksusername = ' + socksusername
+    print '     sockspassword = ' + sockspassword
+    print ' '
+
+    uInput = userInput('Would you like to modify any of these settings, (n)o or (Y)es?').lower()
+
+    if uInput in ['y', 'yes']:
+        while True:  # loops if they mistype the setting name, they can exit the loop with 'exit'
+            invalidInput = False
+            uInput = userInput('What setting would you like to modify?').lower()
+            print ' '
+
+            if uInput == "port":
+                print '     Current port number: ' + port
+                uInput = userInput("Input the new port number.")
+                BMConfigParser().set('bitmessagesettings', 'port', str(uInput))
+            elif uInput == "startonlogon":
+                print '     Current status: ' + str(startonlogon)
+                uInput = userInput("Input the new status.")
+                BMConfigParser().set('bitmessagesettings', 'startonlogon', str(uInput))
+            elif uInput == "minimizetotray":
+                print '     Current status: ' + str(minimizetotray)
+                uInput = userInput("Input the new status.")
+                BMConfigParser().set('bitmessagesettings', 'minimizetotray', str(uInput))
+            elif uInput == "showtraynotifications":
+                print '     Current status: ' + str(showtraynotifications)
+                uInput = userInput("Input the new status.")
+                BMConfigParser().set('bitmessagesettings', 'showtraynotifications', str(uInput))
+            elif uInput == "startintray":
+                print '     Current status: ' + str(startintray)
+                uInput = userInput("Input the new status.")
+                BMConfigParser().set('bitmessagesettings', 'startintray', str(uInput))
+            elif uInput == "defaultnoncetrialsperbyte":
+                print '     Current default nonce trials per byte: ' + defaultnoncetrialsperbyte
+                uInput = userInput("Input the new defaultnoncetrialsperbyte.")
+                BMConfigParser().set('bitmessagesettings', 'defaultnoncetrialsperbyte', str(uInput))
+            elif uInput == "defaultpayloadlengthextrabytes":
+                print '     Current default payload length extra bytes: ' + defaultpayloadlengthextrabytes
+                uInput = userInput("Input the new defaultpayloadlengthextrabytes.")
+                BMConfigParser().set('bitmessagesettings', 'defaultpayloadlengthextrabytes', str(uInput))
+            elif uInput == "daemon":
+                print '     Current status: ' + str(daemon)
+                uInput = userInput("Input the new status.").lower()
+                BMConfigParser().set('bitmessagesettings', 'daemon', str(uInput))
+            elif uInput == "socksproxytype":
+                print '     Current socks proxy type: ' + socksproxytype
+                print "Possibilities: 'none', 'SOCKS4a', 'SOCKS5'."
+                uInput = userInput("Input the new socksproxytype.")
+                BMConfigParser().set('bitmessagesettings', 'socksproxytype', str(uInput))
+            elif uInput == "sockshostname":
+                print '     Current socks host name: ' + sockshostname
+                uInput = userInput("Input the new sockshostname.")
+                BMConfigParser().set('bitmessagesettings', 'sockshostname', str(uInput))
+            elif uInput == "socksport":
+                print '     Current socks port number: ' + socksport
+                uInput = userInput("Input the new socksport.")
+                BMConfigParser().set('bitmessagesettings', 'socksport', str(uInput))
+            elif uInput == "socksauthentication":
+                print '     Current status: ' + str(socksauthentication)
+                uInput = userInput("Input the new status.")
+                BMConfigParser().set('bitmessagesettings', 'socksauthentication', str(uInput))
+            elif uInput == "socksusername":
+                print '     Current socks username: ' + socksusername
+                uInput = userInput("Input the new socksusername.")
+                BMConfigParser().set('bitmessagesettings', 'socksusername', str(uInput))
+            elif uInput == "sockspassword":
+                print '     Current socks password: ' + sockspassword
+                uInput = userInput("Input the new password.")
+                BMConfigParser().set('bitmessagesettings', 'sockspassword', str(uInput))
+            else:
+                print "\n     Invalid field. Please try again.\n"
+                invalidInput = True
+
+            if invalidInput is not True:  # don't prompt if they made a mistake.
+                uInput = userInput("Would you like to change another setting, (n)o or (Y)es?").lower()
+
+                if uInput in ['n', 'no']:
+                    with open(keysPath, 'wb') as configfile:
+                        src = BMConfigParser().write(configfile)
+                    restartBmNotify()
+                    break
+
+
+def main():
+    apiData()  # configuration file "keys.dat" searching
+    bmSettings()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/class_objectProcessorQueue.py
+++ b/src/class_objectProcessorQueue.py
@@ -1,4 +1,8 @@
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 import threading
 import time
 

--- a/src/class_singleCleaner.py
+++ b/src/class_singleCleaner.py
@@ -134,7 +134,7 @@ class singleCleaner(threading.Thread, StoppableThread):
                                 del knownnodes.knownNodes[stream][node]
                                 continue
                         except TypeError:
-                            print "Error in %s" % node
+                            print("Error in %s" % node)
                     keys = []
 
             # Let us write out the knowNodes to disk

--- a/src/debug.py
+++ b/src/debug.py
@@ -56,10 +56,11 @@ def configureLogging():
             print(
                 'Failed to load logger configuration from %s, using default'
                 ' logging config\n%s' %
-                (os.path.join(state.appdata, 'logging.dat'), sys.exc_info()))
+                os.path.join(state.appdata, 'logging.dat'))
+            sys.exc_info()
         else:
             # no need to confuse the user if the logger config is missing entirely
-            print "Using default logger configuration"
+            print("Using default logger configuration")
 
     sys.excepthook = log_uncaught_exceptions
 

--- a/src/debug.py
+++ b/src/debug.py
@@ -1,26 +1,28 @@
-# -*- coding: utf-8 -*-
 """
 Logging and debuging facility
 =============================
 
 Levels:
-    DEBUG       Detailed information, typically of interest only when
-                diagnosing problems.
-    INFO        Confirmation that things are working as expected.
-    WARNING     An indication that something unexpected happened, or indicative
-                of some problem in the near future (e.g. ‘disk space low’).
-                The software is still working as expected.
-    ERROR       Due to a more serious problem, the software has not been able
-                to perform some function.
-    CRITICAL    A serious error, indicating that the program itself may be
-                unable to continue running.
+
+   DEBUG
+      Detailed information, typically of interest only when diagnosing problems.
+   INFO
+      Confirmation that things are working as expected.
+   WARNING
+      An indication that something unexpected happened, or indicative of some problem in the
+      near future (e.g. 'disk space low'). The software is still working as expected.
+   ERROR
+      Due to a more serious problem, the software has not been able to perform some function.
+   CRITICAL
+      A serious error, indicating that the program itself may be unable to continue running.
 
 There are three loggers: `console_only`, `file_only` and `both`.
 
-Use: `from debug import logger` to import this facility into whatever module
-     you wish to log messages from. Logging is thread-safe so you don't have
-     to worry about locks, just import and log.
+Use: `from debug import logger` to import this facility into whatever module you wish to log messages from.
+    Logging is thread-safe so you don't have to worry about locks, just import and log.
+
 """
+
 import logging
 import logging.config
 import os
@@ -56,9 +58,8 @@ def configureLogging():
                 ' logging config\n%s' %
                 (os.path.join(state.appdata, 'logging.dat'), sys.exc_info()))
         else:
-            # no need to confuse the user if the logger config
-            # is missing entirely
-            print('Using default logger configuration')
+            # no need to confuse the user if the logger config is missing entirely
+            print "Using default logger configuration"
 
     sys.excepthook = log_uncaught_exceptions
 
@@ -113,13 +114,16 @@ def configureLogging():
 
 # TODO (xj9): Get from a config file.
 # logger = logging.getLogger('console_only')
-if configureLogging():
-    if '-c' in sys.argv:
-        logger = logging.getLogger('file_only')
+
+def initLogging():
+    if configureLogging():
+        if '-c' in sys.argv:
+            logger = logging.getLogger('file_only')
+        else:
+            logger = logging.getLogger('both')
     else:
-        logger = logging.getLogger('both')
-else:
-    logger = logging.getLogger('default')
+        logger = logging.getLogger('default')
+    return logger
 
 
 def restartLoggingInUpdatedAppdataLocation():
@@ -128,10 +132,8 @@ def restartLoggingInUpdatedAppdataLocation():
         logger.removeHandler(i)
         i.flush()
         i.close()
-    if configureLogging():
-        if '-c' in sys.argv:
-            logger = logging.getLogger('file_only')
-        else:
-            logger = logging.getLogger('both')
-    else:
-        logger = logging.getLogger('default')
+    logger = initLogging()
+
+
+# !
+logger = initLogging()

--- a/src/depends.py
+++ b/src/depends.py
@@ -1,52 +1,196 @@
-#! python
+"""
+Utility functions to check the availability of dependencies
+and suggest how it may be installed
+"""
 
 import sys
-import os
-import pyelliptic.openssl
 
 # Only really old versions of Python don't have sys.hexversion. We don't
 # support them. The logging module was introduced in Python 2.3
 if not hasattr(sys, 'hexversion') or sys.hexversion < 0x20300F0:
-    sys.stdout.write('Python version: ' + sys.version)
-    sys.stdout.write('PyBitmessage requires Python 2.7.3 or greater (but not Python 3)')
-    sys.exit()
+    sys.exit(
+        'Python version: %s\n'
+        'PyBitmessage requires Python 2.7.4 or greater (but not Python 3)'
+        % sys.version
+    )
+
+import logging
+import os
+from importlib import import_module
 
 # We can now use logging so set up a simple configuration
-import logging
 formatter = logging.Formatter(
     '%(levelname)s: %(message)s'
 )
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(formatter)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('both')
 logger.addHandler(handler)
 logger.setLevel(logging.ERROR)
+
+OS_RELEASE = {
+    "fedora": "Fedora",
+    "opensuse": "openSUSE",
+    "ubuntu": "Ubuntu",
+    "gentoo": "Gentoo",
+    "calculate": "Gentoo"
+}
+
+PACKAGE_MANAGER = {
+    "OpenBSD": "pkg_add",
+    "FreeBSD": "pkg install",
+    "Debian": "apt-get install",
+    "Ubuntu": "apt-get install",
+    "Ubuntu 12": "apt-get install",
+    "openSUSE": "zypper install",
+    "Fedora": "dnf install",
+    "Guix": "guix package -i",
+    "Gentoo": "emerge"
+}
+
+PACKAGES = {
+    "PyQt4": {
+        "OpenBSD": "py-qt4",
+        "FreeBSD": "py27-qt4",
+        "Debian": "python-qt4",
+        "Ubuntu": "python-qt4",
+        "Ubuntu 12": "python-qt4",
+        "openSUSE": "python-qt",
+        "Fedora": "PyQt4",
+        "Guix": "python2-pyqt@4.11.4",
+        "Gentoo": "dev-python/PyQt4",
+        "optional": True,
+        "description":
+        "You only need PyQt if you want to use the GUI."
+        " When only running as a daemon, this can be skipped.\n"
+        "However, you would have to install it manually"
+        " because setuptools does not support PyQt."
+    },
+    "msgpack": {
+        "OpenBSD": "py-msgpack",
+        "FreeBSD": "py27-msgpack-python",
+        "Debian": "python-msgpack",
+        "Ubuntu": "python-msgpack",
+        "Ubuntu 12": "msgpack-python",
+        "openSUSE": "python-msgpack-python",
+        "Fedora": "python2-msgpack",
+        "Guix": "python2-msgpack",
+        "Gentoo": "dev-python/msgpack",
+        "optional": True,
+        "description":
+        "python-msgpack is recommended for improved performance of"
+        " message encoding/decoding"
+    },
+    "pyopencl": {
+        "FreeBSD": "py27-pyopencl",
+        "Debian": "python-pyopencl",
+        "Ubuntu": "python-pyopencl",
+        "Ubuntu 12": "python-pyopencl",
+        "Fedora": "python2-pyopencl",
+        "openSUSE": "",
+        "OpenBSD": "",
+        "Guix": "",
+        "Gentoo": "dev-python/pyopencl",
+        "optional": True,
+        "description":
+        "If you install pyopencl, you will be able to use"
+        " GPU acceleration for proof of work.\n"
+        "You also need a compatible GPU and drivers."
+    },
+    "setuptools": {
+        "OpenBSD": "py-setuptools",
+        "FreeBSD": "py27-setuptools",
+        "Debian": "python-setuptools",
+        "Ubuntu": "python-setuptools",
+        "Ubuntu 12": "python-setuptools",
+        "Fedora": "python2-setuptools",
+        "openSUSE": "python-setuptools",
+        "Guix": "python2-setuptools",
+        "Gentoo": "dev-python/setuptools",
+        "optional": False,
+    }
+}
+
+
+def detectOS():
+    if detectOS.result is not None:
+        return detectOS.result
+    if sys.platform.startswith('openbsd'):
+        detectOS.result = "OpenBSD"
+    elif sys.platform.startswith('freebsd'):
+        detectOS.result = "FreeBSD"
+    elif sys.platform.startswith('win'):
+        detectOS.result = "Windows"
+    elif os.path.isfile("/etc/os-release"):
+        detectOSRelease()
+    elif os.path.isfile("/etc/config.scm"):
+        detectOS.result = "Guix"
+    return detectOS.result
+
+
+detectOS.result = None
+
+
+def detectOSRelease():
+    with open("/etc/os-release", 'r') as osRelease:
+        version = None
+        for line in osRelease:
+            if line.startswith("NAME="):
+                detectOS.result = OS_RELEASE.get(
+                    line.replace('"', '').split("=")[-1].strip().lower())
+            elif line.startswith("VERSION_ID="):
+                try:
+                    version = float(line.split("=")[1].replace("\"", ""))
+                except ValueError:
+                    pass
+        if detectOS.result == "Ubuntu" and version < 14:
+            detectOS.result = "Ubuntu 12"
+
+
+def try_import(module, log_extra=False):
+    try:
+        return import_module(module)
+    except ImportError:
+        module = module.split('.')[0]
+        logger.error('The %s module is not available.', module)
+        if log_extra:
+            logger.error(log_extra)
+            dist = detectOS()
+            logger.error(
+                'On %s, try running "%s %s" as root.',
+                dist, PACKAGE_MANAGER[dist], PACKAGES[module][dist])
+        return False
+
 
 # We need to check hashlib for RIPEMD-160, as it won't be available
 # if OpenSSL is not linked against or the linked OpenSSL has RIPEMD
 # disabled.
-
-
 def check_hashlib():
     """Do hashlib check.
 
     The hashlib module check with version as if it included or not
-    in The Python Standard library , its a module containing an
+    in The Python Standard library, it's a module containing an
     interface to the most popular hashing algorithms. hashlib
     implements some of the algorithms, however if  OpenSSL
     installed, hashlib is able to use this algorithms as well.
     """
     if sys.hexversion < 0x020500F0:
-        logger.error('The hashlib module is not included in this version of Python.')
+        logger.error(
+            'The hashlib module is not included in this version of Python.')
         return False
     import hashlib
     if '_hashlib' not in hashlib.__dict__:
-        logger.error('The RIPEMD-160 hash algorithm is not available. The hashlib module is not linked against OpenSSL.')
+        logger.error(
+            'The RIPEMD-160 hash algorithm is not available.'
+            ' The hashlib module is not linked against OpenSSL.')
         return False
     try:
         hashlib.new('ripemd160')
     except ValueError:
-        logger.error('The RIPEMD-160 hash algorithm is not available. The hashlib module utilizes an OpenSSL library with RIPEMD disabled.')
+        logger.error(
+            'The RIPEMD-160 hash algorithm is not available.'
+            ' The hashlib module utilizes an OpenSSL library with'
+            ' RIPEMD disabled.')
         return False
     return True
 
@@ -58,35 +202,48 @@ def check_sqlite():
     support in python version for specifieed platform.
     """
     if sys.hexversion < 0x020500F0:
-        logger.error('The sqlite3 module is not included in this version of Python.')
+        logger.error(
+            'The sqlite3 module is not included in this version of Python.')
         if sys.platform.startswith('freebsd'):
-            logger.error('On FreeBSD, try running "pkg install py27-sqlite3" as root.')
-        return False
-    try:
-        import sqlite3
-    except ImportError:
-        logger.error('The sqlite3 module is not available')
+            logger.error(
+                'On FreeBSD, try running "pkg install py27-sqlite3" as root.')
         return False
 
-    logger.info('sqlite3 Module Version: ' + sqlite3.version)
-    logger.info('SQLite Library Version: ' + sqlite3.sqlite_version)
-    #sqlite_version_number formula: https://sqlite.org/c3ref/c_source_id.html
-    sqlite_version_number = sqlite3.sqlite_version_info[0] * 1000000 + sqlite3.sqlite_version_info[1] * 1000 + sqlite3.sqlite_version_info[2]
+    sqlite3 = try_import('sqlite3')
+    if not sqlite3:
+        return False
+
+    logger.info('sqlite3 Module Version: %s', sqlite3.version)
+    logger.info('SQLite Library Version: %s', sqlite3.sqlite_version)
+    # sqlite_version_number formula: https://sqlite.org/c3ref/c_source_id.html
+    sqlite_version_number = (
+        sqlite3.sqlite_version_info[0] * 1000000 +
+        sqlite3.sqlite_version_info[1] * 1000 +
+        sqlite3.sqlite_version_info[2]
+    )
 
     conn = None
     try:
         try:
             conn = sqlite3.connect(':memory:')
             if sqlite_version_number >= 3006018:
-                sqlite_source_id = conn.execute('SELECT sqlite_source_id();').fetchone()[0]
-                logger.info('SQLite Library Source ID: ' + sqlite_source_id)
+                sqlite_source_id = conn.execute(
+                    'SELECT sqlite_source_id();'
+                ).fetchone()[0]
+                logger.info('SQLite Library Source ID: %s', sqlite_source_id)
             if sqlite_version_number >= 3006023:
-                compile_options = ', '.join(map(lambda row: row[0], conn.execute('PRAGMA compile_options;')))
-                logger.info('SQLite Library Compile Options: ' + compile_options)
-            #There is no specific version requirement as yet, so we just use the
-            #first version that was included with Python.
+                compile_options = ', '.join(map(
+                    lambda row: row[0],
+                    conn.execute('PRAGMA compile_options;')
+                ))
+                logger.info(
+                    'SQLite Library Compile Options: %s', compile_options)
+            # There is no specific version requirement as yet, so we just
+            # use the first version that was included with Python.
             if sqlite_version_number < 3000008:
-                logger.error('This version of SQLite is too old. PyBitmessage requires SQLite 3.0.8 or later')
+                logger.error(
+                    'This version of SQLite is too old.'
+                    ' PyBitmessage requires SQLite 3.0.8 or later')
                 return False
             return True
         except sqlite3.Error:
@@ -96,19 +253,20 @@ def check_sqlite():
         if conn:
             conn.close()
 
+
 def check_openssl():
     """Do openssl dependency check.
 
     Here we are checking for openssl with its all dependent libraries
     and version checking.
     """
-    try:
-        import ctypes
-    except ImportError:
-        logger.error('Unable to check OpenSSL. The ctypes module is not available.')
+
+    ctypes = try_import('ctypes')
+    if not ctypes:
+        logger.error('Unable to check OpenSSL.')
         return False
 
-    #We need to emulate the way PyElliptic searches for OpenSSL.
+    # We need to emulate the way PyElliptic searches for OpenSSL.
     if sys.platform == 'win32':
         paths = ['libeay32.dll']
         if getattr(sys, 'frozen', False):
@@ -138,135 +296,128 @@ def check_openssl():
 
     cflags_regex = re.compile(r'(?:OPENSSL_NO_)(AES|EC|ECDH|ECDSA)(?!\w)')
 
+    import pyelliptic.openssl
+
     for path in paths:
-        logger.info('Checking OpenSSL at ' + path)
+        logger.info('Checking OpenSSL at %s', path)
         try:
             library = ctypes.CDLL(path)
         except OSError:
             continue
-        logger.info('OpenSSL Name: ' + library._name)
-        openssl_version, openssl_hexversion, openssl_cflags = pyelliptic.openssl.get_version(library)
+        logger.info('OpenSSL Name: %s', library._name)
+        try:
+            openssl_version, openssl_hexversion, openssl_cflags = \
+                pyelliptic.openssl.get_version(library)
+        except AttributeError:  # sphinx chokes
+            return True
         if not openssl_version:
             logger.error('Cannot determine version of this OpenSSL library.')
             return False
-        logger.info('OpenSSL Version: ' + openssl_version)
-        logger.info('OpenSSL Compile Options: ' + openssl_cflags)
-        #PyElliptic uses EVP_CIPHER_CTX_new and EVP_CIPHER_CTX_free which were
-        #introduced in 0.9.8b.
+        logger.info('OpenSSL Version: %s', openssl_version)
+        logger.info('OpenSSL Compile Options: %s', openssl_cflags)
+        # PyElliptic uses EVP_CIPHER_CTX_new and EVP_CIPHER_CTX_free which were
+        # introduced in 0.9.8b.
         if openssl_hexversion < 0x90802F:
-            logger.error('This OpenSSL library is too old. PyBitmessage requires OpenSSL 0.9.8b or later with AES, Elliptic Curves (EC), ECDH, and ECDSA enabled.')
+            logger.error(
+                'This OpenSSL library is too old. PyBitmessage requires'
+                ' OpenSSL 0.9.8b or later with AES, Elliptic Curves (EC),'
+                ' ECDH, and ECDSA enabled.')
             return False
         matches = cflags_regex.findall(openssl_cflags)
         if len(matches) > 0:
-            logger.error('This OpenSSL library is missing the following required features: ' + ', '.join(matches) + '. PyBitmessage requires OpenSSL 0.9.8b or later with AES, Elliptic Curves (EC), ECDH, and ECDSA enabled.')
+            logger.error(
+                'This OpenSSL library is missing the following required'
+                ' features: %s. PyBitmessage requires OpenSSL 0.9.8b'
+                ' or later with AES, Elliptic Curves (EC), ECDH,'
+                ' and ECDSA enabled.', ', '.join(matches))
             return False
         return True
     return False
 
-#TODO: The minimum versions of pythondialog and dialog need to be determined
+
+# TODO: The minimum versions of pythondialog and dialog need to be determined
 def check_curses():
     """Do curses dependency check.
 
-    Here we are checking for curses if available or not with check 
+    Here we are checking for curses if available or not with check
     as interface requires the pythondialog\ package and the dialog
     utility.
     """
     if sys.hexversion < 0x20600F0:
-        logger.error('The curses interface requires the pythondialog package and the dialog utility.')
+        logger.error(
+            'The curses interface requires the pythondialog package and'
+            ' the dialog utility.')
         return False
+    curses = try_import('curses')
+    if not curses:
+        logger.error('The curses interface can not be used.')
+        return False
+
+    logger.info('curses Module Version: %s', curses.version)
+
+    dialog = try_import('dialog')
+    if not dialog:
+        logger.error('The curses interface can not be used.')
+        return False
+
+    import subprocess
+
     try:
-        import curses
-    except ImportError:
-        logger.error('The curses interface can not be used. The curses module is not available.')
+        subprocess.check_call('which dialog')
+    except subprocess.CalledProcessError:
+        logger.error(
+            'Curses requires the `dialog` command to be installed as well as'
+            ' the python library.')
         return False
-    logger.info('curses Module Version: ' + curses.version)
-    try:
-        import dialog
-    except ImportError:
-        logger.error('The curses interface can not be used. The pythondialog package is not available.')
-        return False
-    logger.info('pythondialog Package Version: ' + dialog.__version__)
+
+    logger.info('pythondialog Package Version: %s', dialog.__version__)
     dialog_util_version = dialog.Dialog().cached_backend_version
-    #The pythondialog author does not like Python2 str, so we have to use
-    #unicode for just the version otherwise we get the repr form which includes
-    #the module and class names along with the actual version.
-    logger.info('dialog Utility Version' + unicode(dialog_util_version))
+    # The pythondialog author does not like Python2 str, so we have to use
+    # unicode for just the version otherwise we get the repr form which
+    # includes the module and class names along with the actual version.
+    logger.info('dialog Utility Version %s', unicode(dialog_util_version))
     return True
+
 
 def check_pyqt():
     """Do pyqt dependency check.
 
     Here we are checking for PyQt4 with its version, as for it require
-    PyQt 4.7 or later.
+    PyQt 4.8 or later.
     """
-    try:
-        import PyQt4.QtCore
-    except ImportError:
-        logger.error('The PyQt4 package is not available. PyBitmessage requires PyQt 4.8 or later and Qt 4.7 or later.')
-        if sys.platform.startswith('openbsd'):
-            logger.error('On OpenBSD, try running "pkg_add py-qt4" as root.')
-        elif sys.platform.startswith('freebsd'):
-            logger.error('On FreeBSD, try running "pkg install py27-qt4" as root.')
-        elif os.path.isfile("/etc/os-release"):
-            with open("/etc/os-release", 'rt') as osRelease:
-                for line in osRelease:
-                    if line.startswith("NAME="):
-                        if "fedora" in line.lower():
-                            logger.error('On Fedora, try running "dnf install PyQt4" as root.')
-                        elif "opensuse" in line.lower():
-                            logger.error('On openSUSE, try running "zypper install python-qt" as root.')
-                        elif "ubuntu" in line.lower():
-                            logger.error('On Ubuntu, try running "apt-get install python-qt4" as root.')
-                        elif "debian" in line.lower():
-                            logger.error('On Debian, try running "apt-get install python-qt4" as root.')
-                        else:
-                            logger.error('If your package manager does not have this package, try running "pip install PyQt4".')
+    QtCore = try_import(
+        'PyQt4.QtCore', 'PyBitmessage requires PyQt 4.8 or later and Qt 4.7 or later.')
+
+    if not QtCore:
         return False
-    logger.info('PyQt Version: ' + PyQt4.QtCore.PYQT_VERSION_STR)
-    logger.info('Qt Version: ' + PyQt4.QtCore.QT_VERSION_STR)
+
+    logger.info('PyQt Version: %s', QtCore.PYQT_VERSION_STR)
+    logger.info('Qt Version: %s', QtCore.QT_VERSION_STR)
     passed = True
-    if PyQt4.QtCore.PYQT_VERSION < 0x40800:
-        logger.error('This version of PyQt is too old. PyBitmessage requries PyQt 4.8 or later.')
+    if QtCore.PYQT_VERSION < 0x40800:
+        logger.error(
+            'This version of PyQt is too old. PyBitmessage requries'
+            ' PyQt 4.8 or later.')
         passed = False
-    if PyQt4.QtCore.QT_VERSION < 0x40700:
-        logger.error('This version of Qt is too old. PyBitmessage requries Qt 4.7 or later.')
+    if QtCore.QT_VERSION < 0x40700:
+        logger.error(
+            'This version of Qt is too old. PyBitmessage requries'
+            ' Qt 4.7 or later.')
         passed = False
     return passed
+
 
 def check_msgpack():
     """Do sgpack module check.
 
-    simply checking if msgpack package with all its dependency 
+    simply checking if msgpack package with all its dependency
     is available or not as recommended for messages coding.
     """
-    try:
-        import msgpack
-    except ImportError:
-        logger.error(
-            'The msgpack package is not available.'
-            'It is highly recommended for messages coding.')
-        if sys.platform.startswith('openbsd'):
-            logger.error('On OpenBSD, try running "pkg_add py-msgpack" as root.')
-        elif sys.platform.startswith('freebsd'):
-            logger.error('On FreeBSD, try running "pkg install py27-msgpack-python" as root.')
-        elif os.path.isfile("/etc/os-release"):
-            with open("/etc/os-release", 'rt') as osRelease:
-                for line in osRelease:
-                    if line.startswith("NAME="):
-                        if "fedora" in line.lower():
-                            logger.error('On Fedora, try running "dnf install python2-msgpack" as root.')
-                        elif "opensuse" in line.lower():
-                            logger.error('On openSUSE, try running "zypper install python-msgpack-python" as root.')
-                        elif "ubuntu" in line.lower():
-                            logger.error('On Ubuntu, try running "apt-get install python-msgpack" as root.')
-                        elif "debian" in line.lower():
-                            logger.error('On Debian, try running "apt-get install python-msgpack" as root.')
-                        else:
-                            logger.error('If your package manager does not have this package, try running "pip install msgpack-python".')
+    return try_import(
+        'msgpack', 'It is highly recommended for messages coding.') is not False
 
-    return True
 
-def check_dependencies(verbose = False, optional = False):
+def check_dependencies(verbose=False, optional=False):
     """Do dependency check.
 
     It identifies project dependencies and checks if there are
@@ -279,33 +430,36 @@ def check_dependencies(verbose = False, optional = False):
 
     has_all_dependencies = True
 
-    #Python 2.7.3 is the required minimum. Python 3+ is not supported, but it is
-    #still useful to provide information about our other requirements.
+    # Python 2.7.4 is the required minimum.
+    # (https://bitmessage.org/forum/index.php?topic=4081.0)
+    # Python 3+ is not supported, but it is still useful to provide
+    # information about our other requirements.
     logger.info('Python version: %s', sys.version)
-    if sys.hexversion < 0x20703F0:
-        logger.error('PyBitmessage requires Python 2.7.3 or greater (but not Python 3+)')
+    if sys.hexversion < 0x20704F0:
+        logger.error(
+            'PyBitmessage requires Python 2.7.4 or greater'
+            ' (but not Python 3+)')
         has_all_dependencies = False
     if sys.hexversion >= 0x3000000:
-        logger.error('PyBitmessage does not support Python 3+. Python 2.7.3 or greater is required.')
+        logger.error(
+            'PyBitmessage does not support Python 3+. Python 2.7.4'
+            ' or greater is required.')
         has_all_dependencies = False
 
-    check_functions = [check_hashlib, check_sqlite, check_openssl, check_msgpack]
+    check_functions = [check_hashlib, check_sqlite, check_openssl]
     if optional:
-        check_functions.extend([check_pyqt, check_curses])
+        check_functions.extend([check_msgpack, check_pyqt, check_curses])
 
-    #Unexpected exceptions are handled here
+    # Unexpected exceptions are handled here
     for check in check_functions:
         try:
             has_all_dependencies &= check()
         except:
-            logger.exception(check.__name__ + ' failed unexpectedly.')
+            logger.exception('%s failed unexpectedly.', check.__name__)
             has_all_dependencies = False
-        
+
     if not has_all_dependencies:
-        logger.critical('PyBitmessage cannot start. One or more dependencies are unavailable.')
-        sys.exit()
-
-if __name__ == '__main__':
-    """Check Dependencies"""
-    check_dependencies(True, True)
-
+        sys.exit(
+            'PyBitmessage cannot start. One or more dependencies are'
+            ' unavailable.'
+        )

--- a/src/depends.py
+++ b/src/depends.py
@@ -137,7 +137,7 @@ def detectOSRelease():
         for line in osRelease:
             if line.startswith("NAME="):
                 detectOS.result = OS_RELEASE.get(
-                    line.replace('"', '').split("=")[-1].strip().lower())
+                    line.replace('"', '').split("=")[-1].strip().lower().split(" ")[0])
             elif line.startswith("VERSION_ID="):
                 try:
                     version = float(line.split("=")[1].replace("\"", ""))
@@ -294,7 +294,7 @@ def check_openssl():
     openssl_hexversion = None
     openssl_cflags = None
 
-    cflags_regex = re.compile(r'(?:OPENSSL_NO_)(AES|EC|ECDH|ECDSA)(?!\w)')
+    cflags_regex = re.compile(b'(?:OPENSSL_NO_)(AES|EC|ECDH|ECDSA)(?!\w)')
 
     import pyelliptic.openssl
 
@@ -444,7 +444,7 @@ def check_dependencies(verbose=False, optional=False):
         logger.error(
             'PyBitmessage does not support Python 3+. Python 2.7.4'
             ' or greater is required.')
-        has_all_dependencies = False
+        has_all_dependencies = True
 
     check_functions = [check_hashlib, check_sqlite, check_openssl]
     if optional:

--- a/src/helper_bitcoin.py
+++ b/src/helper_bitcoin.py
@@ -4,7 +4,7 @@ from pyelliptic import arithmetic
 # This function expects that pubkey begin with \x04
 def calculateBitcoinAddressFromPubkey(pubkey):
     if len(pubkey) != 65:
-        print 'Could not calculate Bitcoin address from pubkey because function was passed a pubkey that was', len(pubkey), 'bytes long rather than 65.'
+        print('Could not calculate Bitcoin address from pubkey because function was passed a pubkey that was %d bytes long rather than 65.' % len(pubkey))
         return "error"
     ripe = hashlib.new('ripemd160')
     sha = hashlib.new('sha256')
@@ -25,7 +25,7 @@ def calculateBitcoinAddressFromPubkey(pubkey):
 
 def calculateTestnetAddressFromPubkey(pubkey):
     if len(pubkey) != 65:
-        print 'Could not calculate Bitcoin address from pubkey because function was passed a pubkey that was', len(pubkey), 'bytes long rather than 65.'
+        print('Could not calculate Bitcoin address from pubkey because function was passed a pubkey that was %d bytes long rather than 65.' % len(pubkey))
         return "error"
     ripe = hashlib.new('ripemd160')
     sha = hashlib.new('sha256')

--- a/src/helper_msgcoding.py
+++ b/src/helper_msgcoding.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
     obj1 = MsgEncode(messageData, 1)
     obj2 = MsgEncode(messageData, 2)
     obj3 = MsgEncode(messageData, 3)
-    print "1:%i 2:%i 3:%i" %(len(obj1.data), len(obj2.data), len(obj3.data))
+    print("1:%i 2:%i 3:%i" %(len(obj1.data), len(obj2.data), len(obj3.data)))
 
     obj1e = MsgDecode(1, obj1.data)
     # no subject in trivial encoding

--- a/src/helper_sql.py
+++ b/src/helper_sql.py
@@ -1,7 +1,10 @@
 """Helper Sql performs sql operations."""
 
 import threading
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
 
 sqlSubmitQueue = Queue.Queue()
 # SQLITE3 is so thread-unsafe that they won't even let you call it from different threads using your own locks.

--- a/src/helper_startup.py
+++ b/src/helper_startup.py
@@ -1,6 +1,10 @@
 """Helper Start performs all the startup operations."""
 
-import ConfigParser
+try:
+    import ConfigParser as ConfigParser
+except ImportError:
+    import configparser as ConfigParser
+
 from bmconfigparser import BMConfigParser
 import defaults
 import sys
@@ -44,7 +48,7 @@ def loadConfig():
         config.read(paths.lookupExeFolder() + 'keys.dat')
         try:
             config.get('bitmessagesettings', 'settingsversion')
-            print 'Loading config files from same directory as program.'
+            print('Loading config files from same directory as program.')
             needToCreateKeysFile = False
             state.appdata = paths.lookupExeFolder()
         except:
@@ -55,7 +59,7 @@ def loadConfig():
             needToCreateKeysFile = config.safeGet(
                 'bitmessagesettings', 'settingsversion') is None
             if not needToCreateKeysFile:
-                print 'Loading existing config files from', state.appdata
+                print('Loading existing config files from', state.appdata)
 
     if needToCreateKeysFile:
 
@@ -127,9 +131,9 @@ def loadConfig():
             # Just use the same directory as the program and forget about
             # the appdata folder
             state.appdata = ''
-            print 'Creating new config files in same directory as program.'
+            print('Creating new config files in same directory as program.')
         else:
-            print 'Creating new config files in', state.appdata
+            print('Creating new config files in', state.appdata)
             if not os.path.exists(state.appdata):
                 os.makedirs(state.appdata)
         if not sys.platform.startswith('win'):
@@ -143,7 +147,7 @@ def loadConfig():
 
 def updateConfig():
     config = BMConfigParser()
-    settingsversion = config.getint('bitmessagesettings', 'settingsversion')
+    settingsversion = config.safeGetInt('bitmessagesettings', 'settingsversion')
     if settingsversion == 1:
         config.set('bitmessagesettings', 'socksproxytype', 'none')
         config.set('bitmessagesettings', 'sockshostname', 'localhost')

--- a/src/knownnodes.py
+++ b/src/knownnodes.py
@@ -90,7 +90,7 @@ def createDefaultKnownNodes():
 
 def readKnownNodes():
     try:
-        with open(state.appdata + 'knownnodes.dat', 'rb') as source:
+        with open(state.appdata + 'knownnodes.dat', 'r') as source:
             with knownNodesLock:
                 try:
                     json_deserialize_knownnodes(source)

--- a/src/messagetypes/__init__.py
+++ b/src/messagetypes/__init__.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 from os import path, listdir
-from string import lower
+#from string import lower
 
 from debug import logger
 import messagetypes
@@ -8,7 +8,7 @@ import paths
 
 class MsgBase(object):
     def encode(self):
-        self.data = {"": lower(type(self).__name__)}
+        self.data = {"": type(self).__name__.lower()}
 
 
 def constructObject(data):

--- a/src/multiqueue.py
+++ b/src/multiqueue.py
@@ -1,5 +1,9 @@
 from collections import deque
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 import random
 import helper_random
 

--- a/src/network/addrthread.py
+++ b/src/network/addrthread.py
@@ -1,4 +1,8 @@
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 import threading
 
 import addresses

--- a/src/network/advanceddispatcher.py
+++ b/src/network/advanceddispatcher.py
@@ -2,7 +2,11 @@ import socket
 import threading
 import time
 
-import asyncore_pollchoose as asyncore
+try:
+    import asyncore_pollchoose as asyncore
+except ImportError:
+    import asyncore as asyncore
+
 from debug import logger
 from helper_threading import BusyError, nonBlocking
 import state

--- a/src/network/asyncore_pollchoose.py
+++ b/src/network/asyncore_pollchoose.py
@@ -346,7 +346,7 @@ def epoll_poller(timeout=0.0, map=None):
             if e.errno != EINTR:
                 raise
             r = []
-        except select.error, err:
+        except select.error as err:
             if err.args[0] != EINTR:
                 raise
             r = []

--- a/src/network/connectionchooser.py
+++ b/src/network/connectionchooser.py
@@ -38,7 +38,7 @@ def chooseConnection(stream):
         try:
             rating = knownnodes.knownNodes[stream][peer]["rating"]
         except TypeError:
-            print "Error in %s" % (peer)
+            print("Error in %s" % peer)
             rating = 0
         if haveOnion:
             # onion addresses have a higher priority when SOCKS

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -1,4 +1,8 @@
-from ConfigParser import NoOptionError, NoSectionError
+try:
+    from ConfigParser import NoOptionError, NoSectionError
+except ImportError:
+    from configparser import NoOptionError, NoSectionError
+
 import errno
 import socket
 import time

--- a/src/network/downloadthread.py
+++ b/src/network/downloadthread.py
@@ -3,7 +3,7 @@ import threading
 import time
 
 import addresses
-from dandelion import Dandelion
+from .dandelion import Dandelion
 from debug import logger
 from helper_threading import StoppableThread
 from inventory import Inventory

--- a/src/network/invthread.py
+++ b/src/network/invthread.py
@@ -1,4 +1,8 @@
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 from random import randint, shuffle
 import threading
 from time import time

--- a/src/network/proxy.py
+++ b/src/network/proxy.py
@@ -1,8 +1,12 @@
 import socket
 import time
 
-from advanceddispatcher import AdvancedDispatcher
-import asyncore_pollchoose as asyncore
+from .advanceddispatcher import AdvancedDispatcher
+try:
+    import asyncore_pollchoose as asyncore
+except ImportError:
+    import asyncore as asyncore
+
 from bmconfigparser import BMConfigParser
 from debug import logger
 import network.connectionpool

--- a/src/network/receivequeuethread.py
+++ b/src/network/receivequeuethread.py
@@ -1,5 +1,9 @@
 import errno
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 import socket
 import sys
 import threading

--- a/src/network/socks4a.py
+++ b/src/network/socks4a.py
@@ -1,7 +1,7 @@
 import socket
 import struct
 
-from proxy import Proxy, ProxyError, GeneralProxyError
+from .proxy import Proxy, ProxyError, GeneralProxyError
 
 class Socks4aError(ProxyError):
     errorCodes = ("Request granted",
@@ -108,4 +108,4 @@ class Socks4aResolver(Socks4a):
         return True
 
     def resolved(self):
-        print "Resolved %s as %s" % (self.host, self.proxy_sock_name())
+        print("Resolved %s as %s" % (self.host, self.proxy_sock_name()))

--- a/src/network/socks5.py
+++ b/src/network/socks5.py
@@ -1,7 +1,7 @@
 import socket
 import struct
 
-from proxy import Proxy, ProxyError, GeneralProxyError
+from .proxy import Proxy, ProxyError, GeneralProxyError
 
 class Socks5AuthError(ProxyError):
     errorCodes = ("Succeeded",
@@ -173,4 +173,4 @@ class Socks5Resolver(Socks5):
         return True
 
     def resolved(self):
-        print "Resolved %s as %s" % (self.host, self.proxy_sock_name())
+        print("Resolved %s as %s" % (self.host, self.proxy_sock_name()))

--- a/src/network/stats.py
+++ b/src/network/stats.py
@@ -1,7 +1,11 @@
 import time
 
 from network.connectionpool import BMConnectionPool
-import asyncore_pollchoose as asyncore
+try:
+    import asyncore_pollchoose as asyncore
+except ImportError:
+    import asyncore as asyncore
+
 from state import missingObjects
 
 lastReceivedTimestamp = time.time()

--- a/src/network/tcp.py
+++ b/src/network/tcp.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
     for host in (("127.0.0.1", 8448),):
         direct = TCPConnection(host)
         while len(asyncore.socket_map) > 0:
-            print "loop, state = %s" % (direct.state)
+            print ("loop, state = %s" % direct.state)
             asyncore.loop(timeout=10, count=1)
         continue
 

--- a/src/network/udp.py
+++ b/src/network/udp.py
@@ -1,5 +1,9 @@
 import time
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 import socket
 
 from debug import logger
@@ -161,7 +165,7 @@ if __name__ == "__main__":
     for host in (("127.0.0.1", 8448),):
         direct = BMConnection(host)
         while len(asyncore.socket_map) > 0:
-            print "loop, state = %s" % (direct.state)
+            print("loop, state = %s" % direct.state)
             asyncore.loop(timeout=10, count=1)
         continue
 

--- a/src/openclpow.py
+++ b/src/openclpow.py
@@ -20,10 +20,11 @@ vendors = []
 hash_dt = None
 
 try:
-    import numpy
     import pyopencl as cl
-except:
+    import numpy
+except ImportError:
     libAvailable = False
+
 
 def initCL():
     global ctx, queue, program, hash_dt, libAvailable

--- a/src/openclpow.py
+++ b/src/openclpow.py
@@ -104,9 +104,9 @@ def do_opencl_pow(hash, target):
 #initCL()
 
 if __name__ == "__main__":
-    target = 54227212183L
+    target = long(54227212183)
     initialHash = "3758f55b5a8d902fd3597e4ce6a2d3f23daff735f65d9698c270987f4e67ad590b93f3ffeba0ef2fd08a8dc2f87b68ae5a0dc819ab57f22ad2c4c9c8618a43b3".decode("hex")
     nonce = do_opencl_pow(initialHash.encode("hex"), target)
     trialValue, = unpack('>Q',hashlib.sha512(hashlib.sha512(pack('>Q',nonce) + initialHash).digest()).digest()[0:8])
-    print "{} - value {} < {}".format(nonce, trialValue, target)
+    print("{} - value {} < {}".format(nonce, trialValue, target))
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -35,7 +35,7 @@ def lookupAppdataFolder():
             if 'logger' in globals():
                 logger.critical(stringToLog)
             else:
-                print stringToLog
+                print(stringToLog)
             sys.exit()
 
     elif 'win32' in sys.platform or 'win64' in sys.platform:
@@ -54,7 +54,7 @@ def lookupAppdataFolder():
             if 'logger' in globals():
                 logger.info(stringToLog)
             else:
-                print stringToLog
+                print(stringToLog)
         except IOError:
             # Old directory may not exist.
             pass

--- a/src/protocol.py
+++ b/src/protocol.py
@@ -660,11 +660,11 @@ def broadcastToSendDataQueues(data):
 
 
 # sslProtocolVersion
-if sys.version_info >= (2, 7, 13):
+if sys.version_info >= (3, 5, 3):
     # this means TLSv1 or higher
     # in the future change to
     # ssl.PROTOCOL_TLS1.2
-    sslProtocolVersion = ssl.PROTOCOL_TLS  # pylint: disable=no-member
+    sslProtocolVersion = ssl.PROTOCOL_TLS  # pylint: disable=no-member new in 3.5.3:alias PROTOCOL_SSLv23, and deprecated since 3.6
 elif sys.version_info >= (2, 7, 9):
     # this means any SSL/TLS. SSLv2 and 3 are excluded with an option after context is created
     sslProtocolVersion = ssl.PROTOCOL_SSLv23

--- a/src/pyelliptic/openssl.py
+++ b/src/pyelliptic/openssl.py
@@ -8,6 +8,7 @@
 
 import sys
 import ctypes
+import traceback
 
 OpenSSL = None
 
@@ -72,7 +73,7 @@ class _OpenSSL:
         """
         self._lib = ctypes.CDLL(library)
         self._version, self._hexversion, self._cflags = get_version(self._lib)
-        self._libreSSL = self._version.startswith("LibreSSL")
+        self._libreSSL = self._version.startswith(b"LibreSSL")
 
         self.pointer = ctypes.pointer
         self.c_int = ctypes.c_int
@@ -516,6 +517,7 @@ def loadOpenSSL():
             libdir.extend([
                 path.join(sys._MEIPASS, 'libcrypto.so'),
                 path.join(sys._MEIPASS, 'libssl.so'),
+                path.join(sys._MEIPASS, 'libcrypto.so.37'),
                 path.join(sys._MEIPASS, 'libcrypto.so.1.1.0'),
                 path.join(sys._MEIPASS, 'libssl.so.1.1.0'),
                 path.join(sys._MEIPASS, 'libcrypto.so.1.0.2'),
@@ -544,7 +546,9 @@ def loadOpenSSL():
         try:
             OpenSSL = _OpenSSL(library)
             return
-        except:
+        except Exception as err:
+            print (err)
+            traceback.print_exc()
             pass
     raise Exception("Couldn't find and load the OpenSSL library. You must install it.")
 

--- a/src/queues.py
+++ b/src/queues.py
@@ -1,4 +1,8 @@
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 
 from class_objectProcessorQueue import ObjectProcessorQueue
 from multiqueue import MultiQueue

--- a/src/randomtrackingdict.py
+++ b/src/randomtrackingdict.py
@@ -115,20 +115,20 @@ if __name__ == '__main__':
 #    for i in range(50000):
 #        d[randString()] = True
 #    a.append(time())
-    print "populating random tracking dict"
+    print("populating random tracking dict")
     a.append(time())
     for i in range(50000):
         k[randString()] = True
     a.append(time())
-    print "done"
+    print("done")
     while len(k) > 0:
         retval = k.randomKeys(1000)
         if not retval:
-            print "error getting random keys"
+            print("error getting random keys")
         #a.append(time())
         try:
             k.randomKeys(100)
-            print "bad"
+            print("bad")
         except KeyError:
             pass
         #a.append(time())
@@ -138,4 +138,4 @@ if __name__ == '__main__':
     a.append(time())
 
     for x in range(len(a) - 1):
-        print "%i: %.3f" % (x, a[x+1] - a[x])
+        print("%i: %.3f" % (x, a[x+1] - a[x]))

--- a/src/services.py
+++ b/src/services.py
@@ -1,0 +1,1126 @@
+# Copyright (c) 2012-2016 Jonathan Warren
+# Copyright (c) 2012-2018 The Bitmessage developers
+
+"""
+This is not what you run to run the Bitmessage API. Instead, enable the API
+( https://bitmessage.org/wiki/API ) and optionally enable daemon mode
+( https://bitmessage.org/wiki/Daemon ) then run bitmessagemain.py.
+"""
+
+import base64
+import hashlib
+import json
+import time
+from binascii import hexlify, unhexlify
+
+from struct import pack
+import shared
+from addresses import (
+    decodeAddress, addBMIfNotPresent, decodeVarint,
+    calculateInventoryHash)
+
+from bmconfigparser import BMConfigParser
+import defaults
+import helper_inbox
+import helper_sent
+
+import state
+import queues
+import shutdown
+import network.stats
+
+# Classes
+from helper_sql import sqlQuery, sqlExecute, SqlBulkExecute, sqlStoredProcedure
+from helper_ackPayload import genAckPayload
+from debug import logger
+from inventory import Inventory
+from version import softwareVersion
+
+# Helper Functions
+import proofofwork
+import traceback
+from debug import logger
+
+str_chan = '[chan]'
+
+class APIError(Exception):
+            def __init__(self, error_number, error_message):
+                super(APIError, self).__init__()
+                self.error_number = error_number
+                self.error_message = error_message
+
+            def __str__(self):
+                return "API Error %04i: %s" % (self.error_number, self.error_message)
+
+class Services(object):
+
+        def _decode(self, text, decode_type):
+            try:
+                if decode_type == 'hex':
+                    return unhexlify(text)
+                elif decode_type == 'base64':
+                    return base64.b64decode(text)
+            except Exception as e:
+                raise APIError(
+                    22, "Decode error - %s. Had trouble while decoding string: %r"
+                    % (e, text)
+                )
+
+        def _verifyAddress(self, address):
+            status, addressVersionNumber, streamNumber, ripe = \
+                decodeAddress(address)
+            if status != 'success':
+                logger.warning(
+                    'API Error 0007: Could not decode address %s. Status: %s.',
+                    address, status
+                )
+
+                if status == 'checksumfailed':
+                    raise APIError(8, 'Checksum failed for address: ' + address)
+                if status == 'invalidcharacters':
+                    raise APIError(9, 'Invalid characters in address: ' + address)
+                if status == 'versiontoohigh':
+                    raise APIError(
+                        10,
+                        'Address version number too high (or zero) in address: '
+                        + address
+                    )
+                if status == 'varintmalformed':
+                    raise APIError(26, 'Malformed varint in address: ' + address)
+                raise APIError(
+                    7, 'Could not decode address: %s : %s' % (address, status))
+            if addressVersionNumber < 2 or addressVersionNumber > 4:
+                raise APIError(
+                    11, 'The address version number currently must be 2, 3 or 4.'
+                    ' Others aren\'t supported. Check the address.'
+                )
+            if streamNumber != 1:
+                raise APIError(
+                    12, 'The stream number must be 1. Others aren\'t supported.'
+                    ' Check the address.'
+                )
+
+            return (status, addressVersionNumber, streamNumber, ripe)
+
+        # Request Handlers
+
+        def HandleListAddresses(self, method):
+            data = '{"addresses":['
+            for addressInKeysFile in BMConfigParser().addresses():
+                status, addressVersionNumber, streamNumber, hash01 = decodeAddress(
+                    addressInKeysFile)
+                if len(data) > 20:
+                    data += ','
+                if BMConfigParser().has_option(addressInKeysFile, 'chan'):
+                    chan = BMConfigParser().getboolean(addressInKeysFile, 'chan')
+                else:
+                    chan = False
+                label = BMConfigParser().get(addressInKeysFile, 'label')
+                if method == 'listAddresses2':
+                    label = base64.b64encode(label)
+                data += json.dumps({
+                    'label': label,
+                    'address': addressInKeysFile,
+                    'stream': streamNumber,
+                    'enabled':
+                    BMConfigParser().getboolean(addressInKeysFile, 'enabled'),
+                    'chan': chan
+                    }, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleListAddressBookEntries(self, params):
+            if len(params) == 1:
+                label, = params
+                label = self._decode(label, "base64")
+                queryreturn = sqlQuery(
+                    "SELECT label, address from addressbook WHERE label = ?",
+                    label)
+            elif len(params) > 1:
+                raise APIError(0, "Too many paremeters, max 1")
+            else:
+                queryreturn = sqlQuery("SELECT label, address from addressbook")
+            data = '{"addresses":['
+            for row in queryreturn:
+                label, address = row
+                label = shared.fixPotentiallyInvalidUTF8Data(label)
+                if len(data) > 20:
+                    data += ','
+                data += json.dumps({
+                    'label': base64.b64encode(label),
+                    'address': address}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleAddAddressBookEntry(self, params):
+            if len(params) != 2:
+                raise APIError(0, "I need label and address")
+            address, label = params
+            label = self._decode(label, "base64")
+            address = addBMIfNotPresent(address)
+            self._verifyAddress(address)
+            queryreturn = sqlQuery(
+                "SELECT address FROM addressbook WHERE address=?", address)
+            if queryreturn != []:
+                raise APIError(
+                    16, 'You already have this address in your address book.')
+
+            sqlExecute("INSERT INTO addressbook VALUES(?,?)", label, address)
+            queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
+            queues.UISignalQueue.put(('rerenderMessagelistToLabels', ''))
+            queues.UISignalQueue.put(('rerenderAddressBook', ''))
+            return "Added address %s to address book" % address
+
+        def HandleDeleteAddressBookEntry(self, params):
+            if len(params) != 1:
+                raise APIError(0, "I need an address")
+            address, = params
+            address = addBMIfNotPresent(address)
+            self._verifyAddress(address)
+            sqlExecute('DELETE FROM addressbook WHERE address=?', address)
+            queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
+            queues.UISignalQueue.put(('rerenderMessagelistToLabels', ''))
+            queues.UISignalQueue.put(('rerenderAddressBook', ''))
+            return "Deleted address book entry for %s if it existed" % address
+
+        def HandleCreateRandomAddress(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            elif len(params) == 1:
+                label, = params
+                eighteenByteRipe = False
+                nonceTrialsPerByte = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultnoncetrialsperbyte')
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 2:
+                label, eighteenByteRipe = params
+                nonceTrialsPerByte = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultnoncetrialsperbyte')
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 3:
+                label, eighteenByteRipe, totalDifficulty = params
+                nonceTrialsPerByte = int(
+                    defaults.networkDefaultProofOfWorkNonceTrialsPerByte
+                    * totalDifficulty)
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 4:
+                label, eighteenByteRipe, totalDifficulty, \
+                    smallMessageDifficulty = params
+                nonceTrialsPerByte = int(
+                    defaults.networkDefaultProofOfWorkNonceTrialsPerByte
+                    * totalDifficulty)
+                payloadLengthExtraBytes = int(
+                    defaults.networkDefaultPayloadLengthExtraBytes
+                    * smallMessageDifficulty)
+            else:
+                raise APIError(0, 'Too many parameters!')
+            label = self._decode(label, "base64")
+            try:
+                unicode(label, 'utf-8')
+            except:
+                raise APIError(17, 'Label is not valid UTF-8 data.')
+            queues.apiAddressGeneratorReturnQueue.queue.clear()
+            streamNumberForAddress = 1
+            queues.addressGeneratorQueue.put((
+                'createRandomAddress', 4, streamNumberForAddress, label, 1, "",
+                eighteenByteRipe, nonceTrialsPerByte, payloadLengthExtraBytes
+            ))
+            return queues.apiAddressGeneratorReturnQueue.get()
+
+        def HandleCreateDeterministicAddresses(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            elif len(params) == 1:
+                passphrase, = params
+                numberOfAddresses = 1
+                addressVersionNumber = 0
+                streamNumber = 0
+                eighteenByteRipe = False
+                nonceTrialsPerByte = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultnoncetrialsperbyte')
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 2:
+                passphrase, numberOfAddresses = params
+                addressVersionNumber = 0
+                streamNumber = 0
+                eighteenByteRipe = False
+                nonceTrialsPerByte = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultnoncetrialsperbyte')
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 3:
+                passphrase, numberOfAddresses, addressVersionNumber = params
+                streamNumber = 0
+                eighteenByteRipe = False
+                nonceTrialsPerByte = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultnoncetrialsperbyte')
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 4:
+                passphrase, numberOfAddresses, addressVersionNumber, \
+                    streamNumber = params
+                eighteenByteRipe = False
+                nonceTrialsPerByte = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultnoncetrialsperbyte')
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 5:
+                passphrase, numberOfAddresses, addressVersionNumber, \
+                    streamNumber, eighteenByteRipe = params
+                nonceTrialsPerByte = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultnoncetrialsperbyte')
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 6:
+                passphrase, numberOfAddresses, addressVersionNumber, \
+                    streamNumber, eighteenByteRipe, totalDifficulty = params
+                nonceTrialsPerByte = int(
+                    defaults.networkDefaultProofOfWorkNonceTrialsPerByte
+                    * totalDifficulty)
+                payloadLengthExtraBytes = BMConfigParser().get(
+                    'bitmessagesettings', 'defaultpayloadlengthextrabytes')
+            elif len(params) == 7:
+                passphrase, numberOfAddresses, addressVersionNumber, \
+                    streamNumber, eighteenByteRipe, totalDifficulty, \
+                    smallMessageDifficulty = params
+                nonceTrialsPerByte = int(
+                    defaults.networkDefaultProofOfWorkNonceTrialsPerByte
+                    * totalDifficulty)
+                payloadLengthExtraBytes = int(
+                    defaults.networkDefaultPayloadLengthExtraBytes
+                    * smallMessageDifficulty)
+            else:
+                raise APIError(0, 'Too many parameters!')
+            if len(passphrase) == 0:
+                raise APIError(1, 'The specified passphrase is blank.')
+            if not isinstance(eighteenByteRipe, bool):
+                raise APIError(
+                    23, 'Bool expected in eighteenByteRipe, saw %s instead' %
+                    type(eighteenByteRipe))
+            passphrase = self._decode(passphrase, "base64")
+            # 0 means "just use the proper addressVersionNumber"
+            if addressVersionNumber == 0:
+                addressVersionNumber = 4
+            if addressVersionNumber != 3 and addressVersionNumber != 4:
+                raise APIError(
+                    2, 'The address version number currently must be 3, 4, or 0'
+                    ' (which means auto-select). %i isn\'t supported.' %
+                    addressVersionNumber)
+            if streamNumber == 0:  # 0 means "just use the most available stream"
+                streamNumber = 1
+            if streamNumber != 1:
+                raise APIError(
+                    3, 'The stream number must be 1 (or 0 which means'
+                    ' auto-select). Others aren\'t supported.')
+            if numberOfAddresses == 0:
+                raise APIError(
+                    4, 'Why would you ask me to generate 0 addresses for you?')
+            if numberOfAddresses > 999:
+                raise APIError(
+                    5, 'You have (accidentally?) specified too many addresses to'
+                    ' make. Maximum 999. This check only exists to prevent'
+                    ' mischief; if you really want to create more addresses than'
+                    ' this, contact the Bitmessage developers and we can modify'
+                    ' the check or you can do it yourself by searching the source'
+                    ' code for this message.')
+            queues.apiAddressGeneratorReturnQueue.queue.clear()
+            logger.debug(
+                'Requesting that the addressGenerator create %s addresses.',
+                numberOfAddresses)
+            queues.addressGeneratorQueue.put((
+                'createDeterministicAddresses', addressVersionNumber, streamNumber,
+                'unused API address', numberOfAddresses, passphrase,
+                eighteenByteRipe, nonceTrialsPerByte, payloadLengthExtraBytes
+            ))
+            data = '{"addresses":['
+            queueReturn = queues.apiAddressGeneratorReturnQueue.get()
+            for item in queueReturn:
+                if len(data) > 20:
+                    data += ','
+                data += "\"" + item + "\""
+            data += ']}'
+            return data
+
+        def HandleGetDeterministicAddress(self, params):
+            if len(params) != 3:
+                raise APIError(0, 'I need exactly 3 parameters.')
+            passphrase, addressVersionNumber, streamNumber = params
+            numberOfAddresses = 1
+            eighteenByteRipe = False
+            if len(passphrase) == 0:
+                raise APIError(1, 'The specified passphrase is blank.')
+            passphrase = self._decode(passphrase, "base64")
+            if addressVersionNumber != 3 and addressVersionNumber != 4:
+                raise APIError(
+                    2, 'The address version number currently must be 3 or 4. %i'
+                    ' isn\'t supported.' % addressVersionNumber)
+            if streamNumber != 1:
+                raise APIError(
+                    3, ' The stream number must be 1. Others aren\'t supported.')
+            queues.apiAddressGeneratorReturnQueue.queue.clear()
+            logger.debug(
+                'Requesting that the addressGenerator create %s addresses.',
+                numberOfAddresses)
+            queues.addressGeneratorQueue.put((
+                'getDeterministicAddress', addressVersionNumber, streamNumber,
+                'unused API address', numberOfAddresses, passphrase,
+                eighteenByteRipe
+            ))
+            return queues.apiAddressGeneratorReturnQueue.get()
+
+        def HandleCreateChan(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters.')
+            elif len(params) == 1:
+                passphrase, = params
+            passphrase = self._decode(passphrase, "base64")
+            if len(passphrase) == 0:
+                raise APIError(1, 'The specified passphrase is blank.')
+            # It would be nice to make the label the passphrase but it is
+            # possible that the passphrase contains non-utf-8 characters.
+            try:
+                unicode(passphrase, 'utf-8')
+                label = str_chan + ' ' + passphrase
+            except:
+                label = str_chan + ' ' + repr(passphrase)
+
+            addressVersionNumber = 4
+            streamNumber = 1
+            queues.apiAddressGeneratorReturnQueue.queue.clear()
+            logger.debug(
+                'Requesting that the addressGenerator create chan %s.', passphrase)
+            queues.addressGeneratorQueue.put((
+                'createChan', addressVersionNumber, streamNumber, label,
+                passphrase, True
+            ))
+            queueReturn = queues.apiAddressGeneratorReturnQueue.get()
+            if len(queueReturn) == 0:
+                raise APIError(24, 'Chan address is already present.')
+            address = queueReturn[0]
+            return address
+
+        def HandleJoinChan(self, params):
+            if len(params) < 2:
+                raise APIError(0, 'I need two parameters.')
+            elif len(params) == 2:
+                passphrase, suppliedAddress = params
+            passphrase = self._decode(passphrase, "base64")
+            if len(passphrase) == 0:
+                raise APIError(1, 'The specified passphrase is blank.')
+            # It would be nice to make the label the passphrase but it is
+            # possible that the passphrase contains non-utf-8 characters.
+            try:
+                unicode(passphrase, 'utf-8')
+                label = str_chan + ' ' + passphrase
+            except:
+                label = str_chan + ' ' + repr(passphrase)
+
+            status, addressVersionNumber, streamNumber, toRipe = \
+                self._verifyAddress(suppliedAddress)
+            suppliedAddress = addBMIfNotPresent(suppliedAddress)
+            queues.apiAddressGeneratorReturnQueue.queue.clear()
+            queues.addressGeneratorQueue.put((
+                'joinChan', suppliedAddress, label, passphrase, True
+            ))
+            addressGeneratorReturnValue = \
+                queues.apiAddressGeneratorReturnQueue.get()
+
+            if addressGeneratorReturnValue[0] == \
+                    'chan name does not match address':
+                raise APIError(18, 'Chan name does not match address.')
+            if len(addressGeneratorReturnValue) == 0:
+                raise APIError(24, 'Chan address is already present.')
+            # TODO: this variable is not used to anything
+            # in case we ever want it for anything.
+            # createdAddress = addressGeneratorReturnValue[0]
+            return "success"
+
+        def HandleLeaveChan(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters.')
+            elif len(params) == 1:
+                address, = params
+            status, addressVersionNumber, streamNumber, toRipe = \
+                self._verifyAddress(address)
+            address = addBMIfNotPresent(address)
+            if not BMConfigParser().has_section(address):
+                raise APIError(
+                    13, 'Could not find this address in your keys.dat file.')
+            if not BMConfigParser().safeGetBoolean(address, 'chan'):
+                raise APIError(
+                    25, 'Specified address is not a chan address.'
+                    ' Use deleteAddress API call instead.')
+            BMConfigParser().remove_section(address)
+            with open(state.appdata + 'keys.dat', 'wb') as configfile:
+                BMConfigParser().write(configfile)
+            return 'success'
+
+        def HandleDeleteAddress(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters.')
+            elif len(params) == 1:
+                address, = params
+            status, addressVersionNumber, streamNumber, toRipe = \
+                self._verifyAddress(address)
+            address = addBMIfNotPresent(address)
+            if not BMConfigParser().has_section(address):
+                raise APIError(
+                    13, 'Could not find this address in your keys.dat file.')
+            BMConfigParser().remove_section(address)
+            with open(state.appdata + 'keys.dat', 'wb') as configfile:
+                BMConfigParser().write(configfile)
+            queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
+            queues.UISignalQueue.put(('rerenderMessagelistToLabels', ''))
+            shared.reloadMyAddressHashes()
+            return 'success'
+
+        def HandleGetAllInboxMessages(self, params):
+            queryreturn = sqlQuery(
+                "SELECT msgid, toaddress, fromaddress, subject, received, message,"
+                " encodingtype, read FROM inbox where folder='inbox'"
+                " ORDER BY received"
+            )
+            data = '{"inboxMessages":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, received, message, \
+                    encodingtype, read = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                if len(data) > 25:
+                    data += ','
+                data += json.dumps({
+                    'msgid': hexlify(msgid),
+                    'toAddress': toAddress,
+                    'fromAddress': fromAddress,
+                    'subject': base64.b64encode(subject),
+                    'message': base64.b64encode(message),
+                    'encodingType': encodingtype,
+                    'receivedTime': received,
+                    'read': read}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleGetAllInboxMessageIds(self, params):
+            queryreturn = sqlQuery(
+                "SELECT msgid FROM inbox where folder='inbox' ORDER BY received")
+            data = '{"inboxMessageIds":['
+            for row in queryreturn:
+                msgid = row[0]
+                if len(data) > 25:
+                    data += ','
+                data += json.dumps(
+                    {'msgid': hexlify(msgid)}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleGetInboxMessageById(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            elif len(params) == 1:
+                msgid = self._decode(params[0], "hex")
+            elif len(params) >= 2:
+                msgid = self._decode(params[0], "hex")
+                readStatus = params[1]
+                if not isinstance(readStatus, bool):
+                    raise APIError(
+                        23, 'Bool expected in readStatus, saw %s instead.' %
+                        type(readStatus))
+                queryreturn = sqlQuery(
+                    "SELECT read FROM inbox WHERE msgid=?", msgid)
+                # UPDATE is slow, only update if status is different
+                if queryreturn != [] and (queryreturn[0][0] == 1) != readStatus:
+                    sqlExecute(
+                        "UPDATE inbox set read = ? WHERE msgid=?",
+                        readStatus, msgid)
+                    queues.UISignalQueue.put(('changedInboxUnread', None))
+            queryreturn = sqlQuery(
+                "SELECT msgid, toaddress, fromaddress, subject, received, message,"
+                " encodingtype, read FROM inbox WHERE msgid=?", msgid
+            )
+            data = '{"inboxMessage":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, received, message, \
+                    encodingtype, read = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                data += json.dumps({
+                    'msgid': hexlify(msgid),
+                    'toAddress': toAddress,
+                    'fromAddress': fromAddress,
+                    'subject': base64.b64encode(subject),
+                    'message': base64.b64encode(message),
+                    'encodingType': encodingtype,
+                    'receivedTime': received,
+                    'read': read}, indent=4, separators=(',', ': '))
+                data += ']}'
+                return data
+
+        def HandleGetAllSentMessages(self, params):
+            queryreturn = sqlQuery(
+                "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
+                " message, encodingtype, status, ackdata FROM sent"
+                " WHERE folder='sent' ORDER BY lastactiontime"
+            )
+            data = '{"sentMessages":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, lastactiontime, message, \
+                    encodingtype, status, ackdata = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                if len(data) > 25:
+                    data += ','
+                data += json.dumps({
+                    'msgid': hexlify(msgid),
+                    'toAddress': toAddress,
+                    'fromAddress': fromAddress,
+                    'subject': base64.b64encode(subject),
+                    'message': base64.b64encode(message),
+                    'encodingType': encodingtype,
+                    'lastActionTime': lastactiontime,
+                    'status': status,
+                    'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleGetAllSentMessageIds(self, params):
+            queryreturn = sqlQuery(
+                "SELECT msgid FROM sent where folder='sent'"
+                " ORDER BY lastactiontime"
+            )
+            data = '{"sentMessageIds":['
+            for row in queryreturn:
+                msgid = row[0]
+                if len(data) > 25:
+                    data += ','
+                data += json.dumps(
+                    {'msgid': hexlify(msgid)}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleInboxMessagesByReceiver(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            toAddress = params[0]
+            queryreturn = sqlQuery(
+                "SELECT msgid, toaddress, fromaddress, subject, received, message,"
+                " encodingtype FROM inbox WHERE folder='inbox' AND toAddress=?",
+                toAddress)
+            data = '{"inboxMessages":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, received, message, \
+                    encodingtype = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                if len(data) > 25:
+                    data += ','
+                data += json.dumps({
+                    'msgid': hexlify(msgid),
+                    'toAddress': toAddress,
+                    'fromAddress': fromAddress,
+                    'subject': base64.b64encode(subject),
+                    'message': base64.b64encode(message),
+                    'encodingType': encodingtype,
+                    'receivedTime': received}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleGetSentMessageById(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            msgid = self._decode(params[0], "hex")
+            queryreturn = sqlQuery(
+                "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
+                " message, encodingtype, status, ackdata FROM sent WHERE msgid=?",
+                msgid
+            )
+            data = '{"sentMessage":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, lastactiontime, message, \
+                    encodingtype, status, ackdata = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                data += json.dumps({
+                    'msgid': hexlify(msgid),
+                    'toAddress': toAddress,
+                    'fromAddress': fromAddress,
+                    'subject': base64.b64encode(subject),
+                    'message': base64.b64encode(message),
+                    'encodingType': encodingtype,
+                    'lastActionTime': lastactiontime,
+                    'status': status,
+                    'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
+                data += ']}'
+                return data
+
+        def HandleGetSentMessagesBySender(self, params):  # HandleGetSentMessagesByAddress
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            fromAddress = params[0]
+            queryreturn = sqlQuery(
+                "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
+                " message, encodingtype, status, ackdata FROM sent"
+                " WHERE folder='sent' AND fromAddress=? ORDER BY lastactiontime",
+                fromAddress
+            )
+            data = '{"sentMessages":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, lastactiontime, message, \
+                    encodingtype, status, ackdata = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                if len(data) > 25:
+                    data += ','
+                data += json.dumps({
+                    'msgid': hexlify(msgid),
+                    'toAddress': toAddress,
+                    'fromAddress': fromAddress,
+                    'subject': base64.b64encode(subject),
+                    'message': base64.b64encode(message),
+                    'encodingType': encodingtype,
+                    'lastActionTime': lastactiontime,
+                    'status': status,
+                    'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleGetSentMessagesByAckData(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            ackData = self._decode(params[0], "hex")
+            queryreturn = sqlQuery(
+                "SELECT msgid, toaddress, fromaddress, subject, lastactiontime,"
+                " message, encodingtype, status, ackdata FROM sent"
+                " WHERE ackdata=?", ackData
+            )
+            data = '{"sentMessage":['
+            for row in queryreturn:
+                msgid, toAddress, fromAddress, subject, lastactiontime, message, \
+                    encodingtype, status, ackdata = row
+                subject = shared.fixPotentiallyInvalidUTF8Data(subject)
+                message = shared.fixPotentiallyInvalidUTF8Data(message)
+                data += json.dumps({
+                    'msgid': hexlify(msgid),
+                    'toAddress': toAddress,
+                    'fromAddress': fromAddress,
+                    'subject': base64.b64encode(subject),
+                    'message': base64.b64encode(message),
+                    'encodingType': encodingtype,
+                    'lastActionTime': lastactiontime,
+                    'status': status,
+                    'ackData': hexlify(ackdata)}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleTrashMessage(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            msgid = self._decode(params[0], "hex")
+
+            # Trash if in inbox table
+            helper_inbox.trash(msgid)
+            # Trash if in sent table
+            sqlExecute('''UPDATE sent SET folder='trash' WHERE msgid=?''', msgid)
+            return 'Trashed message (assuming message existed).'
+
+        def HandleTrashInboxMessage(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            msgid = self._decode(params[0], "hex")
+            helper_inbox.trash(msgid)
+            return 'Trashed inbox message (assuming message existed).'
+
+        def HandleTrashSentMessage(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            msgid = self._decode(params[0], "hex")
+            sqlExecute('''UPDATE sent SET folder='trash' WHERE msgid=?''', msgid)
+            return 'Trashed sent message (assuming message existed).'
+
+        def HandleSendMessage(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            elif len(params) == 4:
+                toAddress, fromAddress, subject, message = params
+                encodingType = 2
+                TTL = 4 * 24 * 60 * 60
+            elif len(params) == 5:
+                toAddress, fromAddress, subject, message, encodingType = params
+                TTL = 4 * 24 * 60 * 60
+            elif len(params) == 6:
+                toAddress, fromAddress, subject, message, encodingType, TTL = \
+                    params
+            if encodingType not in [2, 3]:
+                raise APIError(6, 'The encoding type must be 2 or 3.')
+            subject = self._decode(subject, "base64")
+            message = self._decode(message, "base64")
+            if len(subject + message) > (2 ** 18 - 500):
+                raise APIError(27, 'Message is too long.')
+            if TTL < 60 * 60:
+                TTL = 60 * 60
+            if TTL > 28 * 24 * 60 * 60:
+                TTL = 28 * 24 * 60 * 60
+            toAddress = addBMIfNotPresent(toAddress)
+            fromAddress = addBMIfNotPresent(fromAddress)
+            status, addressVersionNumber, streamNumber, toRipe = \
+                self._verifyAddress(toAddress)
+            self._verifyAddress(fromAddress)
+            try:
+                fromAddressEnabled = BMConfigParser().getboolean(
+                    fromAddress, 'enabled')
+            except:
+                raise APIError(
+                    13, 'Could not find your fromAddress in the keys.dat file.')
+            if not fromAddressEnabled:
+                raise APIError(14, 'Your fromAddress is disabled. Cannot send.')
+
+            stealthLevel = BMConfigParser().safeGetInt(
+                'bitmessagesettings', 'ackstealthlevel')
+            ackdata = genAckPayload(streamNumber, stealthLevel)
+
+            t = ('',
+                toAddress,
+                toRipe,
+                fromAddress,
+                subject,
+                message,
+                ackdata,
+                int(time.time()),  # sentTime (this won't change)
+                int(time.time()),  # lastActionTime
+                0,
+                'msgqueued',
+                0,
+                'sent',
+                2,
+                TTL)
+            helper_sent.insert(t)
+
+            toLabel = ''
+            queryreturn = sqlQuery(
+                "SELECT label FROM addressbook WHERE address=?", toAddress)
+            if queryreturn != []:
+                for row in queryreturn:
+                    toLabel, = row
+            # apiSignalQueue.put(('displayNewSentMessage',(toAddress,toLabel,fromAddress,subject,message,ackdata)))
+            queues.UISignalQueue.put(('displayNewSentMessage', (
+                toAddress, toLabel, fromAddress, subject, message, ackdata)))
+
+            queues.workerQueue.put(('sendmessage', toAddress))
+
+            return hexlify(ackdata)
+
+        def HandleSendBroadcast(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            if len(params) == 3:
+                fromAddress, subject, message = params
+                encodingType = 2
+                TTL = 4 * 24 * 60 * 60
+            elif len(params) == 4:
+                fromAddress, subject, message, encodingType = params
+                TTL = 4 * 24 * 60 * 60
+            elif len(params) == 5:
+                fromAddress, subject, message, encodingType, TTL = params
+            if encodingType not in [2, 3]:
+                raise APIError(6, 'The encoding type must be 2 or 3.')
+            subject = self._decode(subject, "base64")
+            message = self._decode(message, "base64")
+            if len(subject + message) > (2 ** 18 - 500):
+                raise APIError(27, 'Message is too long.')
+            if TTL < 60 * 60:
+                TTL = 60 * 60
+            if TTL > 28 * 24 * 60 * 60:
+                TTL = 28 * 24 * 60 * 60
+            fromAddress = addBMIfNotPresent(fromAddress)
+            self._verifyAddress(fromAddress)
+            try:
+                BMConfigParser().getboolean(fromAddress, 'enabled')
+            except:
+                raise APIError(
+                    13, 'could not find your fromAddress in the keys.dat file.')
+            streamNumber = decodeAddress(fromAddress)[2]
+            ackdata = genAckPayload(streamNumber, 0)
+            toAddress = '[Broadcast subscribers]'
+            ripe = ''
+
+            t = ('',
+                toAddress,
+                ripe,
+                fromAddress,
+                subject,
+                message,
+                ackdata,
+                int(time.time()),  # sentTime (this doesn't change)
+                int(time.time()),  # lastActionTime
+                0,
+                'broadcastqueued',
+                0,
+                'sent',
+                2,
+                TTL)
+            helper_sent.insert(t)
+
+            toLabel = '[Broadcast subscribers]'
+            queues.UISignalQueue.put(('displayNewSentMessage', (
+                toAddress, toLabel, fromAddress, subject, message, ackdata)))
+            queues.workerQueue.put(('sendbroadcast', ''))
+
+            return hexlify(ackdata)
+
+        def HandleGetStatus(self, params):
+            if len(params) != 1:
+                raise APIError(0, 'I need one parameter!')
+            ackdata, = params
+            if len(ackdata) < 76:
+                # The length of ackData should be at least 38 bytes (76 hex digits)
+                raise APIError(15, 'Invalid ackData object size.')
+            ackdata = self._decode(ackdata, "hex")
+            queryreturn = sqlQuery(
+                "SELECT status FROM sent where ackdata=?", ackdata)
+            if queryreturn == []:
+                return 'notfound'
+            for row in queryreturn:
+                status, = row
+                return status
+
+        def HandleAddSubscription(self, params):
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            if len(params) == 1:
+                address, = params
+                label = ''
+            if len(params) == 2:
+                address, label = params
+                label = self._decode(label, "base64")
+                try:
+                    unicode(label, 'utf-8')
+                except:
+                    raise APIError(17, 'Label is not valid UTF-8 data.')
+            if len(params) > 2:
+                raise APIError(0, 'I need either 1 or 2 parameters!')
+            address = addBMIfNotPresent(address)
+            self._verifyAddress(address)
+            # First we must check to see if the address is already in the
+            # subscriptions list.
+            queryreturn = sqlQuery(
+                "SELECT * FROM subscriptions WHERE address=?", address)
+            if queryreturn != []:
+                raise APIError(16, 'You are already subscribed to that address.')
+            sqlExecute(
+                "INSERT INTO subscriptions VALUES (?,?,?)", label, address, True)
+            shared.reloadBroadcastSendersForWhichImWatching()
+            queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
+            queues.UISignalQueue.put(('rerenderSubscriptions', ''))
+            return 'Added subscription.'
+
+        def HandleDeleteSubscription(self, params):
+            if len(params) != 1:
+                raise APIError(0, 'I need 1 parameter!')
+            address, = params
+            address = addBMIfNotPresent(address)
+            sqlExecute('''DELETE FROM subscriptions WHERE address=?''', address)
+            shared.reloadBroadcastSendersForWhichImWatching()
+            queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
+            queues.UISignalQueue.put(('rerenderSubscriptions', ''))
+            return 'Deleted subscription if it existed.'
+
+        def HandleListSubscriptions(self, params):  # ListSubscriptions
+            queryreturn = sqlQuery(
+                "SELECT label, address, enabled FROM subscriptions")
+            data = {'subscriptions': []}
+            for row in queryreturn:
+                label, address, enabled = row
+                label = shared.fixPotentiallyInvalidUTF8Data(label)
+                data['subscriptions'].append({
+                    'label': base64.b64encode(label),
+                    'address': address,
+                    'enabled': enabled == 1
+                })
+            return json.dumps(data, indent=4, separators=(',', ': '))
+
+        def HandleDisseminatePreEncryptedMsg(self, params):
+            # The device issuing this command to PyBitmessage supplies a msg
+            # object that has already been encrypted but which still needs the POW
+            # to be done. PyBitmessage accepts this msg object and sends it out
+            # to the rest of the Bitmessage network as if it had generated
+            # the message itself. Please do not yet add this to the api doc.
+            if len(params) != 3:
+                raise APIError(0, 'I need 3 parameter!')
+            encryptedPayload, requiredAverageProofOfWorkNonceTrialsPerByte, \
+                requiredPayloadLengthExtraBytes = params
+            encryptedPayload = self._decode(encryptedPayload, "hex")
+            # Let us do the POW and attach it to the front
+            target = 2**64 / (
+                (len(encryptedPayload) + requiredPayloadLengthExtraBytes + 8)
+                * requiredAverageProofOfWorkNonceTrialsPerByte)
+            with shared.printLock:
+                print('(For msg message via API) Doing proof of work. Total required difficulty:', float(requiredAverageProofOfWorkNonceTrialsPerByte) / defaults.networkDefaultProofOfWorkNonceTrialsPerByte, 'Required small message difficulty:', float(requiredPayloadLengthExtraBytes) / defaults.networkDefaultPayloadLengthExtraBytes)
+            powStartTime = time.time()
+            initialHash = hashlib.sha512(encryptedPayload).digest()
+            trialValue, nonce = proofofwork.run(target, initialHash)
+            with shared.printLock:
+                print('(For msg message via API) Found proof of work', trialValue, 'Nonce:', nonce)
+                try:
+                    print('POW took %d seconds. %d nonce trials per second.' % (int(time.time() - powStartTime), nonce / (time.time() - powStartTime)))
+                except:
+                    pass
+            encryptedPayload = pack('>Q', nonce) + encryptedPayload
+            toStreamNumber = decodeVarint(encryptedPayload[16:26])[0]
+            inventoryHash = calculateInventoryHash(encryptedPayload)
+            objectType = 2
+            TTL = 2.5 * 24 * 60 * 60
+            Inventory()[inventoryHash] = (
+                objectType, toStreamNumber, encryptedPayload,
+                int(time.time()) + TTL, ''
+            )
+            with shared.printLock:
+                print('Broadcasting inv for msg(API disseminatePreEncryptedMsg command):', hexlify(inventoryHash))
+            queues.invQueue.put((toStreamNumber, inventoryHash))
+
+        def HandleTrashSentMessageByAckDAta(self, params):
+            # This API method should only be used when msgid is not available
+            if len(params) == 0:
+                raise APIError(0, 'I need parameters!')
+            ackdata = self._decode(params[0], "hex")
+            sqlExecute("UPDATE sent SET folder='trash' WHERE ackdata=?", ackdata)
+            return 'Trashed sent message (assuming message existed).'
+
+        def HandleDissimatePubKey(self, params):
+            # The device issuing this command to PyBitmessage supplies a pubkey
+            # object to be disseminated to the rest of the Bitmessage network.
+            # PyBitmessage accepts this pubkey object and sends it out to the rest
+            # of the Bitmessage network as if it had generated the pubkey object
+            # itself. Please do not yet add this to the api doc.
+            if len(params) != 1:
+                raise APIError(0, 'I need 1 parameter!')
+            payload, = params
+            payload = self._decode(payload, "hex")
+
+            # Let us do the POW
+            target = 2 ** 64 / (
+                (len(payload) + defaults.networkDefaultPayloadLengthExtraBytes
+                + 8) * defaults.networkDefaultProofOfWorkNonceTrialsPerByte)
+            print('(For pubkey message via API) Doing proof of work...')
+            initialHash = hashlib.sha512(payload).digest()
+            trialValue, nonce = proofofwork.run(target, initialHash)
+            print('(For pubkey message via API) Found proof of work', trialValue, 'Nonce:', nonce)
+            payload = pack('>Q', nonce) + payload
+
+            pubkeyReadPosition = 8  # bypass the nonce
+            if payload[pubkeyReadPosition:pubkeyReadPosition+4] == \
+                    '\x00\x00\x00\x00':  # if this pubkey uses 8 byte time
+                pubkeyReadPosition += 8
+            else:
+                pubkeyReadPosition += 4
+            addressVersion, addressVersionLength = decodeVarint(
+                payload[pubkeyReadPosition:pubkeyReadPosition+10])
+            pubkeyReadPosition += addressVersionLength
+            pubkeyStreamNumber = decodeVarint(
+                payload[pubkeyReadPosition:pubkeyReadPosition+10])[0]
+            inventoryHash = calculateInventoryHash(payload)
+            objectType = 1  # TODO: support v4 pubkeys
+            TTL = 28 * 24 * 60 * 60
+            Inventory()[inventoryHash] = (
+                objectType, pubkeyStreamNumber, payload, int(time.time()) + TTL, ''
+            )
+            with shared.printLock:
+                print('broadcasting inv within API command disseminatePubkey with hash:', hexlify(inventoryHash))
+            queues.invQueue.put((pubkeyStreamNumber, inventoryHash))
+
+        def HandleGetMessageDataByDestinationHash(self, params):
+            # Method will eventually be used by a particular Android app to
+            # select relevant messages. Do not yet add this to the api
+            # doc.
+            if len(params) != 1:
+                raise APIError(0, 'I need 1 parameter!')
+            requestedHash, = params
+            if len(requestedHash) != 32:
+                raise APIError(
+                    19, 'The length of hash should be 32 bytes (encoded in hex'
+                    ' thus 64 characters).')
+            requestedHash = self._decode(requestedHash, "hex")
+
+            # This is not a particularly commonly used API function. Before we
+            # use it we'll need to fill out a field in our inventory database
+            # which is blank by default (first20bytesofencryptedmessage).
+            queryreturn = sqlQuery(
+                "SELECT hash, payload FROM inventory WHERE tag = ''"
+                " and objecttype = 2")
+            with SqlBulkExecute() as sql:
+                for row in queryreturn:
+                    hash01, payload = row
+                    readPosition = 16  # Nonce length + time length
+                    # Stream Number length
+                    readPosition += decodeVarint(
+                        payload[readPosition:readPosition+10])[1]
+                    t = (payload[readPosition:readPosition+32], hash01)
+                    sql.execute("UPDATE inventory SET tag=? WHERE hash=?", *t)
+
+            queryreturn = sqlQuery(
+                "SELECT payload FROM inventory WHERE tag = ?", requestedHash)
+            data = '{"receivedMessageDatas":['
+            for row in queryreturn:
+                payload, = row
+                if len(data) > 25:
+                    data += ','
+                data += json.dumps(
+                    {'data': hexlify(payload)}, indent=4, separators=(',', ': '))
+            data += ']}'
+            return data
+
+        def HandleClientStatus(self, params):
+            if len(network.stats.connectedHostsList()) == 0:
+                networkStatus = 'notConnected'
+            elif len(network.stats.connectedHostsList()) > 0 \
+                    and not shared.clientHasReceivedIncomingConnections:
+                networkStatus = 'connectedButHaveNotReceivedIncomingConnections'
+            else:
+                networkStatus = 'connectedAndReceivingIncomingConnections'
+            return json.dumps({
+                'networkConnections': len(network.stats.connectedHostsList()),
+                'numberOfMessagesProcessed': shared.numberOfMessagesProcessed,
+                'numberOfBroadcastsProcessed': shared.numberOfBroadcastsProcessed,
+                'numberOfPubkeysProcessed': shared.numberOfPubkeysProcessed,
+                'networkStatus': networkStatus,
+                'softwareName': 'PyBitmessage',
+                'softwareVersion': softwareVersion
+                }, indent=4, separators=(',', ': '))
+
+        def HandleDecodeAddress(self, params):
+            # Return a meaningful decoding of an address.
+            if len(params) != 1:
+                raise APIError(0, 'I need 1 parameter!')
+            address, = params
+            status, addressVersion, streamNumber, ripe = decodeAddress(address)
+            return json.dumps({
+                'status': status,
+                'addressVersion': addressVersion,
+                'streamNumber': streamNumber,
+                'ripe': base64.b64encode(ripe)
+                }, indent=4, separators=(',', ': '))
+
+        def HandleHelloWorld(self, params):
+            a, b = params
+            return a + '-' + b
+
+        def HandleAdd(self, params):
+            a, b = params
+            return a + b
+
+        def HandleStatusBar(self, params):
+            message, = params
+            queues.UISignalQueue.put(('updateStatusBar', message))
+
+        def HandleDeleteAndVacuum(self, params):
+            if not params:
+                sqlStoredProcedure('deleteandvacuume')
+                return 'done'
+
+        def HandleShutdown(self, params):
+            if not params:
+                shutdown.doCleanShutdown()
+                return 'done'
+

--- a/src/shutdown.py
+++ b/src/shutdown.py
@@ -1,5 +1,9 @@
 import os
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 import threading
 import time
 

--- a/src/singleinstance.py
+++ b/src/singleinstance.py
@@ -74,7 +74,7 @@ class singleinstance:
                     fcntl.lockf(self.fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 self.lockPid = os.getpid()
             except IOError:
-                print 'Another instance of this application is already running'
+                print('Another instance of this application is already running')
                 sys.exit(-1)
             else:
                 pidLine = "%i\n" % self.lockPid
@@ -93,11 +93,11 @@ class singleinstance:
                         os.close(self.fd)
                 else:
                     fcntl.lockf(self.fp, fcntl.LOCK_UN)
-            except Exception, e:
+            except Exception as e:
                 pass
 
             return
-        print "Cleaning up lockfile"
+        print('Cleaning up lockfile')
         try:
             if sys.platform == 'win32':
                 if hasattr(self, 'fd'):

--- a/src/storage/filesystem.py
+++ b/src/storage/filesystem.py
@@ -6,7 +6,7 @@ import time
 import traceback
 
 from paths import lookupAppdataFolder
-from storage import InventoryStorage, InventoryItem
+from .storage import InventoryStorage, InventoryItem
 
 class FilesystemInventory(InventoryStorage):
     topDir = "inventory"
@@ -108,7 +108,7 @@ class FilesystemInventory(InventoryStorage):
                     newInventory[streamNumber] = {}
                     newInventory[streamNumber][hashId] = InventoryItem(objectType, streamNumber, None, expiresTime, tag)
             except KeyError:
-                print "error loading %s" % (hexlify(hashId))
+                print ("error loading %s" % (hexlify(hashId)))
                 pass
         self._inventory = newInventory
 #        for i, v in self._inventory.items():

--- a/src/storage/sqlite.py
+++ b/src/storage/sqlite.py
@@ -1,11 +1,15 @@
 import collections
 from threading import current_thread, enumerate as threadingEnumerate, RLock
-import Queue
+try:
+    import Queue as Queue
+except ImportError:
+    import queue as Queue
+
 import sqlite3
 import time
 
 from helper_sql import *
-from storage import InventoryStorage, InventoryItem
+from .storage import InventoryStorage, InventoryItem
 
 class SqliteInventory(InventoryStorage):
     def __init__(self):

--- a/src/tr.py
+++ b/src/tr.py
@@ -25,8 +25,8 @@ def translateText(context, text, n = None):
         try:
             from PyQt4 import QtCore, QtGui
         except Exception as err:
-            print 'PyBitmessage requires PyQt unless you want to run it as a daemon and interact with it using the API. You can download PyQt from http://www.riverbankcomputing.com/software/pyqt/download   or by searching Google for \'PyQt Download\'. If you want to run in daemon mode, see https://bitmessage.org/wiki/Daemon'
-            print 'Error message:', err
+            print('PyBitmessage requires PyQt unless you want to run it as a daemon and interact with it using the API. You can download PyQt from http://www.riverbankcomputing.com/software/pyqt/download   or by searching Google for \'PyQt Download\'. If you want to run in daemon mode, see https://bitmessage.org/wiki/Daemon')
+            print('Error message:', err)
             os._exit(0)
         if n is None:
             return QtGui.QApplication.translate(context, text)


### PR DESCRIPTION
API service refactoring

* Introspection and multicall API method restored(server side apply)
+ Try import ssl for API server
+ Test mode for `src/api.py`
+ Try compatible to python3(curses and PyQt4 GUI not tested.)

* Mainly changes:
  * Message attachments faults detecting, dump base64 embeded contents to files allowed
  * Multi-line message acceptable in sending(cancel with `Ctrl+D`), and allow resent on 'Connection Error.'
  * Print out detailed API Error returned.
  * Update Contacts list cmd, bcz contact list API returns unEncoded lable
  * Message pull routing refine, mainlly access inbox messages by IDs
  * API connections `SOCKS5` `HTTP` proxy supportted
* UIs
  * Shorten the user cmds inputs
  * Try to replay user last choices.(rest to default selection by input a blank string)
  * A comprehensive command line parser, override configurations read from file `client.dat` in current working directory.(parse API settings from "keys.dat" either, if located in BMs main directory)
  * Message review limited to 380 characters in default and rewinds enabled

default settings `client.dat`
```
[global]
#start_daemon = http://127.0.0.1:8442

[api]
path = 127.0.0.1:8442
type = HTTP

[proxy]
path = 127.0.0.1:1080
type = none
timeout = 30
remotedns = True
```