### PR TITLE
pycrypto fallback for RIPEMD160 hash function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python_prctl
 psutil
+pycrypto

--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,13 @@ if __name__ == "__main__":
         'pybitmessage',
         'pybitmessage.bitmessageqt',
         'pybitmessage.bitmessagecurses',
+        'pybitmessage.fallback',
         'pybitmessage.messagetypes',
         'pybitmessage.network',
+        'pybitmessage.plugins',
         'pybitmessage.pyelliptic',
         'pybitmessage.socks',
-        'pybitmessage.storage',
-        'pybitmessage.plugins'
+        'pybitmessage.storage'
     ]
 
     # this will silently accept alternative providers of msgpack
@@ -84,8 +85,7 @@ if __name__ == "__main__":
             import umsgpack
             installRequires.append("umsgpack")
         except ImportError:
-            packages += [
-                'pybitmessage.fallback', 'pybitmessage.fallback.umsgpack']
+            packages += ['pybitmessage.fallback.umsgpack']
 
     dist = setup(
         name='pybitmessage',

--- a/src/class_objectProcessor.py
+++ b/src/class_objectProcessor.py
@@ -24,6 +24,7 @@ import queues
 import state
 import tr
 from debug import logger
+from fallback import RIPEMD160Hash
 import l10n
 
 
@@ -288,9 +289,7 @@ class objectProcessor(threading.Thread):
             sha = hashlib.new('sha512')
             sha.update(
                 '\x04' + publicSigningKey + '\x04' + publicEncryptionKey)
-            ripeHasher = hashlib.new('ripemd160')
-            ripeHasher.update(sha.digest())
-            ripe = ripeHasher.digest()
+            ripe = RIPEMD160Hash(sha.digest()).digest()
 
             logger.debug(
                 'within recpubkey, addressVersion: %s, streamNumber: %s'
@@ -354,9 +353,7 @@ class objectProcessor(threading.Thread):
 
             sha = hashlib.new('sha512')
             sha.update(publicSigningKey + publicEncryptionKey)
-            ripeHasher = hashlib.new('ripemd160')
-            ripeHasher.update(sha.digest())
-            ripe = ripeHasher.digest()
+            ripe = RIPEMD160Hash(sha.digest()).digest()
 
             logger.debug(
                 'within recpubkey, addressVersion: %s, streamNumber: %s'
@@ -575,10 +572,9 @@ class objectProcessor(threading.Thread):
         # calculate the fromRipe.
         sha = hashlib.new('sha512')
         sha.update(pubSigningKey + pubEncryptionKey)
-        ripe = hashlib.new('ripemd160')
-        ripe.update(sha.digest())
+        ripe = RIPEMD160Hash(sha.digest()).digest()
         fromAddress = encodeAddress(
-            sendersAddressVersionNumber, sendersStreamNumber, ripe.digest())
+            sendersAddressVersionNumber, sendersStreamNumber, ripe)
 
         # Let's store the public key in case we want to reply to this
         # person.
@@ -897,9 +893,7 @@ class objectProcessor(threading.Thread):
 
         sha = hashlib.new('sha512')
         sha.update(sendersPubSigningKey + sendersPubEncryptionKey)
-        ripeHasher = hashlib.new('ripemd160')
-        ripeHasher.update(sha.digest())
-        calculatedRipe = ripeHasher.digest()
+        calculatedRipe = RIPEMD160Hash(sha.digest()).digest()
 
         if broadcastVersion == 4:
             if toRipe != calculatedRipe:

--- a/src/depends.py
+++ b/src/depends.py
@@ -165,7 +165,7 @@ def try_import(module, log_extra=False):
 def check_ripemd160():
     """Check availability of the RIPEMD160 hash function"""
     try:
-        from fallback import RIPEMD160Hash
+        from fallback import RIPEMD160Hash  # pylint: disable=relative-import
     except ImportError:
         return False
     return RIPEMD160Hash is not None

--- a/src/depends.py
+++ b/src/depends.py
@@ -162,37 +162,13 @@ def try_import(module, log_extra=False):
         return False
 
 
-# We need to check hashlib for RIPEMD-160, as it won't be available
-# if OpenSSL is not linked against or the linked OpenSSL has RIPEMD
-# disabled.
-def check_hashlib():
-    """Do hashlib check.
-
-    The hashlib module check with version as if it included or not
-    in The Python Standard library, it's a module containing an
-    interface to the most popular hashing algorithms. hashlib
-    implements some of the algorithms, however if  OpenSSL
-    installed, hashlib is able to use this algorithms as well.
-    """
-    if sys.hexversion < 0x020500F0:
-        logger.error(
-            'The hashlib module is not included in this version of Python.')
-        return False
-    import hashlib
-    if '_hashlib' not in hashlib.__dict__:
-        logger.error(
-            'The RIPEMD-160 hash algorithm is not available.'
-            ' The hashlib module is not linked against OpenSSL.')
-        return False
+def check_ripemd160():
+    """Check availability of the RIPEMD160 hash function"""
     try:
-        hashlib.new('ripemd160')
-    except ValueError:
-        logger.error(
-            'The RIPEMD-160 hash algorithm is not available.'
-            ' The hashlib module utilizes an OpenSSL library with'
-            ' RIPEMD disabled.')
+        from fallback import RIPEMD160Hash
+    except ImportError:
         return False
-    return True
+    return RIPEMD160Hash is not None
 
 
 def check_sqlite():
@@ -446,7 +422,7 @@ def check_dependencies(verbose=False, optional=False):
             ' or greater is required.')
         has_all_dependencies = False
 
-    check_functions = [check_hashlib, check_sqlite, check_openssl]
+    check_functions = [check_ripemd160, check_sqlite, check_openssl]
     if optional:
         check_functions.extend([check_msgpack, check_pyqt, check_curses])
 

--- a/src/fallback/__init__.py
+++ b/src/fallback/__init__.py
@@ -1,3 +1,26 @@
 """
 .. todo:: hello world
 """
+
+import hashlib
+
+# We need to check hashlib for RIPEMD-160, as it won't be available
+# if OpenSSL is not linked against or the linked OpenSSL has RIPEMD
+# disabled.
+
+try:
+    hashlib.new('ripemd160')
+except ValueError:
+    try:
+        from Crypto.Hash import RIPEMD
+    except ImportError:
+        RIPEMD160Hash = None
+    else:
+        RIPEMD160Hash = RIPEMD.RIPEMD160Hash
+else:
+    def RIPEMD160Hash(data=None):
+        """hashlib based RIPEMD160Hash"""
+        hasher = hashlib.new('ripemd160')
+        if data:
+            hasher.update(data)
+        return hasher

--- a/src/protocol.py
+++ b/src/protocol.py
@@ -25,6 +25,7 @@ from addresses import (
     encodeVarint, decodeVarint, decodeAddress, varintDecodeError)
 from bmconfigparser import BMConfigParser
 from debug import logger
+from fallback import RIPEMD160Hash
 from helper_sql import sqlExecute
 from version import softwareVersion
 
@@ -411,9 +412,7 @@ def decryptAndCheckPubkeyPayload(data, address):
 
         sha = hashlib.new('sha512')
         sha.update(publicSigningKey + publicEncryptionKey)
-        ripeHasher = hashlib.new('ripemd160')
-        ripeHasher.update(sha.digest())
-        embeddedRipe = ripeHasher.digest()
+        embeddedRipe = RIPEMD160Hash(sha.digest()).digest()
 
         if embeddedRipe != ripe:
             # Although this pubkey object had the tag were were looking for

--- a/src/tests/test_crypto.py
+++ b/src/tests/test_crypto.py
@@ -1,0 +1,60 @@
+"""
+Test the alternatives for crypto primitives
+"""
+
+import hashlib
+import unittest
+from abc import ABCMeta, abstractmethod
+from binascii import hexlify, unhexlify
+
+try:
+    from Crypto.Hash import RIPEMD
+except ImportError:
+    RIPEMD = None
+
+
+# These keys are from addresses test script
+sample_pubsigningkey = unhexlify(
+    '044a367f049ec16cb6b6118eb734a9962d10b8db59c890cd08f210c43ff08bdf09d'
+    '16f502ca26cd0713f38988a1237f1fc8fa07b15653c996dc4013af6d15505ce')
+sample_pubencryptionkey = unhexlify(
+    '044597d59177fc1d89555d38915f581b5ff2286b39d022ca0283d2bdd5c36be5d3c'
+    'e7b9b97792327851a562752e4b79475d1f51f5a71352482b241227f45ed36a9')
+
+sample_ripe = '003cd097eb7f35c87b5dc8b4538c22cb55312a9f'
+
+_sha = hashlib.new('sha512')
+_sha.update(sample_pubsigningkey + sample_pubencryptionkey)
+
+pubkey_sha = _sha.digest()
+
+
+class RIPEMD160TestCase(object):
+    """Base class for RIPEMD160 test case"""
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def _hashdigest(self, data):
+        """RIPEMD160 digest implementation"""
+        pass
+
+    def test_hash_string(self):
+        """Check RIPEMD160 hash function on string"""
+        self.assertEqual(hexlify(self._hashdigest(pubkey_sha)), sample_ripe)
+
+
+class TestHashlib(RIPEMD160TestCase, unittest.TestCase):
+    """RIPEMD160 test case for hashlib"""
+    @staticmethod
+    def _hashdigest(data):
+        hasher = hashlib.new('ripemd160')
+        hasher.update(data)
+        return hasher.digest()
+
+
+@unittest.skipUnless(RIPEMD, 'pycrypto package not found')
+class TestCrypto(RIPEMD160TestCase, unittest.TestCase):
+    """RIPEMD160 test case for Crypto"""
+    @staticmethod
+    def _hashdigest(data):
+        return RIPEMD.RIPEMD160Hash(data).digest()

--- a/src/tests/test_crypto.py
+++ b/src/tests/test_crypto.py
@@ -31,6 +31,7 @@ pubkey_sha = _sha.digest()
 
 class RIPEMD160TestCase(object):
     """Base class for RIPEMD160 test case"""
+    # pylint: disable=too-few-public-methods,no-member
     __metaclass__ = ABCMeta
 
     @abstractmethod


### PR DESCRIPTION
Hello!

I added pycrypto fallback for RIPEMD160 hash function which can be used if RIPEMD is disabled in OpenSSL.