### PR TITLE
Add self peer into knownnodes if detected external IP with UPnP

### DIFF
--- a/src/knownnodes.py
+++ b/src/knownnodes.py
@@ -98,7 +98,7 @@ def saveKnownNodes(dirName=None):
 def addKnownNode(stream, peer, lastseen=None, is_self=False):
     knownNodes[stream][peer] = {
         "lastseen": lastseen or time.time(),
-        "rating": 0,
+        "rating": 1 if is_self else 0,
         "self": is_self,
     }
 


### PR DESCRIPTION
If UPnP is used it means that user wants to accept incoming connections. So if there is known external IP, it should be added into knownnodes to propagate in `addr` messages.