### PR TITLE
Fix: Mac build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/.settings/
 src/**/.dll
 src/**/*.o
 src/**/*.so
+src/**/a.out
 build/lib.*
 build/temp.*
 dist

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,8 @@ For an up-to-date version of these instructions, please visit the
 PyBitmessage can be run in either one of two ways:
 
 - straight from source
- 
- or 
+
+ or
 - from an installed
 package.
 
@@ -19,13 +19,13 @@ Here's a list of dependencies needed for PyBitmessage
 - python2.7
 - python2-qt4 (python-qt4 on Debian/Ubuntu)
 - openssl
-- (Fedora & Redhat only) openssl-compat-bitcoin-libs 
+- (Fedora & Redhat only) openssl-compat-bitcoin-libs
 
 ## Running PyBitmessage
-PyBitmessage can be run in two ways: 
+PyBitmessage can be run in two ways:
 - straight from source
 
- or 
+ or
 - via a package which is installed on your system. Since PyBitmessage is Beta, it is best to run
 PyBitmessage from source, so that you may update as needed.
 
@@ -65,7 +65,7 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 
 Now, install the required dependencies
 ```
-brew install git python pyqt
+brew install git python pyqt@4 openssl
 ```
 
 Download and run PyBitmessage:

--- a/src/bitmsghash/Makefile
+++ b/src/bitmsghash/Makefile
@@ -1,14 +1,14 @@
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	CCFLAGS += -I/usr/local/Cellar/openssl/1.0.2d_1/include
-	LDFLAGS += -L/usr/local/Cellar/openssl/1.0.2d_1/lib
+	CCFLAGS += -I/usr/local/opt/openssl/include
+	LDFLAGS += -L/usr/local/opt/openssl/lib
 else ifeq ($(UNAME_S),MINGW32_NT-6.1)
 	CCFLAGS += -IC:\OpenSSL-1.0.2j-mingw\include -D_WIN32 -march=native
 	LDFLAGS += -static-libgcc -LC:\OpenSSL-1.0.2j-mingw\lib -lwsock32 -o bitmsghash32.dll -Wl,--out-implib,bitmsghash.a
 else
 	LDFLAGS += -lpthread -o bitmsghash.so
 endif
-   	
+
 all: bitmsghash.so
 
 powtest:
@@ -22,4 +22,3 @@ bitmsghash.o:
 
 clean:
 	rm -f bitmsghash.o bitmsghash.so bitmsghash*.dll
-


### PR DESCRIPTION
* Use `/usr/local/opt/openssl` symlink for `bitmsghash` flags:
The current version from homebrew is `1.0.2q`. Using the symlink eliminates the need for updating the version in `CCFLAGS` and `LDFLAGS`.

* Install `pyqt@4`:
`pyqt` 5.x is installed by default, so the `@4` is needed to install a compatible version.
