### PR TITLE
New logging approach

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -38,8 +38,8 @@ from bmconfigparser import BMConfigParser
 from debug import logger
 from helper_ackPayload import genAckPayload
 from helper_sql import SqlBulkExecute, sqlExecute, sqlQuery, sqlStoredProcedure
-from helper_threading import StoppableThread
 from inventory import Inventory
+from network.threads import StoppableThread
 
 str_chan = '[chan]'
 

--- a/src/api.py
+++ b/src/api.py
@@ -95,6 +95,8 @@ class singleAPI(StoppableThread):
         for attempt in range(50):
             try:
                 if attempt > 0:
+                    logger.warning(
+                        'Failed to start API listener on port %s', port)
                     port = random.randint(32767, 65535)
                 se = StoppableXMLRPCServer(
                     (BMConfigParser().get(
@@ -106,8 +108,9 @@ class singleAPI(StoppableThread):
                     continue
             else:
                 if attempt > 0:
+                    logger.warning('Setting apiport to %s', port)
                     BMConfigParser().set(
-                        "bitmessagesettings", "apiport", str(port))
+                        'bitmessagesettings', 'apiport', str(port))
                     BMConfigParser().save()
                 break
         se.register_introspection_functions()

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -41,7 +41,7 @@ import shared
 import knownnodes
 import state
 import shutdown
-from debug import logger
+from debug import logger  # this should go before any threads
 
 # Classes
 from class_sqlThread import sqlThread

--- a/src/class_addressGenerator.py
+++ b/src/class_addressGenerator.py
@@ -12,10 +12,9 @@ import shared
 import defaults
 import highlevelcrypto
 from bmconfigparser import BMConfigParser
-from debug import logger
 from addresses import decodeAddress, encodeAddress, encodeVarint
 from fallback import RIPEMD160Hash
-from helper_threading import StoppableThread
+from network.threads import StoppableThread
 
 
 class addressGenerator(StoppableThread):
@@ -85,12 +84,12 @@ class addressGenerator(StoppableThread):
             elif queueValue[0] == 'stopThread':
                 break
             else:
-                logger.error(
+                self.logger.error(
                     'Programming error: A structure with the wrong number'
                     ' of values was passed into the addressGeneratorQueue.'
                     ' Here is the queueValue: %r\n', queueValue)
             if addressVersionNumber < 3 or addressVersionNumber > 4:
-                logger.error(
+                self.logger.error(
                     'Program error: For some reason the address generator'
                     ' queue has been given a request to create at least'
                     ' one version %s address which it cannot do.\n',
@@ -139,10 +138,10 @@ class addressGenerator(StoppableThread):
                         '\x00' * numberOfNullBytesDemandedOnFrontOfRipeHash
                     ):
                         break
-                logger.info(
+                self.logger.info(
                     'Generated address with ripe digest: %s', hexlify(ripe))
                 try:
-                    logger.info(
+                    self.logger.info(
                         'Address generator calculated %s addresses at %s'
                         ' addresses per second before finding one with'
                         ' the correct ripe-prefix.',
@@ -210,7 +209,7 @@ class addressGenerator(StoppableThread):
                     or command == 'getDeterministicAddress' \
                     or command == 'createChan' or command == 'joinChan':
                 if len(deterministicPassphrase) == 0:
-                    logger.warning(
+                    self.logger.warning(
                         'You are creating deterministic'
                         ' address(es) using a blank passphrase.'
                         ' Bitmessage will do it but it is rather stupid.')
@@ -263,10 +262,10 @@ class addressGenerator(StoppableThread):
                         ):
                             break
 
-                    logger.info(
+                    self.logger.info(
                         'Generated address with ripe digest: %s', hexlify(ripe))
                     try:
-                        logger.info(
+                        self.logger.info(
                             'Address generator calculated %s addresses'
                             ' at %s addresses per second before finding'
                             ' one with the correct ripe-prefix.',
@@ -316,7 +315,7 @@ class addressGenerator(StoppableThread):
                             addressAlreadyExists = True
 
                         if addressAlreadyExists:
-                            logger.info(
+                            self.logger.info(
                                 '%s already exists. Not adding it again.',
                                 address
                             )
@@ -329,7 +328,7 @@ class addressGenerator(StoppableThread):
                                 ).arg(address)
                             ))
                         else:
-                            logger.debug('label: %s', label)
+                            self.logger.debug('label: %s', label)
                             BMConfigParser().set(address, 'label', label)
                             BMConfigParser().set(address, 'enabled', 'true')
                             BMConfigParser().set(address, 'decoy', 'false')

--- a/src/class_objectProcessor.py
+++ b/src/class_objectProcessor.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import random
 import shared
 import threading
@@ -24,9 +25,10 @@ import protocol
 import queues
 import state
 import tr
-from debug import logger
 from fallback import RIPEMD160Hash
 import l10n
+
+logger = logging.getLogger('default')
 
 
 class objectProcessor(threading.Thread):
@@ -316,13 +318,14 @@ class objectProcessor(threading.Thread):
                 '\x04' + publicSigningKey + '\x04' + publicEncryptionKey)
             ripe = RIPEMD160Hash(sha.digest()).digest()
 
-            logger.debug(
-                'within recpubkey, addressVersion: %s, streamNumber: %s'
-                '\nripe %s\npublicSigningKey in hex: %s'
-                '\npublicEncryptionKey in hex: %s',
-                addressVersion, streamNumber, hexlify(ripe),
-                hexlify(publicSigningKey), hexlify(publicEncryptionKey)
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    'within recpubkey, addressVersion: %s, streamNumber: %s'
+                    '\nripe %s\npublicSigningKey in hex: %s'
+                    '\npublicEncryptionKey in hex: %s',
+                    addressVersion, streamNumber, hexlify(ripe),
+                    hexlify(publicSigningKey), hexlify(publicEncryptionKey)
+                )
 
             address = encodeAddress(addressVersion, streamNumber, ripe)
 
@@ -380,13 +383,14 @@ class objectProcessor(threading.Thread):
             sha.update(publicSigningKey + publicEncryptionKey)
             ripe = RIPEMD160Hash(sha.digest()).digest()
 
-            logger.debug(
-                'within recpubkey, addressVersion: %s, streamNumber: %s'
-                '\nripe %s\npublicSigningKey in hex: %s'
-                '\npublicEncryptionKey in hex: %s',
-                addressVersion, streamNumber, hexlify(ripe),
-                hexlify(publicSigningKey), hexlify(publicEncryptionKey)
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    'within recpubkey, addressVersion: %s, streamNumber: %s'
+                    '\nripe %s\npublicSigningKey in hex: %s'
+                    '\npublicEncryptionKey in hex: %s',
+                    addressVersion, streamNumber, hexlify(ripe),
+                    hexlify(publicSigningKey), hexlify(publicEncryptionKey)
+                )
 
             address = encodeAddress(addressVersion, streamNumber, ripe)
             queryreturn = sqlQuery(
@@ -579,17 +583,18 @@ class objectProcessor(threading.Thread):
             logger.debug('ECDSA verify failed')
             return
         logger.debug('ECDSA verify passed')
-        logger.debug(
-            'As a matter of intellectual curiosity, here is the Bitcoin'
-            ' address associated with the keys owned by the other person:'
-            ' %s  ..and here is the testnet address: %s. The other person'
-            ' must take their private signing key from Bitmessage and'
-            ' import it into Bitcoin (or a service like Blockchain.info)'
-            ' for it to be of any use. Do not use this unless you know'
-            ' what you are doing.',
-            helper_bitcoin.calculateBitcoinAddressFromPubkey(pubSigningKey),
-            helper_bitcoin.calculateTestnetAddressFromPubkey(pubSigningKey)
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                'As a matter of intellectual curiosity, here is the Bitcoin'
+                ' address associated with the keys owned by the other person:'
+                ' %s  ..and here is the testnet address: %s. The other person'
+                ' must take their private signing key from Bitmessage and'
+                ' import it into Bitcoin (or a service like Blockchain.info)'
+                ' for it to be of any use. Do not use this unless you know'
+                ' what you are doing.',
+                helper_bitcoin.calculateBitcoinAddressFromPubkey(pubSigningKey),
+                helper_bitcoin.calculateTestnetAddressFromPubkey(pubSigningKey)
+            )
         # Used to detect and ignore duplicate messages in our inbox
         sigHash = hashlib.sha512(
             hashlib.sha512(signature).digest()).digest()[32:]

--- a/src/class_smtpDeliver.py
+++ b/src/class_smtpDeliver.py
@@ -5,7 +5,6 @@ src/class_smtpDeliver.py
 # pylint: disable=unused-variable
 
 import smtplib
-import sys
 import urlparse
 from email.header import Header
 from email.mime.text import MIMEText
@@ -13,8 +12,7 @@ from email.mime.text import MIMEText
 import queues
 import state
 from bmconfigparser import BMConfigParser
-from debug import logger
-from helper_threading import StoppableThread
+from network.threads import StoppableThread
 
 SMTPDOMAIN = "bmaddr.lan"
 
@@ -75,10 +73,12 @@ class smtpDeliver(StoppableThread):
                     client.starttls()
                     client.ehlo()
                     client.sendmail(msg['From'], [to], msg.as_string())
-                    logger.info("Delivered via SMTP to %s through %s:%i ...", to, u.hostname, u.port)
+                    self.logger.info(
+                        'Delivered via SMTP to %s through %s:%i ...',
+                        to, u.hostname, u.port)
                     client.quit()
                 except:
-                    logger.error("smtp delivery error", exc_info=True)
+                    self.logger.error('smtp delivery error', exc_info=True)
             elif command == 'displayNewSentMessage':
                 toAddress, fromLabel, fromAddress, subject, message, ackdata = data
             elif command == 'updateNetworkStatusTab':
@@ -112,5 +112,5 @@ class smtpDeliver(StoppableThread):
             elif command == 'stopThread':
                 break
             else:
-                sys.stderr.write(
-                    'Command sent to smtpDeliver not recognized: %s\n' % command)
+                self.logger.warning(
+                    'Command sent to smtpDeliver not recognized: %s', command)

--- a/src/debug.py
+++ b/src/debug.py
@@ -1,26 +1,38 @@
 """
 Logging and debuging facility
-=============================
+-----------------------------
 
 Levels:
 
-   DEBUG
-      Detailed information, typically of interest only when diagnosing problems.
-   INFO
-      Confirmation that things are working as expected.
-   WARNING
-      An indication that something unexpected happened, or indicative of some problem in the
-      near future (e.g. 'disk space low'). The software is still working as expected.
-   ERROR
-      Due to a more serious problem, the software has not been able to perform some function.
-   CRITICAL
-      A serious error, indicating that the program itself may be unable to continue running.
+  DEBUG
+    Detailed information, typically of interest only when diagnosing problems.
+  INFO
+    Confirmation that things are working as expected.
+  WARNING
+    An indication that something unexpected happened, or indicative of
+    some problem in the near future (e.g. 'disk space low'). The software
+    is still working as expected.
+  ERROR
+    Due to a more serious problem, the software has not been able to
+    perform some function.
+  CRITICAL
+    A serious error, indicating that the program itself may be unable to
+    continue running.
 
-There are three loggers: `console_only`, `file_only` and `both`.
+There are three loggers by default: `console_only`, `file_only` and `both`.
+You can configure logging in the logging.dat in the appdata dir.
+It's format is described in the :func:`logging.config.fileConfig` doc.
 
-Use: `from debug import logger` to import this facility into whatever module you wish to log messages from.
-    Logging is thread-safe so you don't have to worry about locks, just import and log.
+Use:
 
+>>> import logging
+>>> logger = logging.getLogger('default')
+
+The old form: ``from debug import logger`` is also may be used,
+but only in the top level modules.
+
+Logging is thread-safe so you don't have to worry about locks,
+just import and log.
 """
 
 import ConfigParser
@@ -28,6 +40,7 @@ import logging
 import logging.config
 import os
 import sys
+
 import helper_startup
 import state
 
@@ -41,10 +54,17 @@ log_level = 'WARNING'
 
 
 def log_uncaught_exceptions(ex_cls, ex, tb):
+    """The last resort logging function used for sys.excepthook"""
     logging.critical('Unhandled exception', exc_info=(ex_cls, ex, tb))
 
 
 def configureLogging():
+    """
+    Configure logging,
+    using either logging.dat file in the state.appdata dir
+    or dictionary with hardcoded settings.
+    """
+    sys.excepthook = log_uncaught_exceptions
     fail_msg = ''
     try:
         logging_config = os.path.join(state.appdata, 'logging.dat')
@@ -63,9 +83,7 @@ def configureLogging():
             # no need to confuse the user if the logger config is missing entirely
             fail_msg = 'Using default logger configuration'
 
-    sys.excepthook = log_uncaught_exceptions
-
-    logging.config.dictConfig({
+    logging_config = {
         'version': 1,
         'formatters': {
             'default': {
@@ -107,34 +125,28 @@ def configureLogging():
             'level': log_level,
             'handlers': ['console'],
         },
-    })
+    }
+
+    logging_config['loggers']['default'] = logging_config['loggers'][
+        'file_only' if '-c' in sys.argv else 'both']
+    logging.config.dictConfig(logging_config)
 
     return True, fail_msg
 
 
-def initLogging():
-    preconfigured, msg = configureLogging()
-    if preconfigured:
-        if '-c' in sys.argv:
-            logger = logging.getLogger('file_only')
-        else:
-            logger = logging.getLogger('both')
-    else:
-        logger = logging.getLogger('default')
-
-    if msg:
-        logger.log(logging.WARNING if preconfigured else logging.INFO, msg)
-    return logger
-
-
 def resetLogging():
+    """Reconfigure logging in runtime when state.appdata dir changed"""
     global logger
-    for i in logger.handlers.iterkeys():
+    for i in logger.handlers:
         logger.removeHandler(i)
         i.flush()
         i.close()
-    logger = initLogging()
+    configureLogging()
+    logger = logging.getLogger('default')
 
 
 # !
-logger = initLogging()
+preconfigured, msg = configureLogging()
+logger = logging.getLogger('default')
+if msg:
+    logger.log(logging.WARNING if preconfigured else logging.INFO, msg)

--- a/src/debug.py
+++ b/src/debug.py
@@ -68,7 +68,8 @@ def configureLogging():
     fail_msg = ''
     try:
         logging_config = os.path.join(state.appdata, 'logging.dat')
-        logging.config.fileConfig(logging_config)
+        logging.config.fileConfig(
+            logging_config, disable_existing_loggers=False)
         return (
             False,
             'Loaded logger configuration from %s' % logging_config
@@ -80,7 +81,8 @@ def configureLogging():
                 ' logging config\n%s' % \
                 (logging_config, sys.exc_info())
         else:
-            # no need to confuse the user if the logger config is missing entirely
+            # no need to confuse the user if the logger config
+            # is missing entirely
             fail_msg = 'Using default logger configuration'
 
     logging_config = {

--- a/src/helper_threading.py
+++ b/src/helper_threading.py
@@ -1,9 +1,6 @@
-"""Helper threading perform all the threading operations."""
+"""set_thread_name for threads that don't use StoppableThread"""
 
 import threading
-from contextlib import contextmanager
-
-import helper_random
 
 try:
     import prctl
@@ -22,37 +19,3 @@ else:
 
     threading.Thread.__bootstrap_original__ = threading.Thread._Thread__bootstrap
     threading.Thread._Thread__bootstrap = _thread_name_hack
-
-
-class StoppableThread(threading.Thread):
-    name = None
-
-    def __init__(self, name=None):
-        if name:
-            self.name = name
-        super(StoppableThread, self).__init__(name=self.name)
-        self.initStop()
-        helper_random.seed()
-
-    def initStop(self):
-        self.stop = threading.Event()
-        self._stopped = False
-
-    def stopThread(self):
-        self._stopped = True
-        self.stop.set()
-
-
-class BusyError(threading.ThreadError):
-    pass
-
-
-@contextmanager
-def nonBlocking(lock):
-    locked = lock.acquire(False)
-    if not locked:
-        raise BusyError
-    try:
-        yield
-    finally:
-        lock.release()

--- a/src/l10n.py
+++ b/src/l10n.py
@@ -6,8 +6,7 @@ import time
 from bmconfigparser import BMConfigParser
 
 
-#logger = logging.getLogger(__name__)
-logger = logging.getLogger('file_only')
+logger = logging.getLogger('default')
 
 
 DEFAULT_ENCODING = 'ISO8859-1'

--- a/src/messagetypes/__init__.py
+++ b/src/messagetypes/__init__.py
@@ -1,17 +1,15 @@
-"""
-src/messagetypes/__init__.py
-============================
-"""
+import logging
 from importlib import import_module
 from os import path, listdir
 from string import lower
 
-from debug import logger
 import messagetypes
 import paths
 
+logger = logging.getLogger('default')
 
-class MsgBase(object):    # pylint: disable=too-few-public-methods
+
+class MsgBase(object):  # pylint: disable=too-few-public-methods
     """Base class for message types"""
     def __init__(self):
         self.data = {"": lower(type(self).__name__)}

--- a/src/messagetypes/message.py
+++ b/src/messagetypes/message.py
@@ -1,9 +1,8 @@
-"""
-src/messagetypes/message.py
-===========================
-"""
-from debug import logger
+import logging
+
 from messagetypes import MsgBase
+
+logger = logging.getLogger('default')
 
 
 class Message(MsgBase):

--- a/src/messagetypes/vote.py
+++ b/src/messagetypes/vote.py
@@ -1,9 +1,8 @@
-"""
-src/messagetypes/vote.py
-========================
-"""
-from debug import logger
+import logging
+
 from messagetypes import MsgBase
+
+logger = logging.getLogger('default')
 
 
 class Vote(MsgBase):

--- a/src/network/addrthread.py
+++ b/src/network/addrthread.py
@@ -1,9 +1,9 @@
 import Queue
 
-from helper_threading import StoppableThread
+import state
 from network.connectionpool import BMConnectionPool
 from queues import addrQueue
-import state
+from threads import StoppableThread
 
 
 class AddrThread(StoppableThread):

--- a/src/network/advanceddispatcher.py
+++ b/src/network/advanceddispatcher.py
@@ -10,8 +10,7 @@ import time
 
 import network.asyncore_pollchoose as asyncore
 import state
-from debug import logger
-from helper_threading import BusyError, nonBlocking
+from threads import BusyError, nonBlocking
 
 
 class ProcessingError(Exception):
@@ -84,7 +83,8 @@ class AdvancedDispatcher(asyncore.dispatcher):
                     try:
                         cmd = getattr(self, "state_" + str(self.state))
                     except AttributeError:
-                        logger.error("Unknown state %s", self.state, exc_info=True)
+                        self.logger.error(
+                            'Unknown state %s', self.state, exc_info=True)
                         raise UnknownStateError(self.state)
                     if not cmd():
                         break

--- a/src/network/announcethread.py
+++ b/src/network/announcethread.py
@@ -2,22 +2,20 @@
 src/network/announcethread.py
 =================================
 """
+
 import time
 
+import state
 from bmconfigparser import BMConfigParser
-from debug import logger
-from helper_threading import StoppableThread
 from network.bmproto import BMProto
 from network.connectionpool import BMConnectionPool
 from network.udp import UDPSocket
-import state
+from threads import StoppableThread
 
 
 class AnnounceThread(StoppableThread):
     """A thread to manage regular announcing of this node"""
-    def __init__(self):
-        super(AnnounceThread, self).__init__(name="Announcer")
-        logger.info("init announce thread")
+    name = "Announcer"
 
     def run(self):
         lastSelfAnnounced = 0

--- a/src/network/bmobject.py
+++ b/src/network/bmobject.py
@@ -2,14 +2,16 @@
 BMObject and it's exceptions.
 """
 
+import logging
 import time
 
 import protocol
 import state
 from addresses import calculateInventoryHash
-from debug import logger
 from inventory import Inventory
 from network.dandelion import Dandelion
+
+logger = logging.getLogger('default')
 
 
 class BMObjectInsufficientPOWError(Exception):

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -510,7 +510,7 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
         self.timeOffset = self.timestamp - int(time.time())
         logger.debug('remoteProtocolVersion: %i', self.remoteProtocolVersion)
         logger.debug('services: 0x%08X', self.services)
-        logger.debug('time offset: %i', self.timestamp - int(time.time()))
+        logger.debug('time offset: %i', self.timeOffset)
         logger.debug('my external IP: %s', self.sockNode.host)
         logger.debug(
             'remote node incoming address: %s:%i',

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -5,6 +5,7 @@ src/network/bmproto.py
 # pylint: disable=attribute-defined-outside-init
 import base64
 import hashlib
+import logging
 import socket
 import struct
 import time
@@ -16,7 +17,6 @@ import knownnodes
 import protocol
 import state
 from bmconfigparser import BMConfigParser
-from debug import logger
 from inventory import Inventory
 from network.advanceddispatcher import AdvancedDispatcher
 from network.dandelion import Dandelion
@@ -29,6 +29,8 @@ from network.proxy import ProxyError
 from objectracker import missingObjects, ObjectTracker
 from queues import objectProcessorQueue, portCheckerQueue, invQueue, addrQueue
 from randomtrackingdict import RandomTrackingDict
+
+logger = logging.getLogger('default')
 
 
 class BMProtoError(ProxyError):

--- a/src/network/connectionchooser.py
+++ b/src/network/connectionchooser.py
@@ -1,12 +1,14 @@
 # pylint: disable=too-many-branches
+import logging
 import random  # nosec
 
 import knownnodes
 import protocol
 import state
 from bmconfigparser import BMConfigParser
-from debug import logger
 from queues import Queue, portCheckerQueue
+
+logger = logging.getLogger('default')
 
 
 def getDiscoveredPeer():

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -3,6 +3,7 @@ src/network/connectionpool.py
 ==================================
 """
 import errno
+import logging
 import re
 import socket
 import time
@@ -14,13 +15,14 @@ import protocol
 import state
 from bmconfigparser import BMConfigParser
 from connectionchooser import chooseConnection
-from debug import logger
 from proxy import Proxy
 from singleton import Singleton
 from tcp import (
     bootstrap, Socks4aBMConnection, Socks5BMConnection,
     TCPConnection, TCPServer)
 from udp import UDPSocket
+
+logger = logging.getLogger('default')
 
 
 @Singleton

--- a/src/network/dandelion.py
+++ b/src/network/dandelion.py
@@ -2,6 +2,7 @@
 src/network/dandelion.py
 ========================
 """
+import logging
 from collections import namedtuple
 from random import choice, sample, expovariate
 from threading import RLock
@@ -9,7 +10,6 @@ from time import time
 
 import connectionpool
 import state
-from debug import logging
 from queues import invQueue
 from singleton import Singleton
 
@@ -23,6 +23,8 @@ FLUFF_TRIGGER_MEAN_DELAY = 30
 MAX_STEMS = 2
 
 Stem = namedtuple('Stem', ['child', 'stream', 'timeout'])
+
+logger = logging.getLogger('default')
 
 
 @Singleton
@@ -72,7 +74,7 @@ class Dandelion():      # pylint: disable=old-style-class
 
     def removeHash(self, hashId, reason="no reason specified"):
         """Switch inventory vector from stem to fluff mode"""
-        logging.debug(
+        logger.debug(
             "%s entering fluff mode due to %s.",
             ''.join('%02x' % ord(i) for i in hashId), reason)
         with self.lock:

--- a/src/network/dandelion.py
+++ b/src/network/dandelion.py
@@ -74,9 +74,10 @@ class Dandelion():      # pylint: disable=old-style-class
 
     def removeHash(self, hashId, reason="no reason specified"):
         """Switch inventory vector from stem to fluff mode"""
-        logger.debug(
-            "%s entering fluff mode due to %s.",
-            ''.join('%02x' % ord(i) for i in hashId), reason)
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                '%s entering fluff mode due to %s.',
+                ''.join('%02x' % ord(i) for i in hashId), reason)
         with self.lock:
             try:
                 del self.hashMap[hashId]

--- a/src/network/downloadthread.py
+++ b/src/network/downloadthread.py
@@ -2,17 +2,17 @@
 src/network/downloadthread.py
 =============================
 """
+
 import time
 
 import addresses
 import helper_random
 import protocol
 from dandelion import Dandelion
-from debug import logger
-from helper_threading import StoppableThread
 from inventory import Inventory
 from network.connectionpool import BMConnectionPool
 from objectracker import missingObjects
+from threads import StoppableThread
 
 
 class DownloadThread(StoppableThread):
@@ -25,7 +25,6 @@ class DownloadThread(StoppableThread):
 
     def __init__(self):
         super(DownloadThread, self).__init__(name="Downloader")
-        logger.info("init download thread")
         self.lastCleaned = time.time()
 
     def cleanPending(self):
@@ -78,7 +77,9 @@ class DownloadThread(StoppableThread):
                     continue
                 payload[0:0] = addresses.encodeVarint(chunkCount)
                 i.append_write_buf(protocol.CreatePacket('getdata', payload))
-                logger.debug("%s:%i Requesting %i objects", i.destination.host, i.destination.port, chunkCount)
+                self.logger.debug(
+                    '%s:%i Requesting %i objects',
+                    i.destination.host, i.destination.port, chunkCount)
                 requested += chunkCount
             if time.time() >= self.lastCleaned + DownloadThread.cleanInterval:
                 self.cleanPending()

--- a/src/network/invthread.py
+++ b/src/network/invthread.py
@@ -9,10 +9,10 @@ from time import time
 import addresses
 import protocol
 import state
-from helper_threading import StoppableThread
 from network.connectionpool import BMConnectionPool
 from network.dandelion import Dandelion
 from queues import invQueue
+from threads import StoppableThread
 
 
 def handleExpiredDandelion(expired):

--- a/src/network/networkthread.py
+++ b/src/network/networkthread.py
@@ -1,20 +1,13 @@
-"""
-src/network/networkthread.py
-============================
-"""
 import network.asyncore_pollchoose as asyncore
 import state
-from debug import logger
-from helper_threading import StoppableThread
 from network.connectionpool import BMConnectionPool
 from queues import excQueue
+from threads import StoppableThread
 
 
 class BMNetworkThread(StoppableThread):
     """A thread to handle network concerns"""
-    def __init__(self):
-        super(BMNetworkThread, self).__init__(name="Asyncore")
-        logger.info("init asyncore thread")
+    name = "Asyncore"
 
     def run(self):
         try:

--- a/src/network/proxy.py
+++ b/src/network/proxy.py
@@ -3,6 +3,7 @@ src/network/proxy.py
 ====================
 """
 # pylint: disable=protected-access
+import logging
 import socket
 import time
 
@@ -10,7 +11,8 @@ import asyncore_pollchoose as asyncore
 import state
 from advanceddispatcher import AdvancedDispatcher
 from bmconfigparser import BMConfigParser
-from debug import logger
+
+logger = logging.getLogger('default')
 
 
 class ProxyError(Exception):
@@ -144,5 +146,6 @@ class Proxy(AdvancedDispatcher):
 
     def state_proxy_handshake_done(self):
         """Handshake is complete at this point"""
-        self.connectedAt = time.time()      # pylint: disable=attribute-defined-outside-init
+        # pylint: disable=attribute-defined-outside-init
+        self.connectedAt = time.time()
         return False

--- a/src/network/receivequeuethread.py
+++ b/src/network/receivequeuethread.py
@@ -2,18 +2,16 @@ import errno
 import Queue
 import socket
 
-from debug import logger
-from helper_threading import StoppableThread
+import state
 from network.connectionpool import BMConnectionPool
 from network.advanceddispatcher import UnknownStateError
 from queues import receiveDataQueue
-import state
+from threads import StoppableThread
 
 
 class ReceiveQueueThread(StoppableThread):
     def __init__(self, num=0):
         super(ReceiveQueueThread, self).__init__(name="ReceiveQueue_%i" % num)
-        logger.info("init receive queue thread %i", num)
 
     def run(self):
         while not self._stopped and state.shutdown == 0:
@@ -26,10 +24,11 @@ class ReceiveQueueThread(StoppableThread):
                 break
 
             # cycle as long as there is data
-            # methods should return False if there isn't enough data, or the connection is to be aborted
-
-            # state_* methods should return False if there isn't enough data,
+            # methods should return False if there isn't enough data,
             # or the connection is to be aborted
+
+            # state_* methods should return False if there isn't
+            # enough data, or the connection is to be aborted
 
             try:
                 connection = BMConnectionPool().getConnectionByAddr(dest)
@@ -40,13 +39,13 @@ class ReceiveQueueThread(StoppableThread):
             try:
                 connection.process()
             # UnknownStateError = state isn't implemented
-            except (UnknownStateError):
+            except UnknownStateError:
                 pass
             except socket.error as err:
                 if err.errno == errno.EBADF:
                     connection.set_state("close", 0)
                 else:
-                    logger.error("Socket error: %s", str(err))
+                    self.logger.error('Socket error: %s', err)
             except:
-                logger.error("Error processing", exc_info=True)
+                self.logger.error('Error processing', exc_info=True)
             receiveDataQueue.task_done()

--- a/src/network/tcp.py
+++ b/src/network/tcp.py
@@ -371,6 +371,7 @@ class TCPServer(AdvancedDispatcher):
         for attempt in range(50):
             try:
                 if attempt > 0:
+                    logger.warning('Failed to bind on port %s', port)
                     port = random.randint(32767, 65535)
                 self.bind((host, port))
             except socket.error as e:
@@ -378,6 +379,7 @@ class TCPServer(AdvancedDispatcher):
                     continue
             else:
                 if attempt > 0:
+                    logger.warning('Setting port to %s', port)
                     BMConfigParser().set(
                         'bitmessagesettings', 'port', str(port))
                     BMConfigParser().save()

--- a/src/network/tcp.py
+++ b/src/network/tcp.py
@@ -4,6 +4,7 @@ src/network/tcp.py
 ==================
 """
 
+import logging
 import math
 import random
 import socket
@@ -18,7 +19,6 @@ import protocol
 import shared
 import state
 from bmconfigparser import BMConfigParser
-from debug import logger
 from helper_random import randomBytes
 from inventory import Inventory
 from network.advanceddispatcher import AdvancedDispatcher
@@ -29,6 +29,8 @@ from network.socks4a import Socks4aConnection
 from network.socks5 import Socks5Connection
 from network.tls import TLSDispatcher
 from queues import UISignalQueue, invQueue, receiveDataQueue
+
+logger = logging.getLogger('default')
 
 
 class TCPConnection(BMProto, TLSDispatcher):

--- a/src/network/threads.py
+++ b/src/network/threads.py
@@ -1,0 +1,49 @@
+"""Threading primitives for the network package"""
+
+import logging
+import random
+import threading
+from contextlib import contextmanager
+
+
+class StoppableThread(threading.Thread):
+    """Base class for application threads with stopThread method"""
+    name = None
+    logger = logging.getLogger('default')
+
+    def __init__(self, name=None):
+        if name:
+            self.name = name
+        super(StoppableThread, self).__init__(name=self.name)
+        self.stop = threading.Event()
+        self._stopped = False
+        random.seed()
+        self.logger.info('Init thread %s', self.name)
+
+    def stopThread(self):
+        """Stop the thread"""
+        self._stopped = True
+        self.stop.set()
+
+
+class BusyError(threading.ThreadError):
+    """
+    Thread error raised when another connection holds the lock
+    we are trying to acquire.
+    """
+    pass
+
+
+@contextmanager
+def nonBlocking(lock):
+    """
+    A context manager which acquires given lock non-blocking
+    and raises BusyError if failed to acquire.
+    """
+    locked = lock.acquire(False)
+    if not locked:
+        raise BusyError
+    try:
+        yield
+    finally:
+        lock.release()

--- a/src/network/tls.py
+++ b/src/network/tls.py
@@ -2,17 +2,18 @@
 SSL/TLS negotiation.
 """
 
+import logging
 import os
 import socket
 import ssl
 import sys
 
-from debug import logger
 from network.advanceddispatcher import AdvancedDispatcher
 import network.asyncore_pollchoose as asyncore
 from queues import receiveDataQueue
 import paths
 
+logger = logging.getLogger('default')
 
 _DISCONNECTED_SSL = frozenset((ssl.SSL_ERROR_EOF,))
 

--- a/src/network/tls.py
+++ b/src/network/tls.py
@@ -39,12 +39,13 @@ else:
     sslProtocolCiphers = "AECDH-AES256-SHA"
 
 
-class TLSDispatcher(AdvancedDispatcher):      # pylint: disable=too-many-instance-attributes
+class TLSDispatcher(AdvancedDispatcher):
     """TLS functionality for classes derived from AdvancedDispatcher"""
-    # pylint: disable=too-many-arguments, super-init-not-called, unused-argument
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments,super-init-not-called,unused-argument
     def __init__(
-            self, address=None, sock=None, certfile=None, keyfile=None,
-            server_side=False, ciphers=sslProtocolCiphers
+        self, address=None, sock=None, certfile=None, keyfile=None,
+        server_side=False, ciphers=sslProtocolCiphers
     ):
         self.want_read = self.want_write = True
         if certfile is None:
@@ -96,7 +97,10 @@ class TLSDispatcher(AdvancedDispatcher):      # pylint: disable=too-many-instanc
 
     @staticmethod
     def state_tls_handshake():
-        """Do nothing while TLS handshake is pending, as during this phase we need to react to callbacks instead"""
+        """
+        Do nothing while TLS handshake is pending, as during this phase
+        we need to react to callbacks instead
+        """
         return False
 
     def writable(self):
@@ -122,10 +126,11 @@ class TLSDispatcher(AdvancedDispatcher):      # pylint: disable=too-many-instanc
         except AttributeError:
             return AdvancedDispatcher.readable(self)
 
-    def handle_read(self):      # pylint: disable=inconsistent-return-statements
+    def handle_read(self):  # pylint: disable=inconsistent-return-statements
         """
-        Handle reads for sockets during TLS handshake. Requires special treatment as during the handshake, buffers must
-        remain empty and normal reads must be ignored
+        Handle reads for sockets during TLS handshake. Requires special
+        treatment as during the handshake, buffers must remain empty
+        and normal reads must be ignored.
         """
         try:
             # wait for write buffer flush
@@ -147,10 +152,11 @@ class TLSDispatcher(AdvancedDispatcher):      # pylint: disable=too-many-instanc
             self.handle_close()
             return
 
-    def handle_write(self):     # pylint: disable=inconsistent-return-statements
+    def handle_write(self):  # pylint: disable=inconsistent-return-statements
         """
-        Handle writes for sockets during TLS handshake. Requires special treatment as during the handshake, buffers
-        must remain empty and normal writes must be ignored
+        Handle writes for sockets during TLS handshake. Requires special
+        treatment as during the handshake, buffers must remain empty
+        and normal writes must be ignored.
         """
         try:
             # wait for write buffer flush
@@ -193,18 +199,23 @@ class TLSDispatcher(AdvancedDispatcher):      # pylint: disable=too-many-instanc
             if not (self.want_write or self.want_read):
                 raise
         except socket.error as err:
-            if err.errno in asyncore._DISCONNECTED:     # pylint: disable=protected-access
+            # pylint: disable=protected-access
+            if err.errno in asyncore._DISCONNECTED:
                 self.handle_close()
             else:
                 raise
         else:
             if sys.version_info >= (2, 7, 9):
                 self.tlsVersion = self.sslSocket.version()
-                logger.debug("%s:%i: TLS handshake success, TLS protocol version: %s",
-                             self.destination.host, self.destination.port, self.sslSocket.version())
+                logger.debug(
+                    '%s:%i: TLS handshake success, TLS protocol version: %s',
+                    self.destination.host, self.destination.port,
+                    self.tlsVersion)
             else:
                 self.tlsVersion = "TLSv1"
-                logger.debug("%s:%i: TLS handshake success", self.destination.host, self.destination.port)
+                logger.debug(
+                    '%s:%i: TLS handshake success',
+                    self.destination.host, self.destination.port)
             # The handshake has completed, so remove this channel and...
             self.del_channel()
             self.set_socket(self.sslSocket)

--- a/src/network/udp.py
+++ b/src/network/udp.py
@@ -2,24 +2,27 @@
 src/network/udp.py
 ==================
 """
+import logging
 import time
 import socket
 
 import state
 import protocol
 from bmproto import BMProto
-from debug import logger
 from objectracker import ObjectTracker
 from queues import receiveDataQueue
 
+logger = logging.getLogger('default')
 
-class UDPSocket(BMProto):           # pylint: disable=too-many-instance-attributes
+
+class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
     """Bitmessage protocol over UDP (class)"""
     port = 8444
     announceInterval = 60
 
     def __init__(self, host=None, sock=None, announcing=False):
-        super(BMProto, self).__init__(sock=sock)        # pylint: disable=bad-super-call
+        # pylint: disable=bad-super-call
+        super(BMProto, self).__init__(sock=sock)
         self.verackReceived = True
         self.verackSent = True
         # .. todo:: sort out streams
@@ -79,7 +82,8 @@ class UDPSocket(BMProto):           # pylint: disable=too-many-instance-attribut
             decodedIP = protocol.checkIPAddress(str(ip))
             if stream not in state.streamsInWhichIAmParticipating:
                 continue
-            if (seenTime < time.time() - self.maxTimeOffset or seenTime > time.time() + self.maxTimeOffset):
+            if (seenTime < time.time() - self.maxTimeOffset
+                    or seenTime > time.time() + self.maxTimeOffset):
                 continue
             if decodedIP is False:
                 # if the address isn't local, interpret it as

--- a/src/network/uploadthread.py
+++ b/src/network/uploadthread.py
@@ -1,26 +1,23 @@
 """
 src/network/uploadthread.py
 """
-# pylint: disable=unsubscriptable-object
 import time
 
 import helper_random
 import protocol
-from debug import logger
-from helper_threading import StoppableThread
 from inventory import Inventory
 from network.connectionpool import BMConnectionPool
 from network.dandelion import Dandelion
 from randomtrackingdict import RandomTrackingDict
+from threads import StoppableThread
 
 
 class UploadThread(StoppableThread):
-    """This is a thread that uploads the objects that the peers requested from me """
+    """
+    This is a thread that uploads the objects that the peers requested from me
+    """
     maxBufSize = 2097152  # 2MB
-
-    def __init__(self):
-        super(UploadThread, self).__init__(name="Uploader")
-        logger.info("init upload thread")
+    name = "Uploader"
 
     def run(self):
         while not self._stopped:
@@ -47,22 +44,26 @@ class UploadThread(StoppableThread):
                     if Dandelion().hasHash(chunk) and \
                        i != Dandelion().objectChildStem(chunk):
                         i.antiIntersectionDelay()
-                        logger.info('%s asked for a stem object we didn\'t offer to it.',
-                                    i.destination)
+                        self.logger.info(
+                            '%s asked for a stem object we didn\'t offer to it.',
+                            i.destination)
                         break
                     try:
-                        payload.extend(protocol.CreatePacket('object',
-                                                             Inventory()[chunk].payload))
+                        payload.extend(protocol.CreatePacket(
+                            'object', Inventory()[chunk].payload))
                         chunk_count += 1
                     except KeyError:
                         i.antiIntersectionDelay()
-                        logger.info('%s asked for an object we don\'t have.', i.destination)
+                        self.logger.info(
+                            '%s asked for an object we don\'t have.',
+                            i.destination)
                         break
                 if not chunk_count:
                     continue
                 i.append_write_buf(payload)
-                logger.debug("%s:%i Uploading %i objects",
-                             i.destination.host, i.destination.port, chunk_count)
+                self.logger.debug(
+                    '%s:%i Uploading %i objects',
+                    i.destination.host, i.destination.port, chunk_count)
                 uploaded += chunk_count
             if not uploaded:
                 self.stop.wait(1)

--- a/src/plugins/proxyconfig_stem.py
+++ b/src/plugins/proxyconfig_stem.py
@@ -18,7 +18,7 @@ class DebugLogger(object):
     """Safe logger wrapper for tor and plugin's logs"""
     # pylint: disable=too-few-public-methods
     def __init__(self):
-        self._logger = logging.getLogger(__name__.split('.', 1)[0])
+        self._logger = logging.getLogger('default')
         self._levels = {
             'err': 40,
             'warn': 30,

--- a/src/shutdown.py
+++ b/src/shutdown.py
@@ -3,15 +3,15 @@ import Queue
 import threading
 import time
 
-from debug import logger
-from helper_sql import sqlQuery, sqlStoredProcedure
-from helper_threading import StoppableThread
-from knownnodes import saveKnownNodes
-from inventory import Inventory
-from queues import (
-    addressGeneratorQueue, objectProcessorQueue, UISignalQueue, workerQueue)
 import shared
 import state
+from debug import logger
+from helper_sql import sqlQuery, sqlStoredProcedure
+from inventory import Inventory
+from knownnodes import saveKnownNodes
+from network.threads import StoppableThread
+from queues import (
+    addressGeneratorQueue, objectProcessorQueue, UISignalQueue, workerQueue)
 
 
 def doCleanShutdown():

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -1,0 +1,69 @@
+"""
+Testing the logger configuration
+"""
+
+import logging
+import os
+import tempfile
+import unittest
+
+
+class TestLogger(unittest.TestCase):
+    """A test case for bmconfigparser"""
+
+    conf_template = '''
+[loggers]
+keys=root
+
+[handlers]
+keys=default
+
+[formatters]
+keys=default
+
+[formatter_default]
+format=%(asctime)s {1} %(message)s
+
+[handler_default]
+class=FileHandler
+level=NOTSET
+formatter=default
+args=('{0}', 'w')
+
+[logger_root]
+level=DEBUG
+handlers=default
+'''
+
+    def test_fileConfig(self):
+        """Put logging.dat with special pattern and check it was used"""
+        tmp = os.environ['BITMESSAGE_HOME'] = tempfile.gettempdir()
+        log_config = os.path.join(tmp, 'logging.dat')
+        log_file = os.path.join(tmp, 'debug.log')
+
+        def gen_log_config(pattern):
+            """A small closure to generate logging.dat with custom pattern"""
+            with open(log_config, 'wb') as dst:
+                dst.write(self.conf_template.format(log_file, pattern))
+
+        pattern = r' o_0 '
+        gen_log_config(pattern)
+
+        try:
+            from pybitmessage.debug import logger, resetLogging
+            if not os.path.isfile(log_file):  # second pass
+                pattern = r' <===> '
+                gen_log_config(pattern)
+                resetLogging()
+        except ImportError:
+            self.fail('There is no package pybitmessage. Things gone wrong.')
+        finally:
+            os.remove(log_config)
+
+        logger_ = logging.getLogger('default')
+
+        self.assertEqual(logger, logger_)
+
+        logger_.info('Testing the logger...')
+
+        self.assertRegexpMatches(open(log_file).read(), pattern)

--- a/src/upnp.py
+++ b/src/upnp.py
@@ -21,8 +21,8 @@ import state
 import tr
 from bmconfigparser import BMConfigParser
 from debug import logger
-from helper_threading import StoppableThread
 from network.connectionpool import BMConnectionPool
+from network.threads import StoppableThread
 
 
 def createRequestXML(service, action, arguments=None):


### PR DESCRIPTION
Hello!

All that changes are to reduce imports of outer modules from `network` package. Any `StoppableThread` here has a `logger` attribute which can be used instead of one from `debug` module. All other modules inside the `network` use the following code:

```python
import logging

logger = logging.getLogger('default')
```

