### PR TITLE
Fix exception 'KeyError: None' in checkdeps introduced in e92a85e

### DIFF
--- a/src/depends.py
+++ b/src/depends.py
@@ -137,7 +137,7 @@ def detectOSRelease():
         for line in osRelease:
             if line.startswith("NAME="):
                 detectOS.result = OS_RELEASE.get(
-                    line.split("=")[-1].strip().lower())
+                    line.replace('"', '').split("=")[-1].strip().lower())
             elif line.startswith("VERSION_ID="):
                 try:
                     version = float(line.split("=")[1].replace("\"", ""))


### PR DESCRIPTION
Hello.

#1316 is my bug (: https://travis-ci.org/g1itch/PyBitmessage/builds/405760919
I didn't take into account a quotation marks in /etc/os-release