### PR TITLE
Fix spelling errors for the connection warning dialog.

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -2677,7 +2677,7 @@ class MyForm(settingsmixin.SMainWindow):
             if dontconnect_option else _translate("MainWindow", "Connecting"),
             _translate(
                 "MainWindow",
-                "Bitmessage will now drop all connectins. Are you sure?"
+                "Bitmessage will now drop all connections. Are you sure?"
             ) if dontconnect_option else _translate(
                 "MainWindow",
                 "Bitmessage will now start connecting to network. Are you sure?"


### PR DESCRIPTION
Quick fix: changed 'connectins' to correct spelling of 'connections' in init and lang files. This mispelled word shows up in the connection warning dialog when going online/offline.