### PR TITLE
Tor configurator/starter using stem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ EXTRAS_REQUIRE = {
     'prctl': ['python_prctl'],  # Named threads
     'qrcode': ['qrcode'],
     'sound;platform_system=="Windows"': ['winsound'],
+    'tor': ['stem'],
     'docs': [
         'sphinx',  # fab build_docs
         'graphviz',  # fab build_docs
@@ -146,6 +147,9 @@ if __name__ == "__main__":
             'bitmessage.indicator': [
                 'libmessaging ='
                 'pybitmessage.plugins.indicator_libmessaging [gir]'
+            ],
+            'bitmessage.proxyconfig': [
+                'stem = pybitmessage.plugins.proxyconfig_stem [tor]'
             ],
             # 'console_scripts': [
             #        'pybitmessage = pybitmessage.bitmessagemain:main'

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -187,8 +187,8 @@ class Main:
     def start(self):
         _fixSocket()
 
-        daemon = BMConfigParser().safeGetBoolean(
-            'bitmessagesettings', 'daemon')
+        config = BMConfigParser()
+        daemon = config.safeGetBoolean('bitmessagesettings', 'daemon')
 
         try:
             opts, args = getopt.getopt(
@@ -216,7 +216,6 @@ class Main:
                 # Fallback: in case when no api command was issued
                 state.last_api_response = time.time()
                 # Apply special settings
-                config = BMConfigParser()
                 config.set(
                     'bitmessagesettings', 'apienabled', 'true')
                 config.set(
@@ -256,14 +255,14 @@ class Main:
 
         helper_threading.set_thread_name("PyBitmessage")
 
-        state.dandelion = BMConfigParser().safeGetInt('network', 'dandelion')
+        state.dandelion = config.safeGetInt('network', 'dandelion')
         # dandelion requires outbound connections, without them,
         # stem objects will get stuck forever
-        if state.dandelion and not BMConfigParser().safeGetBoolean(
+        if state.dandelion and not config.safeGetBoolean(
                 'bitmessagesettings', 'sendoutgoingconnections'):
             state.dandelion = 0
 
-        if state.testmode or BMConfigParser().safeGetBoolean(
+        if state.testmode or config.safeGetBoolean(
                 'bitmessagesettings', 'extralowdifficulty'):
             defaults.networkDefaultProofOfWorkNonceTrialsPerByte = int(
                 defaults.networkDefaultProofOfWorkNonceTrialsPerByte / 100)
@@ -302,15 +301,15 @@ class Main:
         if state.enableObjProc:
 
             # SMTP delivery thread
-            if daemon and BMConfigParser().safeGet(
-                    "bitmessagesettings", "smtpdeliver", '') != '':
+            if daemon and config.safeGet(
+                    'bitmessagesettings', 'smtpdeliver', '') != '':
                 from class_smtpDeliver import smtpDeliver
                 smtpDeliveryThread = smtpDeliver()
                 smtpDeliveryThread.start()
 
             # SMTP daemon thread
-            if daemon and BMConfigParser().safeGetBoolean(
-                    "bitmessagesettings", "smtpd"):
+            if daemon and config.safeGetBoolean(
+                    'bitmessagesettings', 'smtpd'):
                 from class_smtpServer import smtpServer
                 smtpServerThread = smtpServer()
                 smtpServerThread.start()
@@ -335,7 +334,7 @@ class Main:
             shared.reloadBroadcastSendersForWhichImWatching()
 
             # API is also objproc dependent
-            if BMConfigParser().safeGetBoolean('bitmessagesettings', 'apienabled'):
+            if config.safeGetBoolean('bitmessagesettings', 'apienabled'):
                 import api  # pylint: disable=relative-import
                 singleAPIThread = api.singleAPI()
                 # close the main program even if there are threads left
@@ -348,7 +347,7 @@ class Main:
             asyncoreThread = BMNetworkThread()
             asyncoreThread.daemon = True
             asyncoreThread.start()
-            for i in range(BMConfigParser().getint("threads", "receive")):
+            for i in range(config.getint('threads', 'receive')):
                 receiveQueueThread = ReceiveQueueThread(i)
                 receiveQueueThread.daemon = True
                 receiveQueueThread.start()
@@ -370,8 +369,7 @@ class Main:
 
             connectToStream(1)
 
-            if BMConfigParser().safeGetBoolean(
-                    'bitmessagesettings', 'upnp'):
+            if config.safeGetBoolean('bitmessagesettings', 'upnp'):
                 import upnp
                 upnpThread = upnp.uPnPThread()
                 upnpThread.start()
@@ -387,14 +385,14 @@ class Main:
                 import bitmessagecurses
                 bitmessagecurses.runwrapper()
             elif state.kivy:
-                BMConfigParser().remove_option('bitmessagesettings', 'dontconnect')
+                config.remove_option('bitmessagesettings', 'dontconnect')
                 from bitmessagekivy.mpybit import NavigateApp
                 NavigateApp().run()
             else:
                 import bitmessageqt
                 bitmessageqt.run()
         else:
-            BMConfigParser().remove_option('bitmessagesettings', 'dontconnect')
+            config.remove_option('bitmessagesettings', 'dontconnect')
 
         if daemon:
             while state.shutdown == 0:

--- a/src/plugins/proxyconfig_stem.py
+++ b/src/plugins/proxyconfig_stem.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+import os
+import logging
+import random  # noseq
+import tempfile
+
+import stem
+import stem.control
+import stem.process
+
+
+class DebugLogger(object):
+    """Safe logger wrapper for tor and plugin's logs"""
+    # pylint: disable=too-few-public-methods
+    def __init__(self):
+        self._logger = logging.getLogger(__name__.split('.', 1)[0])
+        self._levels = {
+            'err': 40,
+            'warn': 30,
+            'notice': 20
+        }
+
+    def __call__(self, line):
+        try:
+            level, line = line.split('[', 1)[1].split(']')
+        except IndexError:
+            # Plugin's debug or unexpected log line from tor
+            self._logger.debug(line)
+        else:
+            self._logger.log(self._levels.get(level, 10), '(tor)' + line)
+
+
+def connect_plugin(config):
+    """Run stem proxy configurator"""
+    logwrite = DebugLogger()
+    if config.safeGet('bitmessagesettings', 'sockshostname') not in (
+        'localhost', '127.0.0.1', ''
+    ):
+        # remote proxy is choosen for outbound connections,
+        # nothing to do here, but need to set socksproxytype to SOCKS5!
+        logwrite(
+            'sockshostname is set to remote address,'
+            ' aborting stem proxy configuration')
+        return
+
+    datadir = tempfile.mkdtemp()
+    control_socket = os.path.join(datadir, 'control')
+    tor_config = {
+        'SocksPort': '9050',
+        # 'DataDirectory': datadir,  # had an exception with control socket
+        'ControlSocket': control_socket
+    }
+    port = config.safeGet('bitmessagesettings', 'socksport', '9050')
+    for attempt in range(50):
+        if attempt > 0:
+            port = random.randint(32767, 65535)
+            tor_config['SocksPort'] = str(port)
+        # It's recommended to use separate tor instance for hidden services.
+        # So if there is a system wide tor, use it for outbound connections.
+        try:
+            stem.process.launch_tor_with_config(
+                tor_config, take_ownership=True, init_msg_handler=logwrite)
+        except OSError:
+            continue
+        else:
+            logwrite('Started tor on port %s' % port)
+            break
+
+    if config.safeGetBoolean('bitmessagesettings', 'sockslisten'):
+        # need a hidden service for inbound connections
+        try:
+            controller = stem.control.Controller.from_socket_file(
+                control_socket)
+            controller.authenticate()
+        except stem.SocketError:
+            # something goes wrong way
+            logwrite('Failed to instantiate or authenticate on controller')
+            return
+
+        onionhostname = config.safeGet('bitmessagesettings', 'onionhostname')
+        onionkey = config.safeGet(onionhostname, 'privsigningkey')
+        if onionhostname and not onionkey:
+            logwrite('The hidden service found in config ): %s' % onionhostname)
+        onionkeytype = config.safeGet(onionhostname, 'keytype')
+
+        response = controller.create_ephemeral_hidden_service(
+            config.safeGetInt('bitmessagesettings', 'onionport', 8444),
+            key_type=(onionkeytype or 'NEW'),
+            key_content=(onionkey or 'BEST')
+        )
+
+        if not response.is_ok():
+            logwrite('Bad response from controller ):')
+            return
+
+        if not onionkey:
+            if not onionhostname:
+                onionhostname = response.service_id + '.onion'
+                config.set(
+                    'bitmessagesettings', 'onionhostname', onionhostname)
+            else:
+                onionhostname = response.service_id + '.onion'
+            logwrite('Started hidden service %s' % onionhostname)
+            config.add_section(onionhostname)
+            config.set(
+                onionhostname, 'privsigningkey', response.private_key)
+            config.set(
+                onionhostname, 'keytype', response.private_key_type)
+            config.save()
+        config.set('bitmessagesettings', 'socksproxytype', 'SOCKS5')

--- a/src/plugins/proxyconfig_stem.py
+++ b/src/plugins/proxyconfig_stem.py
@@ -87,7 +87,7 @@ def connect_plugin(config):
         response = controller.create_ephemeral_hidden_service(
             config.safeGetInt('bitmessagesettings', 'onionport', 8444),
             key_type=(onionkeytype or 'NEW'),
-            key_content=(onionkey or 'BEST')
+            key_content=(onionkey or onionhostname and 'ED25519-V3' or 'BEST')
         )
 
         if not response.is_ok():
@@ -95,17 +95,16 @@ def connect_plugin(config):
             return
 
         if not onionkey:
+            logwrite('Started hidden service %s.onion' % response.service_id)
+            # only save new service keys if onionhostname was not set previously
             if not onionhostname:
                 onionhostname = response.service_id + '.onion'
                 config.set(
                     'bitmessagesettings', 'onionhostname', onionhostname)
-            else:
-                onionhostname = response.service_id + '.onion'
-            logwrite('Started hidden service %s' % onionhostname)
-            config.add_section(onionhostname)
-            config.set(
-                onionhostname, 'privsigningkey', response.private_key)
-            config.set(
-                onionhostname, 'keytype', response.private_key_type)
-            config.save()
+                config.add_section(onionhostname)
+                config.set(
+                    onionhostname, 'privsigningkey', response.private_key)
+                config.set(
+                    onionhostname, 'keytype', response.private_key_type)
+                config.save()
         config.set('bitmessagesettings', 'socksproxytype', 'SOCKS5')


### PR DESCRIPTION
Hello!

I implemented pluggable proxy configurators and stem based configurator plugin for starting a hidden service or tor proxy if there is no system wide tor.

The changes in this PR like much of the previous ones still needs debugging and so contains the debuggy commit efa8cbe. In particular it should ensure that 'socksproxytype' setting is 'SOCKS5' after the plugin starts but will be set to plugins name before config saving.

