### PR TITLE
Fix: Shift handling when deleting from Sent

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3258,7 +3258,7 @@ class MyForm(settingsmixin.SMainWindow):
         if not tableWidget:
             return
         folder = self.getCurrentFolder()
-        shifted = (QtGui.QApplication.queryKeyboardModifiers() & QtCore.Qt.ShiftModifier) > 0
+        shifted = QtGui.QApplication.queryKeyboardModifiers() & QtCore.Qt.ShiftModifier
         while tableWidget.selectedIndexes() != []:
             currentRow = tableWidget.selectedIndexes()[0].row()
             ackdataToTrash = str(tableWidget.item(


### PR DESCRIPTION
Due to the way Qt.KeyboardModifiers works, treating it as an integer results in
unexpected behaviour. As a result, When deleting from Sent, it always deleted
rather than moved an item to trash, when selecting "Move to Trash" from the
context menu. This fixes it.