### PR TITLE
Fix mistakes in Exception() instantiation

### DIFF
--- a/src/class_smtpServer.py
+++ b/src/class_smtpServer.py
@@ -21,6 +21,7 @@ from version import softwareVersion
 SMTPDOMAIN = "bmaddr.lan"
 LISTENPORT = 8425
 
+
 class smtpServerChannel(smtpd.SMTPChannel):
     def smtp_EHLO(self, arg):
         if not arg:
@@ -113,9 +114,9 @@ class smtpServerPyBitmessage(smtpd.SMTPServer):
         try:
             sender, domain = p.sub(r'\1', mailfrom).split("@")
             if domain != SMTPDOMAIN:
-                raise Exception("Bad domain %s", domain)
+                raise Exception("Bad domain %s" % domain)
             if sender not in BMConfigParser().addresses():
-                raise Exception("Nonexisting user %s", sender)
+                raise Exception("Nonexisting user %s" % sender)
         except Exception as err:
             logger.debug("Bad envelope from %s: %s", mailfrom, repr(err))
             msg_from = self.decode_header("from")
@@ -123,9 +124,9 @@ class smtpServerPyBitmessage(smtpd.SMTPServer):
                 msg_from = p.sub(r'\1', self.decode_header("from")[0])
                 sender, domain = msg_from.split("@")
                 if domain != SMTPDOMAIN:
-                    raise Exception("Bad domain %s", domain)
+                    raise Exception("Bad domain %s" % domain)
                 if sender not in BMConfigParser().addresses():
-                    raise Exception("Nonexisting user %s", sender)
+                    raise Exception("Nonexisting user %s" % sender)
             except Exception as err:
                 logger.error("Bad headers from %s: %s", msg_from, repr(err))
                 return
@@ -145,7 +146,7 @@ class smtpServerPyBitmessage(smtpd.SMTPServer):
             try:
                 rcpt, domain = p.sub(r'\1', to).split("@")
                 if domain != SMTPDOMAIN:
-                    raise Exception("Bad domain %s", domain)
+                    raise Exception("Bad domain %s" % domain)
                 logger.debug("Sending %s to %s about %s", sender, rcpt, msg_subject)
                 self.send(sender, rcpt, msg_subject, body)
                 logger.info("Relayed %s to %s", sender, rcpt)

--- a/src/namecoin.py
+++ b/src/namecoin.py
@@ -258,7 +258,7 @@ class namecoinConnection(object):
                 resp = self.con.getresponse()
                 result = resp.read()
                 if resp.status != 200:
-                    raise Exception("Namecoin returned status %i: %s" % resp.status, resp.reason)
+                    raise Exception("Namecoin returned status %i: %s" % (resp.status, resp.reason))
             except:
                 logger.info("HTTP receive error")
         except:
@@ -288,7 +288,7 @@ class namecoinConnection(object):
             return result
 
         except socket.error as exc:
-            raise Exception("Socket error in RPC connection: %s" % str(exc))
+            raise Exception("Socket error in RPC connection: %s" % exc)
 
 
 def lookupNamecoinFolder():


### PR DESCRIPTION
Hello

It looks like you mistyped `Exception()` as `logger.error()` in `class_smtpServer`.
In namecoin:

```
>>> import collections
>>> Resp = collections.namedtuple('Resp', ['status', 'reason'])
>>> resp = Resp(42, 'test')
>>> print "Namecoin returned status %i: %s" % resp.status, resp.reason
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-258-68046a3c466e> in <module>()
----> 1 print "Namecoin returned status %i: %s" % resp.status, resp.reason

TypeError: not enough arguments for format string
```