### PR TITLE
Removed pluralization artifact introduced in a69daa1

### DIFF
--- a/src/translations/bitmessage_de.ts
+++ b/src/translations/bitmessage_de.ts
@@ -1572,7 +1572,7 @@ Willkommen zu einfachem und sicherem Bitmessage
     <message numerus="yes">
         <location filename="../bitmessageqt/address_dialogs.py" line="194"/>
         <source>Display the %n recent broadcast(s) from this address.</source>
-        <translation><numerusform>Den letzten %1 Rundruf von dieser Addresse anzeigen.</numerusform><numerusform>Die letzten %1 Rundrufe von dieser Addresse anzeigen.</numerusform></translation>
+        <translation><numerusform>Den letzten %n Rundruf von dieser Addresse anzeigen.</numerusform><numerusform>Die letzten %n Rundrufe von dieser Addresse anzeigen.</numerusform></translation>
     </message>
     <message>
         <location filename="../bitmessageqt/bitmessageui.py" line="658"/>

--- a/src/translations/bitmessage_sk.ts
+++ b/src/translations/bitmessage_sk.ts
@@ -1570,7 +1570,7 @@ Vitajte v jednoduchom a bezpečnom Bitmessage
     <message numerus="yes">
         <location filename="../bitmessageqt/address_dialogs.py" line="194"/>
         <source>Display the %n recent broadcast(s) from this address.</source>
-        <translation><numerusform>Zobraziť poslednú %1 hromadnú správu z tejto adresy.</numerusform><numerusform>Zobraziť posledné %1 hromadné správy z tejto adresy.</numerusform><numerusform>Zobraziť posledných %1 hromadných správ z tejto adresy.</numerusform></translation>
+        <translation><numerusform>Zobraziť poslednú %n hromadnú správu z tejto adresy.</numerusform><numerusform>Zobraziť posledné %n hromadné správy z tejto adresy.</numerusform><numerusform>Zobraziť posledných %n hromadných správ z tejto adresy.</numerusform></translation>
     </message>
     <message>
         <location filename="../bitmessageqt/bitmessageui.py" line="658"/>


### PR DESCRIPTION
The string "Display the %n recent broadcast(s) from this address." in `bitmessageqt.address_dialogs` had `%1` substitution mark before pluralization in a69daa1. Somehow it remained in the translations and thus shown as is in that locales.

