### PR TITLE
Set status icon color to yellow if last inbound connection is lost

### DIFF
--- a/src/bitmessageqt/networkstatus.py
+++ b/src/bitmessageqt/networkstatus.py
@@ -207,6 +207,8 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
             self.tableWidgetConnectionCount.item(0, 0).setData(QtCore.Qt.UserRole, destination)
             self.tableWidgetConnectionCount.item(0, 1).setData(QtCore.Qt.UserRole, outbound)
         else:
+            if len(BMConnectionPool().inboundConnections) == 0:
+                self.window().setStatusIcon('yellow')
             for i in range(self.tableWidgetConnectionCount.rowCount()):
                 if self.tableWidgetConnectionCount.item(i, 0).data(QtCore.Qt.UserRole).toPyObject() != destination:
                     continue


### PR DESCRIPTION
Hello.

Sometimes the status icon stays green after loosing last inbound connection. I tested this patch with `trustedpeer` setting, looking what happens when I stop the node with `trustedpeer`.
