### PR TITLE
Convert subject to unicode before cgi.escape()

### DIFF
--- a/src/bitmessageqt/foldertree.py
+++ b/src/bitmessageqt/foldertree.py
@@ -459,7 +459,7 @@ class MessageList_SubjectWidget(BMTableWidgetItem):
         if role == QtCore.Qt.UserRole:
             return self.subject
         if role == QtCore.Qt.ToolTipRole:
-            return escape(self.subject)
+            return escape(unicode(self.subject, 'utf-8'))
         return super(MessageList_SubjectWidget, self).data(role)
 
     # label (or address) alphabetically, disabled at the end


### PR DESCRIPTION
Hi!

Another problem in previous PR - #1453, noticed in chan: `cgi.escape()` performs bad for `str`-s with multibyte characters.
