### PR TITLE
More docstrings and formatting

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+python:
+  version: 2.7
+  install:
+    - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .
+  system_packages: true

--- a/src/addresses.py
+++ b/src/addresses.py
@@ -1,7 +1,5 @@
 """
-src/addresses.py
-================
-
+Operations with addresses
 """
 # pylint: disable=redefined-outer-name,inconsistent-return-statements
 
@@ -18,8 +16,9 @@ ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 def encodeBase58(num, alphabet=ALPHABET):
     """Encode a number in Base X
 
-    `num`: The number to encode
-    `alphabet`: The alphabet to use for encoding
+    Args:
+      num: The number to encode
+      alphabet: The alphabet to use for encoding
     """
     if num == 0:
         return alphabet[0]
@@ -27,7 +26,6 @@ def encodeBase58(num, alphabet=ALPHABET):
     base = len(alphabet)
     while num:
         rem = num % base
-        # print 'num is:', num
         num = num // base
         arr.append(alphabet[rem])
     arr.reverse()
@@ -37,9 +35,9 @@ def encodeBase58(num, alphabet=ALPHABET):
 def decodeBase58(string, alphabet=ALPHABET):
     """Decode a Base X encoded string into the number
 
-    Arguments:
-    - `string`: The encoded string
-    - `alphabet`: The alphabet to use for encoding
+    Args:
+      string: The encoded string
+      alphabet: The alphabet to use for encoding
     """
     base = len(alphabet)
     num = 0

--- a/src/highlevelcrypto.py
+++ b/src/highlevelcrypto.py
@@ -1,6 +1,10 @@
 """
-src/highlevelcrypto.py
-======================
+High level cryptographic functions based on `.pyelliptic` OpenSSL bindings.
+
+.. note::
+  Upstream pyelliptic was upgraded from SHA1 to SHA256 for signing.
+  We must upgrade PyBitmessage gracefully.
+  `More discussion. <https://github.com/yann2192/pyelliptic/issues/32>`_
 """
 
 from binascii import hexlify
@@ -12,12 +16,13 @@ from pyelliptic import arithmetic as a
 
 
 def makeCryptor(privkey):
-    """Return a private pyelliptic.ECC() instance"""
+    """Return a private `.pyelliptic.ECC` instance"""
     private_key = a.changebase(privkey, 16, 256, minlen=32)
     public_key = pointMult(private_key)
     privkey_bin = '\x02\xca\x00\x20' + private_key
     pubkey_bin = '\x02\xca\x00\x20' + public_key[1:-32] + '\x00\x20' + public_key[-32:]
-    cryptor = pyelliptic.ECC(curve='secp256k1', privkey=privkey_bin, pubkey=pubkey_bin)
+    cryptor = pyelliptic.ECC(
+        curve='secp256k1', privkey=privkey_bin, pubkey=pubkey_bin)
     return cryptor
 
 
@@ -29,7 +34,7 @@ def hexToPubkey(pubkey):
 
 
 def makePubCryptor(pubkey):
-    """Return a public pyelliptic.ECC() instance"""
+    """Return a public `.pyelliptic.ECC` instance"""
     pubkey_bin = hexToPubkey(pubkey)
     return pyelliptic.ECC(curve='secp256k1', pubkey=pubkey_bin)
 
@@ -43,7 +48,8 @@ def privToPub(privkey):
 
 def encrypt(msg, hexPubkey):
     """Encrypts message with hex public key"""
-    return pyelliptic.ECC(curve='secp256k1').encrypt(msg, hexToPubkey(hexPubkey))
+    return pyelliptic.ECC(curve='secp256k1').encrypt(
+        msg, hexToPubkey(hexPubkey))
 
 
 def decrypt(msg, hexPrivkey):
@@ -52,36 +58,38 @@ def decrypt(msg, hexPrivkey):
 
 
 def decryptFast(msg, cryptor):
-    """Decrypts message with an existing pyelliptic.ECC.ECC object"""
+    """Decrypts message with an existing `.pyelliptic.ECC` object"""
     return cryptor.decrypt(msg)
 
 
 def sign(msg, hexPrivkey):
-    """Signs with hex private key"""
-    # pyelliptic is upgrading from SHA1 to SHA256 for signing. We must
-    # upgrade PyBitmessage gracefully.
-    # https://github.com/yann2192/pyelliptic/pull/33
-    # More discussion: https://github.com/yann2192/pyelliptic/issues/32
-    digestAlg = BMConfigParser().safeGet('bitmessagesettings', 'digestalg', 'sha1')
+    """
+    Signs with hex private key using SHA1 or SHA256 depending on
+    "digestalg" setting
+    """
+    digestAlg = BMConfigParser().safeGet(
+        'bitmessagesettings', 'digestalg', 'sha1')
     if digestAlg == "sha1":
         # SHA1, this will eventually be deprecated
-        return makeCryptor(hexPrivkey).sign(msg, digest_alg=OpenSSL.digest_ecdsa_sha1)
+        return makeCryptor(hexPrivkey).sign(
+            msg, digest_alg=OpenSSL.digest_ecdsa_sha1)
     elif digestAlg == "sha256":
         # SHA256. Eventually this will become the default
         return makeCryptor(hexPrivkey).sign(msg, digest_alg=OpenSSL.EVP_sha256)
     else:
-        raise ValueError("Unknown digest algorithm %s" % (digestAlg))
+        raise ValueError("Unknown digest algorithm %s" % digestAlg)
 
 
 def verify(msg, sig, hexPubkey):
-    """Verifies with hex public key"""
+    """Verifies with hex public key using SHA1 or SHA256"""
     # As mentioned above, we must upgrade gracefully to use SHA256. So
     # let us check the signature using both SHA1 and SHA256 and if one
     # of them passes then we will be satisfied. Eventually this can
     # be simplified and we'll only check with SHA256.
     try:
         # old SHA1 algorithm.
-        sigVerifyPassed = makePubCryptor(hexPubkey).verify(sig, msg, digest_alg=OpenSSL.digest_ecdsa_sha1)
+        sigVerifyPassed = makePubCryptor(hexPubkey).verify(
+            sig, msg, digest_alg=OpenSSL.digest_ecdsa_sha1)
     except:
         sigVerifyPassed = False
     if sigVerifyPassed:
@@ -89,7 +97,8 @@ def verify(msg, sig, hexPubkey):
         return True
     # The signature check using SHA1 failed. Let us try it with SHA256.
     try:
-        return makePubCryptor(hexPubkey).verify(sig, msg, digest_alg=OpenSSL.EVP_sha256)
+        return makePubCryptor(hexPubkey).verify(
+            sig, msg, digest_alg=OpenSSL.EVP_sha256)
     except:
         return False
 
@@ -106,7 +115,8 @@ def pointMult(secret):
     """
     while True:
         try:
-            k = OpenSSL.EC_KEY_new_by_curve_name(OpenSSL.get_curve('secp256k1'))
+            k = OpenSSL.EC_KEY_new_by_curve_name(
+                OpenSSL.get_curve('secp256k1'))
             priv_key = OpenSSL.BN_bin2bn(secret, 32, None)
             group = OpenSSL.EC_KEY_get0_group(k)
             pub_key = OpenSSL.EC_POINT_new(group)

--- a/src/shared.py
+++ b/src/shared.py
@@ -80,7 +80,9 @@ def isAddressInMySubscriptionsList(address):
 
 
 def isAddressInMyAddressBookSubscriptionsListOrWhitelist(address):
-    """Am I subscribed to this address, is it in my addressbook or whitelist?"""
+    """
+    Am I subscribed to this address, is it in my addressbook or whitelist?
+    """
     if isAddressInMyAddressBook(address):
         return True
 
@@ -100,8 +102,12 @@ def isAddressInMyAddressBookSubscriptionsListOrWhitelist(address):
     return False
 
 
-def decodeWalletImportFormat(WIFstring):    # pylint: disable=inconsistent-return-statements
-    """Convert private key from base58 that's used in the config file to 8-bit binary string"""
+def decodeWalletImportFormat(WIFstring):
+    # pylint: disable=inconsistent-return-statements
+    """
+    Convert private key from base58 that's used in the config file to
+    8-bit binary string
+    """
     fullString = arithmetic.changebase(WIFstring, 58, 256)
     privkey = fullString[:-4]
     if fullString[-4:] != \
@@ -126,14 +132,15 @@ def decodeWalletImportFormat(WIFstring):    # pylint: disable=inconsistent-retur
 
 
 def reloadMyAddressHashes():
-    """Reinitialise runtime data (e.g. encryption objects, address hashes) from the config file"""
+    """Reload keys for user's addresses from the config file"""
     logger.debug('reloading keys from keys.dat file')
     myECCryptorObjects.clear()
     myAddressesByHash.clear()
     myAddressesByTag.clear()
     # myPrivateKeys.clear()
 
-    keyfileSecure = checkSensitiveFilePermissions(state.appdata + 'keys.dat')
+    keyfileSecure = checkSensitiveFilePermissions(os.path.join(
+        state.appdata, 'keys.dat'))
     hasEnabledKeys = False
     for addressInKeysFile in BMConfigParser().addresses():
         isEnabled = BMConfigParser().getboolean(addressInKeysFile, 'enabled')
@@ -162,11 +169,15 @@ def reloadMyAddressHashes():
                 )
 
     if not keyfileSecure:
-        fixSensitiveFilePermissions(state.appdata + 'keys.dat', hasEnabledKeys)
+        fixSensitiveFilePermissions(os.path.join(
+            state.appdata, 'keys.dat'), hasEnabledKeys)
 
 
 def reloadBroadcastSendersForWhichImWatching():
-    """Reinitialise runtime data for the broadcasts I'm subscribed to from the config file"""
+    """
+    Reinitialize runtime data for the broadcasts I'm subscribed to
+    from the config file
+    """
     broadcastSendersForWhichImWatching.clear()
     MyECSubscriptionCryptorObjects.clear()
     queryreturn = sqlQuery('SELECT address FROM subscriptions where enabled=1')

--- a/src/shutdown.py
+++ b/src/shutdown.py
@@ -16,7 +16,9 @@ from queues import (
 
 
 def doCleanShutdown():
-    """Used to tell proof of work worker threads and the objectProcessorThread to exit."""
+    """
+    Used to tell all the treads to finish work and exit.
+    """
     state.shutdown = 1
 
     objectProcessorQueue.put(('checkShutdownVariable', 'no data'))
@@ -52,9 +54,11 @@ def doCleanShutdown():
     time.sleep(.25)
 
     for thread in threading.enumerate():
-        if (thread is not threading.currentThread() and
-                isinstance(thread, StoppableThread) and
-                thread.name != 'SQL'):
+        if (
+            thread is not threading.currentThread()
+            and isinstance(thread, StoppableThread)
+            and thread.name != 'SQL'
+        ):
             logger.debug("Waiting for thread %s", thread.name)
             thread.join()
 

--- a/src/state.py
+++ b/src/state.py
@@ -16,8 +16,8 @@ appdata = ''
 
 shutdown = 0
 """
-    Set to 1 by the doCleanShutdown function.
-    Used to tell the proof of work worker threads to exit.
+Set to 1 by the `.shutdown.doCleanShutdown` function.
+Used to tell the threads to exit.
 """
 
 # Component control flags - set on startup, do not change during runtime
@@ -25,7 +25,7 @@ shutdown = 0
 enableNetwork = True
 """enable network threads"""
 enableObjProc = True
-"""enable object processing threads"""
+"""enable object processing thread"""
 enableAPI = True
 """enable API (if configured)"""
 enableGUI = True
@@ -35,7 +35,7 @@ enableSTDIO = False
 curses = False
 
 sqlReady = False
-"""set to true by sqlTread when ready for processing"""
+"""set to true by `.threads.sqlThread` when ready for processing"""
 
 maximumNumberOfHalfOpenConnections = 0
 


### PR DESCRIPTION
Hello.

I reformatted for PEP8 modules `addresses`, `highlevelcrypto`, `protocol`, `shared`, `shutdown`, `state` and edited the docstrings.

There is also `.readthedocs.yml` which should finally help rftd to make proper documentation because it seems that you are not going to edit the Advanced Settings. I removed my Advanced Settings except for ''Default Branch" and there is the result: https://pybitmessage-test.readthedocs.io/en/latest/ (same blank pages with module names). In the opposite there is the documentation for the "doc" branch: https://pybitmessage-test.readthedocs.io/en/doc/index.html (with content collected from docstrings).