### PR TITLE
Dandelion fixes

### DIFF
--- a/src/network/dandelion.py
+++ b/src/network/dandelion.py
@@ -122,12 +122,14 @@ class Dandelion():
     def expire(self):
         with self.lock:
             deadline = time()
-            toDelete = [[v.stream, k, v.child]
-                        for k, v in self.hashMap.iteritems()
-                        if v.timeout < deadline]
+            toDelete = [
+                [v.stream, k, v.child] for k, v in self.hashMap.iteritems()
+                if v.timeout < deadline
+            ]
+
             for row in toDelete:
                 self.removeHash(row[1], 'expiration')
-                invQueue.put((row[0], row[1], row[2]))
+                invQueue.put(row)
         return toDelete
 
     def reRandomiseStems(self):

--- a/src/network/dandelion.py
+++ b/src/network/dandelion.py
@@ -122,11 +122,13 @@ class Dandelion():
     def expire(self):
         with self.lock:
             deadline = time()
-            # only expire those that have a child node, i.e. those without a child not will stick around
-            toDelete = [[v.stream, k, v.child] for k, v in self.hashMap.iteritems() if v.timeout < deadline and v.child]
+            toDelete = [[v.stream, k, v.child]
+                        for k, v in self.hashMap.iteritems()
+                        if v.timeout < deadline]
             for row in toDelete:
                 self.removeHash(row[1], 'expiration')
                 invQueue.put((row[0], row[1], row[2]))
+        return toDelete
 
     def reRandomiseStems(self):
         with self.lock:


### PR DESCRIPTION
- expiration wasn't handled correctly
- objects with no child stems never expired. While this is better for
  anonymity, it can cause objects getting stuck
- upon expiration the nodes weren't marked as not having the object, causing it
  to not be advertised
- I haven't tested it but at least I don't think can make things worse
- also minor PEP8 fixes