### PR TITLE
Fix repeated downloads

### DIFF
--- a/src/randomtrackingdict.py
+++ b/src/randomtrackingdict.py
@@ -111,6 +111,7 @@ class RandomTrackingDict(object):
             # or if last object received too long time ago
             if self.pendingLen == self.len or self.lastObject + self.pendingTimeout > time():
                 self.pendingLen = 0
+                self.setLastObject()
             available = self.len - self.pendingLen
             if count > available:
                 count = available


### PR DESCRIPTION
- a bug in RandomTrackingDict caused requesting to download the same objects
  over and over
- the bug is that the lastObject wasn't properly initalised, this caused the
  write buffer to fill with "getdata" requests until the first object was
  received
- this PR should address both the excessive bandwidth as well as excessive CPU
  usage during downloading
- tested on Debian