### PR TITLE
Rerender more widgets when deleting address by API

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -661,8 +661,7 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
         BMConfigParser().remove_section(address)
         with open(state.appdata + 'keys.dat', 'wb') as configfile:
             BMConfigParser().write(configfile)
-        queues.UISignalQueue.put(('rerenderMessagelistFromLabels', ''))
-        queues.UISignalQueue.put(('rerenderMessagelistToLabels', ''))
+        queues.UISignalQueue.put(('writeNewAddressToTable', ('', '', '')))
         shared.reloadMyAddressHashes()
         return 'success'
 


### PR DESCRIPTION
Hello!

I cannot reproduce #1441 but this change may be a solution.  At least such behaviour is more consistent: address will immediately disappear from any account tree and `ComboBoxSendFrom`.