### PR TITLE
Flaws in bitmessageqt.blacklist remaining after initial refactoring

### DIFF
--- a/src/bitmessageqt/blacklist.py
+++ b/src/bitmessageqt/blacklist.py
@@ -6,6 +6,7 @@ from addresses import addBMIfNotPresent
 from bmconfigparser import BMConfigParser
 from dialogs import AddAddressDialog
 from helper_sql import sqlExecute, sqlQuery
+from queues import UISignalQueue
 from retranslateui import RetranslateMixin
 from utils import avatarize
 from uisignaler import UISignaler
@@ -88,11 +89,21 @@ class Blacklist(QtGui.QWidget, RetranslateMixin):
                         sql = '''INSERT INTO whitelist VALUES (?,?,?)'''
                     sqlExecute(sql, *t)
                 else:
-                    self.statusBar().showMessage(_translate(
-                        "MainWindow", "Error: You cannot add the same address to your list twice. Perhaps rename the existing one if you want."))
+                    UISignalQueue.put((
+                        'updateStatusBar',
+                        _translate(
+                            "MainWindow",
+                            "Error: You cannot add the same address to your"
+                            " list twice. Perhaps rename the existing one"
+                            " if you want.")
+                    ))
             else:
-                self.statusBar().showMessage(_translate(
-                    "MainWindow", "The address you entered was invalid. Ignoring it."))
+                UISignalQueue.put((
+                    'updateStatusBar',
+                    _translate(
+                        "MainWindow",
+                        "The address you entered was invalid. Ignoring it.")
+                ))
 
     def tableWidgetBlacklistItemChanged(self, item):
         if item.column() == 0:

--- a/src/bitmessageqt/blacklist.py
+++ b/src/bitmessageqt/blacklist.py
@@ -1,6 +1,5 @@
 from PyQt4 import QtCore, QtGui
-from tr import _translate
-import l10n
+
 import widgets
 from addresses import addBMIfNotPresent
 from bmconfigparser import BMConfigParser
@@ -8,8 +7,9 @@ from dialogs import AddAddressDialog
 from helper_sql import sqlExecute, sqlQuery
 from queues import UISignalQueue
 from retranslateui import RetranslateMixin
-from utils import avatarize
+from tr import _translate
 from uisignaler import UISignaler
+from utils import avatarize
 
 
 class Blacklist(QtGui.QWidget, RetranslateMixin):
@@ -250,4 +250,3 @@ class Blacklist(QtGui.QWidget, RetranslateMixin):
 
     def on_action_BlacklistSetAvatar(self):
         self.window().on_action_SetAvatar(self.tableWidgetBlacklist)
-


### PR DESCRIPTION
Hello!

There are two exceptions you can raise on "Blacklist" tab:
 1. copy one of existing addresses;
 1. click "Add new entry";
 1. paste the address;
 1. click OK;
 1. repeat 2-4 removing a couple of characters in the address.

Instead of `UISignalQueue.put()` there may be used `self.window().statusBar()...` if you prefer.