### PR TITLE
Fixed: Wait for lists to be populated. Closes #1335.

### DIFF
--- a/src/network/connectionchooser.py
+++ b/src/network/connectionchooser.py
@@ -1,5 +1,6 @@
 from queues import Queue
 import random
+import time
 
 from bmconfigparser import BMConfigParser
 import knownnodes
@@ -33,6 +34,8 @@ def chooseConnection(stream):
     if helper_random.randomchoice((False, True)) and not haveOnion:
         # discovered peers are already filtered by allowed streams
         return getDiscoveredPeer()
+    while not knownnodes.knownNodes[stream]:
+        time.sleep(1)
     for _ in range(50):
         peer = helper_random.randomchoice(knownnodes.knownNodes[stream].keys())
         try:

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -31,7 +31,7 @@ class BMConnectionPool(object):
         self.udpSockets = {}
         self.streams = []
         self.lastSpawned = 0
-        self.spawnWait = 2 
+        self.spawnWait = 2
         self.bootstrapped = False
 
     def connectToStream(self, streamNumber):
@@ -156,6 +156,8 @@ class BMConnectionPool(object):
                     Proxy.onionproxy = None
             established = sum(1 for c in self.outboundConnections.values() if (c.connected and c.fullyEstablished))
             pending = len(self.outboundConnections) - established
+            while not self.streams:
+                time.sleep(1)
             if established < BMConfigParser().safeGetInt("bitmessagesettings", "maxoutboundconnections"):
                 for i in range(state.maximumNumberOfHalfOpenConnections - pending):
                     try:
@@ -169,7 +171,7 @@ class BMConnectionPool(object):
                     # don't connect to self
                     if chosen in state.ownAddresses:
                         continue
-    
+
                     #for c in self.outboundConnections:
                     #    if chosen == c.destination:
                     #        continue
@@ -247,7 +249,7 @@ class BMConnectionPool(object):
                 if i.fullyEstablished:
                     i.append_write_buf(protocol.CreatePacket('ping'))
                 else:
-                    i.close_reason = "Timeout (%is)" % (time.time() - i.lastTx) 
+                    i.close_reason = "Timeout (%is)" % (time.time() - i.lastTx)
                     i.set_state("close")
         for i in self.inboundConnections.values() + self.outboundConnections.values() + self.listeningSockets.values() + self.udpSockets.values():
             if not (i.accepting or i.connecting or i.connected):


### PR DESCRIPTION
This addresses two cases where non-deterministic initialisation may lead to lists being used by `randomchoice()` before they have been populated. Arguably we should ensure the length of the list is sufficiently large since passing a list of one undermines the point of `randomchoice()` and we are relying on system peculiarities to choose a random item.

However I would favour planning and implementing a more deterministic initialisation than we have currently (simple > complex > complicated).