### PR TITLE
Handle bad trustedpeer setting

### DIFF
--- a/src/helper_startup.py
+++ b/src/helper_startup.py
@@ -31,8 +31,13 @@ def _loadTrustedPeer():
         # This probably means the trusted peer wasn't specified so we
         # can just leave it as None
         return
-
-    host, port = trustedPeer.split(':')
+    try:
+        host, port = trustedPeer.split(':')
+    except ValueError:
+        sys.exit(
+            'Bad trustedpeer config setting! It should be set as'
+            ' trustedpeer=<hostname>:<portnumber>'
+        )
     state.trustedPeer = state.Peer(host, int(port))
 
 


### PR DESCRIPTION
Hello!

I added a tip about `trustedpeer` setting syntax and smooth exit instead of fatal exception.


