### PR TITLE
Fix sendOnionPeerObj() broken in 9923e97

### DIFF
--- a/src/class_singleWorker.py
+++ b/src/class_singleWorker.py
@@ -467,8 +467,8 @@ class singleWorker(StoppableThread):
     def sendOnionPeerObj(self, peer=None):
         """Send onionpeer object representing peer"""
         if not peer:  # find own onionhostname
-            for peer_ in state.ownAddresses:
-                if peer_.host.endswith('.onion'):
+            for peer in state.ownAddresses:
+                if peer.host.endswith('.onion'):
                     break
             else:
                 return


### PR DESCRIPTION
Hello!

The onionpeer objects are not sent to the network since 9923e97. I reverted it back.
