### PR TITLE
Logic error in download reset

### DIFF
--- a/src/randomtrackingdict.py
+++ b/src/randomtrackingdict.py
@@ -108,8 +108,8 @@ class RandomTrackingDict(object):
         # pylint: disable=redefined-outer-name
         with self.lock:
             # reset if we've requested all
-            # or if last object received too long time ago
-            if self.pendingLen == self.len or self.lastObject + self.pendingTimeout > time():
+            # and if last object received too long time ago
+            if self.pendingLen == self.len and self.lastObject + self.pendingTimeout > time():
                 self.pendingLen = 0
                 self.setLastObject()
             available = self.len - self.pendingLen

--- a/src/randomtrackingdict.py
+++ b/src/randomtrackingdict.py
@@ -109,7 +109,7 @@ class RandomTrackingDict(object):
         with self.lock:
             # reset if we've requested all
             # and if last object received too long time ago
-            if self.pendingLen == self.len and self.lastObject + self.pendingTimeout > time():
+            if self.pendingLen == self.len and self.lastObject + self.pendingTimeout < time():
                 self.pendingLen = 0
                 self.setLastObject()
             available = self.len - self.pendingLen


### PR DESCRIPTION
- fix requesting the same object over and over again, now it continues to
  iterate through the other objects and only resets the queue after a timeout
  after the last received object
- tested on Debian