### PR TITLE
Fix import of pickled knownnodes.dat

### DIFF
--- a/src/knownnodes.py
+++ b/src/knownnodes.py
@@ -60,9 +60,10 @@ def pickle_deserialize_old_knownnodes(source):
     the old format was {Peer:lastseen, ...}
     the new format is {Peer:{"lastseen":i, "rating":f}}
     """
+    global knownNodes  # pylint: disable=global-statement
     knownNodes = pickle.load(source)
     for stream in knownNodes.keys():
-        for node, params in knownNodes[stream].items():
+        for node, params in knownNodes[stream].iteritems():
             if isinstance(params, (float, int)):
                 addKnownNode(stream, node, params)
 


### PR DESCRIPTION
Hello.

This is a fix for bug in compatibility code for pickled `knownnodes.dat` discovered when I tried to parse @milahu comments to #1335.
