### PR TITLE
Fix #1504 (regression introduced in 0c1e516)

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3270,8 +3270,8 @@ class MyForm(settingsmixin.SMainWindow):
             tableWidget.model().removeRows(r.topRow(), r.bottomRow()-r.topRow()+1)
         idCount = len(inventoryHashesToTrash)
         sqlExecuteChunked(
-            "DELETE FROM inbox" if folder == "trash" or shifted else
-            "UPDATE inbox SET folder='trash'"
+            ("DELETE FROM inbox" if folder == "trash" or shifted else
+             "UPDATE inbox SET folder='trash'") +
             " WHERE msgid IN ({0})", idCount, *inventoryHashesToTrash)
         tableWidget.selectRow(0 if currentRow == 0 else currentRow - 1)
         tableWidget.setUpdatesEnabled(True)


### PR DESCRIPTION
It seems the problem only with `helper_sql.sqlExecuteChunked()` because the [similar expression](../commit/0c1e51692121e719398ecf3557693c0f5e79063f#diff-7c40f93cd788623cb1ed527c756840eaR3337) with `sqlExecute()` works well.
