### PR TITLE
Fix knownnodes starvation issue

### DIFF
--- a/src/knownnodes.py
+++ b/src/knownnodes.py
@@ -1,7 +1,10 @@
+"""
+Manipulations with knownNodes dictionary.
+"""
+
 import json
 import os
 import pickle
-# import sys
 import threading
 import time
 
@@ -106,10 +109,6 @@ def readKnownNodes():
         createDefaultKnownNodes()
 
     config = BMConfigParser()
-    # if config.safeGetInt('bitmessagesettings', 'settingsversion') > 10:
-    #     sys.exit(
-    #         'Bitmessage cannot read future versions of the keys file'
-    #         ' (keys.dat). Run the newer version of Bitmessage.')
 
     # your own onion address, if setup
     onionhostname = config.safeGet('bitmessagesettings', 'onionhostname')


### PR DESCRIPTION
#1335 steps to reproduce:
 1. run BM with [existing knownnodes.dat](../blob/v0.6/src/network/connectionpool.py#L142) containing only nodes older then 28 days (or run offline long enough to outdate all nodes),
 1. wait 5 min for [cleanup](../blob/v0.6/src/class_singleCleaner.py#L127),
 1. get `IndexError` in [connectionchooser](../blob/v0.6/src/network/connectionchooser.py#L37) because `knownnodes.knownNodes[stream].keys()` returns empty list.

[Corresponding test](../../../g1itch/PyBitmessage/blob/test-mode/src/tests/core.py#L97)
[Test result](https://travis-ci.org/Bitmessage/PyBitmessage/builds/438549302#L1155)
[After this patch](https://travis-ci.org/g1itch/PyBitmessage/builds/438581399#L1143)
