### PR TITLE
Use very easy PoW in test mode

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -69,7 +69,6 @@ import helper_threading
 
 def connectToStream(streamNumber):
     state.streamsInWhichIAmParticipating.append(streamNumber)
-    selfInitiatedConnections[streamNumber] = {}
 
     if isOurOperatingSystemLimitedToHavingVeryFewHalfOpenConnections():
         # Some XP and Vista systems can only have 10 outgoing connections
@@ -184,16 +183,6 @@ def signal_handler(signum, frame):
               ' because the UI captures the signal.')
 
 
-# This is a list of current connections (the thread pointers at least)
-selfInitiatedConnections = {}
-
-if shared.useVeryEasyProofOfWorkForTesting:
-    defaults.networkDefaultProofOfWorkNonceTrialsPerByte = int(
-        defaults.networkDefaultProofOfWorkNonceTrialsPerByte / 100)
-    defaults.networkDefaultPayloadLengthExtraBytes = int(
-        defaults.networkDefaultPayloadLengthExtraBytes / 100)
-
-
 class Main:
     def start(self):
         _fixSocket()
@@ -273,6 +262,13 @@ class Main:
         if state.dandelion and not BMConfigParser().safeGetBoolean(
                 'bitmessagesettings', 'sendoutgoingconnections'):
             state.dandelion = 0
+
+        if state.testmode or BMConfigParser().safeGetBoolean(
+                'bitmessagesettings', 'extralowdifficulty'):
+            defaults.networkDefaultProofOfWorkNonceTrialsPerByte = int(
+                defaults.networkDefaultProofOfWorkNonceTrialsPerByte / 100)
+            defaults.networkDefaultPayloadLengthExtraBytes = int(
+                defaults.networkDefaultPayloadLengthExtraBytes / 100)
 
         knownnodes.readKnownNodes()
 

--- a/src/shared.py
+++ b/src/shared.py
@@ -30,9 +30,6 @@ maximumAgeOfAnObjectThatIAmWillingToAccept = 216000
 # from obtaining a needed pubkey for a period of time.
 lengthOfTimeToHoldOnToAllPubkeys = 2419200
 maximumAgeOfNodesThatIAdvertiseToOthers = 10800  # Equals three hours
-# If you set this to True while on the normal network,
-# you won't be able to send or sometimes receive messages.
-useVeryEasyProofOfWorkForTesting = False
 
 
 myECCryptorObjects = {}

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -2,9 +2,11 @@
 Various tests for config
 """
 
+import os
 import unittest
 
 from pybitmessage.bmconfigparser import BMConfigParser
+from test_process import TestProcessProto
 
 
 class TestConfig(unittest.TestCase):
@@ -34,3 +36,30 @@ class TestConfig(unittest.TestCase):
             BMConfigParser().safeGetInt('nonexistent', 'nonexistent'), 0)
         self.assertEqual(
             BMConfigParser().safeGetInt('nonexistent', 'nonexistent', 42), 42)
+
+
+class TestProcessConfig(TestProcessProto):
+    """A test case for keys.dat"""
+
+    def test_config_defaults(self):
+        """Test settings in the generated config"""
+        self._stop_process()
+        config = BMConfigParser()
+        config.read(os.path.join(self.home, 'keys.dat'))
+
+        self.assertEquals(config.safeGetInt(
+            'bitmessagesettings', 'settingsversion'), 10)
+        self.assertEquals(config.safeGetInt(
+            'bitmessagesettings', 'port'), 8444)
+        # don't connect
+        self.assertTrue(config.safeGetBoolean(
+            'bitmessagesettings', 'dontconnect'))
+        # API disabled
+        self.assertFalse(config.safeGetBoolean(
+            'bitmessagesettings', 'apienabled'))
+
+        # extralowdifficulty is false
+        self.assertEquals(config.safeGetInt(
+            'bitmessagesettings', 'defaultnoncetrialsperbyte'), 1000)
+        self.assertEquals(config.safeGetInt(
+            'bitmessagesettings', 'defaultpayloadlengthextrabytes'), 1000)


### PR DESCRIPTION
Hello!

I realized that `shared.useVeryEasyProofOfWorkForTesting` is unusable. Instead of that var I added the config setting `extralowdifficulty` and also applied easy PoW to test mode.