### PR TITLE
"msgpack-python" package  is now "msgpack"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ if __name__ == "__main__":
 
     try:
         import msgpack
-        installRequires.append("msgpack-python")
+        installRequires.append(
+            "msgpack-python" if msgpack.version[:2] == (0, 4) else "msgpack")
     except ImportError:
         try:
             import umsgpack


### PR DESCRIPTION
Hello!

"msgpack-python" renamed from version 0.5: https://pypi.org/project/msgpack/
I've made corresponding changes to setup script.
