### PR TITLE
Fix API command 'shutdown'

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -204,6 +204,10 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
             self.wfile.flush()
             self.connection.shutdown(1)
 
+            # actually handle shutdown command after sending response
+            if state.shutdown is False:
+                shutdown.doCleanShutdown()
+
     def APIAuthenticateClient(self):
         """Predicate to check for valid API credentials in the request header"""
 
@@ -1386,10 +1390,11 @@ class MySimpleXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
         return None
 
     def HandleShutdown(self, params):
-        """Handle a request to huutdown the client"""
+        """Handle a request to shutdown the node"""
 
         if not params:
-            shutdown.doCleanShutdown()
+            # backward compatible trick because False == 0 is True
+            state.shutdown = False
             return 'done'
         return None
 


### PR DESCRIPTION
Hello!

The API command `shutdown` doesn't return 'done' as you might think reading the code. Considering that it is not in the [API Reference](https://bitmessage.org/wiki/API_Reference) maybe it shouldn't, but in that case the code is simply inconsistent.

I changed the command in order to behave like it seems - return 'done' and shutdown.