### PR TITLE
Moved missingObjects dict from state to network.objectracker

### DIFF
--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import random
 import socket
 import struct
 import time
@@ -17,7 +16,8 @@ from network.bmobject import BMObject, BMObjectInsufficientPOWError, BMObjectInv
 import network.connectionpool
 from network.node import Node
 from network.objectracker import ObjectTracker
-from network.proxy import Proxy, ProxyError, GeneralProxyError
+from network.proxy import ProxyError
+from objectracker import missingObjects
 
 import addresses
 from queues import objectProcessorQueue, portCheckerQueue, invQueue, addrQueue
@@ -359,7 +359,7 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
             BMProto.stopDownloadingObject(self.object.inventoryHash, True)
         else:
             try:
-                del state.missingObjects[self.object.inventoryHash]
+                del missingObjects[self.object.inventoryHash]
             except KeyError:
                 pass
 
@@ -559,7 +559,7 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
                 except KeyError:
                     pass
         try:
-            del state.missingObjects[hashId]
+            del missingObjects[hashId]
         except KeyError:
             pass
 

--- a/src/network/downloadthread.py
+++ b/src/network/downloadthread.py
@@ -1,16 +1,16 @@
-import random
 import threading
 import time
 
 import addresses
+import helper_random
+import protocol
 from dandelion import Dandelion
 from debug import logger
 from helper_threading import StoppableThread
 from inventory import Inventory
 from network.connectionpool import BMConnectionPool
-import protocol
-from state import missingObjects
-import helper_random
+from objectracker import missingObjects
+
 
 class DownloadThread(threading.Thread, StoppableThread):
     minPending = 200

--- a/src/network/objectracker.py
+++ b/src/network/objectracker.py
@@ -1,11 +1,9 @@
 import time
 from threading import RLock
 
-from inventory import Inventory
 import network.connectionpool
 from network.dandelion import Dandelion
 from randomtrackingdict import RandomTrackingDict
-from state import missingObjects
 
 haveBloom = False
 
@@ -23,6 +21,10 @@ except ImportError:
 
 # it isn't actually implemented yet so no point in turning it on
 haveBloom = False
+
+# tracking pending downloads globally, for stats
+missingObjects = {}
+
 
 class ObjectTracker(object):
     invCleanPeriod = 300

--- a/src/network/stats.py
+++ b/src/network/stats.py
@@ -1,8 +1,8 @@
 import time
 
-from network.connectionpool import BMConnectionPool
 import asyncore_pollchoose as asyncore
-from state import missingObjects
+from network.connectionpool import BMConnectionPool
+from objectracker import missingObjects
 
 lastReceivedTimestamp = time.time()
 lastReceivedBytes = 0

--- a/src/state.py
+++ b/src/state.py
@@ -51,9 +51,6 @@ trustedPeer = None
 
 discoveredPeers = {}
 
-# tracking pending downloads globally, for stats
-missingObjects = {}
-
 Peer = collections.namedtuple('Peer', ['host', 'port'])
 
 


### PR DESCRIPTION
Hello

I noticed `missingObjects` dict is used only inside of `network` package. So maybe it's reasonable to define it in `network.objectracker`?
