### PR TITLE
Fix bug in bitmessageqt.propagateUnreadCount()

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -1801,6 +1801,7 @@ class MyForm(settingsmixin.SMainWindow):
             self.ui.tableWidgetInboxSubscriptions,
             self.ui.tableWidgetInboxChans
         ):
+            i = None
             for i in range(inbox.rowCount()):
                 if msgid == \
                         inbox.item(i, 3).data(QtCore.Qt.UserRole).toPyObject():
@@ -1813,7 +1814,8 @@ class MyForm(settingsmixin.SMainWindow):
                 # wrong assumption about current folder here:
                 self.getCurrentFolder(treeWidget), treeWidget
             )
-            inbox.removeRow(i)
+            if i:
+                inbox.removeRow(i)
 
     def newVersionAvailable(self, version):
         self.notifiedNewVersion = ".".join(str(n) for n in version)
@@ -2311,6 +2313,7 @@ class MyForm(settingsmixin.SMainWindow):
             acct.parseMessage(toAddress, fromAddress, subject, "")
         else:
             acct = ret
+        # pylint:disable=undefined-loop-variable
         self.propagateUnreadCount(widget=treeWidget if ret else None)
         if BMConfigParser().getboolean(
                 'bitmessagesettings', 'showtraynotifications'):


### PR DESCRIPTION
Hello!

I fixed unread count calculation when there are unread messages in trash and handled `folder` and `widget` args. I still doubt, should I handle also `address` and `address_type` or remove them completely?

The bug:
![bm_unread_trash](https://user-images.githubusercontent.com/4012700/53575660-af9f1c80-3b7a-11e9-9a57-147fc3c1cdaa.png)
![bm_unread_trash_selected](https://user-images.githubusercontent.com/4012700/53575769-ed03aa00-3b7a-11e9-959c-4f0af703c20d.png)
