### PR TITLE
Add src to path when running pylint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,11 @@ ignore = E722,F841
 # F841: pylint is preferred for unused-variable
 
 # pylint honours the [MESSAGES CONTROL] section
+# as well as [MASTER] section
 [MESSAGES CONTROL]
 disable=invalid-name,bare-except,broad-except
 # invalid-name: needs fixing during a large, project-wide refactor
 # bare-except,broad-except: Need fixing once thorough testing is easier
+
+[MASTER]
+init-hook = import sys;sys.path.append('src')


### PR DESCRIPTION
- this will allow pylint to run in the main directory without complaining about
  imports