### PR TITLE
Do not insert encoded onion v3 address into version message

### DIFF
--- a/src/protocol.py
+++ b/src/protocol.py
@@ -262,7 +262,9 @@ def assembleVersionMessage(remoteHost, remotePort, participatingStreams, server=
         payload += encodeHost('127.0.0.1')
         payload += pack('>H', 8444)
     else:
-        payload += encodeHost(remoteHost)
+        # use first 16 bytes if host data is longer
+        # for example in case of onion v3 service
+        payload += encodeHost(remoteHost)[:16]
         payload += pack('>H', remotePort)  # remote IPv6 and port
 
     # bitflags of the services I offer.


### PR DESCRIPTION
Hi!

This is a followup for #1455. As I can see the `remoteHost` in version command isn't used by receiving party so it may be also replaced with `127.0.0.1` for onion v3 service addresses. Without this change the fields `user_agent` and `stream_numbers` got mangled and interpreted as '' and 0.
