### PR TITLE
PyOpenCL compatibility fix

### DIFF
--- a/src/openclpow.py
+++ b/src/openclpow.py
@@ -90,7 +90,10 @@ def do_opencl_pow(hash, target):
     while output[0][0] == 0 and shutdown == 0:
         kernel.set_arg(2, pack("<Q", progress))
         cl.enqueue_nd_range_kernel(queue, kernel, (globamt,), (worksize,))
-        cl.enqueue_read_buffer(queue, dest_buf, output)
+        try:
+            cl.enqueue_read_buffer(queue, dest_buf, output)
+        except AttributeError:
+            cl.enqueue_copy(queue, output, dest_buf)
         queue.finish()
         progress += globamt
         sofar = time.time() - start


### PR DESCRIPTION
It looks like PyOpenCL obsoleted the enqueue_read_buffer method, and
enqueue_copy should be used instead. Even though enqueue_copy already exists
with the earliest version of PyOpenCL I looked at, I wrote it in a
backwards-compatible way so that it doesn't break in case I missed something.

Tested on OSX in frozen mode, but it should be platform-independent.