### PR TITLE
Put uploads into a separate thread

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -58,6 +58,7 @@ from network.announcethread import AnnounceThread
 from network.invthread import InvThread
 from network.addrthread import AddrThread
 from network.downloadthread import DownloadThread
+from network.uploadthread import UploadThread
 
 # Helper Functions
 import helper_generic
@@ -333,6 +334,9 @@ class Main:
             state.downloadThread = DownloadThread()
             state.downloadThread.daemon = True
             state.downloadThread.start()
+            state.uploadThread = UploadThread()
+            state.uploadThread.daemon = True
+            state.uploadThread.start()
 
             connectToStream(1)
 

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -282,8 +282,8 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
         now = time.time()
         if now < self.skipUntil:
             return True
-        for i in map(str, items):
-            self.pendingUpload[i] = now
+        for i in items:
+            self.pendingUpload[str(i)] = now
         return True
 
     def _command_inv(self, dandelion=False):

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -26,7 +26,6 @@ from queues import objectProcessorQueue, portCheckerQueue, invQueue, addrQueue
 import shared
 import state
 import protocol
-import helper_random
 
 class BMProtoError(ProxyError):
     errorCodes = ("Protocol error")
@@ -280,11 +279,11 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
     def bm_command_getdata(self):
         items = self.decode_payload_content("l32s")
         # skip?
-        if time.time() < self.skipUntil:
+        now = time.time()
+        if now < self.skipUntil:
             return True
-        helper_random.randomshuffle(items)
         for i in map(str, items):
-            self.pendingUpload[i] = time.time()
+            self.pendingUpload[i] = now
         return True
 
     def _command_inv(self, dandelion=False):

--- a/src/network/uploadthread.py
+++ b/src/network/uploadthread.py
@@ -1,0 +1,71 @@
+"""
+src/network/uploadthread.py
+"""
+# pylint: disable=unsubscriptable-object
+import threading
+import time
+
+import helper_random
+import protocol
+from debug import logger
+from helper_threading import StoppableThread
+from inventory import Inventory
+from network.connectionpool import BMConnectionPool
+from network.dandelion import Dandelion
+from randomtrackingdict import RandomTrackingDict
+
+
+class UploadThread(threading.Thread, StoppableThread):
+    """This is a thread that uploads the objects that the peers requested from me """
+    maxBufSize = 2097152  # 2MB
+
+    def __init__(self):
+        threading.Thread.__init__(self, name="Uploader")
+        self.initStop()
+        self.name = "Uploader"
+        logger.info("init upload thread")
+
+    def run(self):
+        while not self._stopped:
+            uploaded = 0
+            # Choose downloading peers randomly
+            connections = [x for x in BMConnectionPool().inboundConnections.values() +
+                           BMConnectionPool().outboundConnections.values() if x.fullyEstablished]
+            helper_random.randomshuffle(connections)
+            for i in connections:
+                now = time.time()
+                # avoid unnecessary delay
+                if i.skipUntil >= now:
+                    continue
+                if len(i.write_buf) > UploadThread.maxBufSize:
+                    continue
+                try:
+                    request = i.pendingUpload.randomKeys(RandomTrackingDict.maxPending)
+                except KeyError:
+                    continue
+                payload = bytearray()
+                chunk_count = 0
+                for chunk in request:
+                    del i.pendingUpload[chunk]
+                    if Dandelion().hasHash(chunk) and \
+                       i != Dandelion().objectChildStem(chunk):
+                        i.antiIntersectionDelay()
+                        logger.info('%s asked for a stem object we didn\'t offer to it.',
+                                    i.destination)
+                        break
+                    try:
+                        payload.extend(protocol.CreatePacket('object',
+                                                             Inventory()[chunk].payload))
+                        chunk_count += 1
+                    except KeyError:
+                        i.antiIntersectionDelay()
+                        logger.info('%s asked for an object we don\'t have.', i.destination)
+                        break
+                if not chunk_count:
+                    continue
+                i.append_write_buf(payload)
+                logger.debug("%s:%i Uploading %i objects",
+                             i.destination.host, i.destination.port, chunk_count)
+                uploaded += chunk_count
+            if not uploaded:
+                self.stop.wait(1)

--- a/src/state.py
+++ b/src/state.py
@@ -34,6 +34,7 @@ maximumNumberOfHalfOpenConnections = 0
 invThread = None
 addrThread = None
 downloadThread = None
+uploadThread = None
 
 ownAddresses = {}
 

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -23,7 +23,7 @@ class TestProcessProto(unittest.TestCase):
     it starts pybitmessage in setUpClass() and stops it in tearDownClass()
     """
     _process_cmd = ['pybitmessage', '-d']
-    _threads_count = 14
+    _threads_count = 15
     _files = (
         'keys.dat', 'debug.log', 'messages.dat', 'knownnodes.dat',
         '.api_started', 'unittest.lock'


### PR DESCRIPTION
- instead of being processed in the ReceiveQueue thread, uploads are now done
  in a dedicated thread. Only the parsing is done in ReceiveQueue thread.
- the UploadThread is modelled based on the DownloadThred, but simpler.
- it checks for intersection attack, eliminates duplicates and restricts the
  write buffer size to 2MB (may still grow slightly higher if too many big
  objects are requested, but the absolute limit appears to be about 4.5MB in the
  worst case scenario).
- the restriction of the write buffer may cause some upload throttling (to
  about 2MB per second per connection), but can be optimised later
- fixes #1414
- I haven't actually tested it yet, I'll test it as the PR is being checked and reviewed