### PR TITLE
Support for socksproxytype plugins in Settings dialog

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 python_prctl
 psutil
 pycrypto
-stem

--- a/src/bitmessageqt/settings.ui
+++ b/src/bitmessageqt/settings.ui
@@ -419,12 +419,12 @@
             </item>
             <item>
              <property name="text">
-              <string>SOCKS4a</string>
+              <string notr="true">SOCKS4a</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>SOCKS5</string>
+              <string notr="true">SOCKS5</string>
              </property>
             </item>
            </widget>

--- a/src/bitmessageqt/support.py
+++ b/src/bitmessageqt/support.py
@@ -15,6 +15,7 @@ from openclpow import openclAvailable, openclEnabled
 import paths
 import proofofwork
 from pyelliptic.openssl import OpenSSL
+from settings import getSOCKSProxyType
 import queues
 import network.stats
 import state
@@ -118,8 +119,7 @@ def createSupportMessage(myapp):
         BMConfigParser().safeGet('bitmessagesettings', 'opencl')
     ) if openclEnabled() else "None"
     locale = getTranslationLanguage()
-    socks = BMConfigParser().safeGet(
-        'bitmessagesettings', 'socksproxytype', "N/A")
+    socks = getSOCKSProxyType(BMConfigParser()) or "N/A"
     upnp = BMConfigParser().safeGet('bitmessagesettings', 'upnp', "N/A")
     connectedhosts = len(network.stats.connectedHostsList())
 

--- a/src/helper_startup.py
+++ b/src/helper_startup.py
@@ -2,11 +2,12 @@
 Startup operations.
 """
 # pylint: disable=too-many-branches,too-many-statements
-from __future__ import print_function
 
+import logging
 import os
 import platform
 import sys
+import time
 from distutils.version import StrictVersion
 
 import defaults
@@ -15,6 +16,13 @@ import paths
 import state
 from bmconfigparser import BMConfigParser
 
+try:
+    from plugins.plugin import get_plugin
+except ImportError:
+    get_plugin = None
+
+
+logger = logging.getLogger('default')
 
 # The user may de-select Portable Mode in the settings if they want
 # the config files to stay in the application data folder.
@@ -30,14 +38,14 @@ def loadConfig():
         needToCreateKeysFile = config.safeGet(
             'bitmessagesettings', 'settingsversion') is None
         if not needToCreateKeysFile:
-            print(
+            logger.info(
                 'Loading config files from directory specified'
-                ' on startup: %s' % state.appdata)
+                ' on startup: %s', state.appdata)
     else:
         config.read(paths.lookupExeFolder() + 'keys.dat')
         try:
             config.get('bitmessagesettings', 'settingsversion')
-            print('Loading config files from same directory as program.')
+            logger.info('Loading config files from same directory as program.')
             needToCreateKeysFile = False
             state.appdata = paths.lookupExeFolder()
         except:
@@ -48,7 +56,8 @@ def loadConfig():
             needToCreateKeysFile = config.safeGet(
                 'bitmessagesettings', 'settingsversion') is None
             if not needToCreateKeysFile:
-                print('Loading existing config files from', state.appdata)
+                logger.info(
+                    'Loading existing config files from %s', state.appdata)
 
     if needToCreateKeysFile:
 
@@ -103,9 +112,10 @@ def loadConfig():
             # Just use the same directory as the program and forget about
             # the appdata folder
             state.appdata = ''
-            print('Creating new config files in same directory as program.')
+            logger.info(
+                'Creating new config files in same directory as program.')
         else:
-            print('Creating new config files in', state.appdata)
+            logger.info('Creating new config files in %s', state.appdata)
             if not os.path.exists(state.appdata):
                 os.makedirs(state.appdata)
         if not sys.platform.startswith('win'):
@@ -255,7 +265,7 @@ def updateConfig():
             'bitmessagesettings', 'hidetrayconnectionnotifications', 'false')
     if config.safeGetInt('bitmessagesettings', 'maxoutboundconnections') < 1:
         config.set('bitmessagesettings', 'maxoutboundconnections', '8')
-        print('WARNING: your maximum outbound connections must be a number.')
+        logger.warning('Your maximum outbound connections must be a number.')
 
     # TTL is now user-specifiable. Let's add an option to save
     # whatever the user selects.
@@ -278,3 +288,26 @@ def isOurOperatingSystemLimitedToHavingVeryFewHalfOpenConnections():
         return False
     except Exception:
         pass
+
+
+def start_proxyconfig():
+    """Check socksproxytype and start any proxy configuration plugin"""
+    if not get_plugin:
+        return
+    config = BMConfigParser()
+    proxy_type = config.safeGet('bitmessagesettings', 'socksproxytype')
+    if proxy_type and proxy_type not in ('none', 'SOCKS4a', 'SOCKS5'):
+        try:
+            proxyconfig_start = time.time()
+            if not get_plugin('proxyconfig', name=proxy_type)(config):
+                raise TypeError()
+        except TypeError:
+            # cannot import shutdown here ):
+            logger.error(
+                'Failed to run proxy config plugin %s',
+                proxy_type, exc_info=True)
+            os._exit(0)  # pylint: disable=protected-access
+        else:
+            logger.info(
+                'Started proxy config plugin %s in %s sec',
+                proxy_type, time.time() - proxyconfig_start)

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,7 @@
+"""
+Simple plugin system based on setuptools
+----------------------------------------
+
+
+"""
+# .. include:: pybitmessage.plugins.plugin.rst

--- a/src/plugins/plugin.py
+++ b/src/plugins/plugin.py
@@ -1,19 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-src/plugins/plugin.py
-===================================
+Operating with plugins
 """
+import logging
+
 import pkg_resources
+
+
+logger = logging.getLogger('default')
 
 
 def get_plugins(group, point='', name=None, fallback=None):
     """
-    Iterate through plugins (`connect_plugin` attribute of entry point)
-    which name starts with `point` or equals to `name`.
-    If `fallback` kwarg specified, plugin with that name yield last.
+    :param str group: plugin group
+    :param str point: plugin name prefix
+    :param name: exact plugin name
+    :param fallback: fallback plugin name
+
+    Iterate through plugins (``connect_plugin`` attribute of entry point)
+    which name starts with ``point`` or equals to ``name``.
+    If ``fallback`` kwarg specified, plugin with that name yield last.
     """
     for ep in pkg_resources.iter_entry_points('bitmessage.' + group):
-        if name and ep.name == name or ep.name.startswith(point):
+        if name and ep.name == name or not point or ep.name.startswith(point):
             try:
                 plugin = ep.load().connect_plugin
                 if ep.name == fallback:
@@ -25,6 +34,8 @@ def get_plugins(group, point='', name=None, fallback=None):
                     ValueError,
                     pkg_resources.DistributionNotFound,
                     pkg_resources.UnknownExtra):
+                logger.debug(
+                    'Problem while loading %s', ep.name, exc_info=True)
                 continue
     try:
         yield _fallback
@@ -33,6 +44,8 @@ def get_plugins(group, point='', name=None, fallback=None):
 
 
 def get_plugin(*args, **kwargs):
-    """Returns first available plugin `from get_plugins()` if any."""
+    """
+    :return: first available plugin from :func:`get_plugins` if any.
+    """
     for plugin in get_plugins(*args, **kwargs):
         return plugin

--- a/src/plugins/proxyconfig_stem.py
+++ b/src/plugins/proxyconfig_stem.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
 """
-src/plugins/proxyconfig_stem.py
-===================================
+Configure tor proxy and hidden service with
+`stem <https://stem.torproject.org/>`_ depending on *bitmessagesettings*:
+
+  * try to start own tor instance on *socksport* if *sockshostname*
+    is unset or set to localhost;
+  * if *socksport* is already in use that instance is used only for
+    hidden service (if *sockslisten* is also set True);
+  * create ephemeral hidden service v3 if there is already *onionhostname*;
+  * otherwise use stem's 'BEST' version and save onion keys to the new
+    section using *onionhostname* as name for future use.
 """
 import os
 import logging
@@ -36,10 +44,16 @@ class DebugLogger(object):
 
 
 def connect_plugin(config):  # pylint: disable=too-many-branches
-    """Run stem proxy configurator"""
+    """
+    Run stem proxy configurator
+
+    :param config: current configuration instance
+    :type config: :class:`pybitmessage.bmconfigparser.BMConfigParser`
+    :return: True if configuration was done successfully
+    """
     logwrite = DebugLogger()
-    if config.safeGet('bitmessagesettings', 'sockshostname') not in (
-            'localhost', '127.0.0.1', ''
+    if config.safeGet('bitmessagesettings', 'sockshostname', '') not in (
+        'localhost', '127.0.0.1', ''
     ):
         # remote proxy is choosen for outbound connections,
         # nothing to do here, but need to set socksproxytype to SOCKS5!

--- a/src/plugins/proxyconfig_stem.py
+++ b/src/plugins/proxyconfig_stem.py
@@ -43,6 +43,7 @@ def connect_plugin(config):  # pylint: disable=too-many-branches
     ):
         # remote proxy is choosen for outbound connections,
         # nothing to do here, but need to set socksproxytype to SOCKS5!
+        config.set('bitmessagesettings', 'socksproxytype', 'SOCKS5')
         logwrite(
             'sockshostname is set to remote address,'
             ' aborting stem proxy configuration')
@@ -76,6 +77,8 @@ def connect_plugin(config):  # pylint: disable=too-many-branches
         else:
             logwrite('Started tor on port %s' % port)
             break
+
+    config.setTemp('bitmessagesettings', 'socksproxytype', 'SOCKS5')
 
     if config.safeGetBoolean('bitmessagesettings', 'sockslisten'):
         # need a hidden service for inbound connections
@@ -117,6 +120,5 @@ def connect_plugin(config):  # pylint: disable=too-many-branches
                 config.set(
                     onionhostname, 'keytype', response.private_key_type)
                 config.save()
-        config.set('bitmessagesettings', 'socksproxytype', 'SOCKS5')
 
-        return True
+    return True

--- a/src/plugins/proxyconfig_stem.py
+++ b/src/plugins/proxyconfig_stem.py
@@ -112,7 +112,8 @@ def connect_plugin(config):  # pylint: disable=too-many-branches
         onionkeytype = config.safeGet(onionhostname, 'keytype')
 
         response = controller.create_ephemeral_hidden_service(
-            config.safeGetInt('bitmessagesettings', 'onionport', 8444),
+            {config.safeGetInt('bitmessagesettings', 'onionport', 8444):
+             config.safeGetInt('bitmessagesettings', 'port', 8444)},
             key_type=(onionkeytype or 'NEW'),
             key_content=(onionkey or onionhostname and 'ED25519-V3' or 'BEST')
         )

--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -14,6 +14,7 @@ import unittest
 import knownnodes
 import state
 from bmconfigparser import BMConfigParser
+from helper_startup import start_proxyconfig
 from helper_msgcoding import MsgEncode, MsgDecode
 from network import asyncore_pollchoose as asyncore
 from network.connectionpool import BMConnectionPool
@@ -21,8 +22,8 @@ from network.node import Peer
 from network.tcp import Socks4aBMConnection, Socks5BMConnection, TCPConnection
 from queues import excQueue
 
+
 knownnodes_file = os.path.join(state.appdata, 'knownnodes.dat')
-program = None
 
 
 def pickle_knownnodes():
@@ -196,14 +197,12 @@ class TestCore(unittest.TestCase):
         self._check_bootstrap()
         self._initiate_bootstrap()
         BMConfigParser().set('bitmessagesettings', 'socksproxytype', 'stem')
-        program.start_proxyconfig(BMConfigParser())
+        start_proxyconfig()
         self._check_bootstrap()
 
 
-def run(prog):
+def run():
     """Starts all tests defined in this module"""
-    global program  # pylint: disable=global-statement
-    program = prog
     loader = unittest.TestLoader()
     loader.sortTestMethodsUsing = None
     suite = loader.loadTestsFromTestCase(TestCore)

--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -14,13 +14,18 @@ import unittest
 import knownnodes
 import state
 from bmconfigparser import BMConfigParser
-from helper_startup import start_proxyconfig
 from helper_msgcoding import MsgEncode, MsgDecode
+from helper_startup import start_proxyconfig
 from network import asyncore_pollchoose as asyncore
 from network.connectionpool import BMConnectionPool
 from network.node import Peer
 from network.tcp import Socks4aBMConnection, Socks5BMConnection, TCPConnection
 from queues import excQueue
+
+try:
+    import stem.version as stem_version
+except ImportError:
+    stem_version = None
 
 
 knownnodes_file = os.path.join(state.appdata, 'knownnodes.dat')
@@ -171,12 +176,29 @@ class TestCore(unittest.TestCase):
                     self.assertIsInstance(con, connection_base)
                     self.assertNotEqual(peer.host, '127.0.0.1')
                     return
-        else:  # pylint: disable=useless-else-on-loop
-            self.fail(
-                'Failed to connect during %s sec' % (time.time() - _started))
+        self.fail(
+            'Failed to connect during %s sec' % (time.time() - _started))
 
-    def test_onionservicesonly(self):
-        """test onionservicesonly networking mode"""
+    def test_bootstrap(self):
+        """test bootstrapping"""
+        self._initiate_bootstrap()
+        self._check_bootstrap()
+
+    @unittest.skipUnless(stem_version, 'No stem, skipping tor dependent test')
+    def test_bootstrap_tor(self):
+        """test bootstrapping with tor"""
+        self._initiate_bootstrap()
+        BMConfigParser().set('bitmessagesettings', 'socksproxytype', 'stem')
+        start_proxyconfig()
+        self._check_bootstrap()
+
+    @unittest.skipUnless(stem_version, 'No stem, skipping tor dependent test')
+    def test_onionservicesonly(self):  # this should start after bootstrap
+        """
+        set onionservicesonly, wait for 3 connections and check them all
+        are onions
+        """
+        BMConfigParser().set('bitmessagesettings', 'socksproxytype', 'SOCKS5')
         BMConfigParser().set('bitmessagesettings', 'onionservicesonly', 'true')
         self._initiate_bootstrap()
         BMConfigParser().remove_option('bitmessagesettings', 'dontconnect')
@@ -185,20 +207,14 @@ class TestCore(unittest.TestCase):
             for n, peer in enumerate(BMConnectionPool().outboundConnections):
                 if n > 2:
                     return
-                if not peer.host.endswith('.onion'):
+                if (
+                    not peer.host.endswith('.onion')
+                    and not peer.host.startswith('bootstrap')
+                ):
                     self.fail(
                         'Found non onion hostname %s in outbound connections!'
                         % peer.host)
         self.fail('Failed to connect to at least 3 nodes within 360 sec')
-
-    def test_bootstrap(self):
-        """test bootstrapping"""
-        self._initiate_bootstrap()
-        self._check_bootstrap()
-        self._initiate_bootstrap()
-        BMConfigParser().set('bitmessagesettings', 'socksproxytype', 'stem')
-        start_proxyconfig()
-        self._check_bootstrap()
 
 
 def run():


### PR DESCRIPTION
Hello.

With this changes now it's possible to set "Proxy server / Tor Type:" to any one provided by plugin. `start_proxyconfig` will be called when user press "OK" in the Settings dialog.

This is a draft because I'm trying to fix test and maybe port in `proxyconfig_stem`.

