### PR TITLE
Don't upload addresses as they appear

### DIFF
--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -31,7 +31,7 @@ from network.dandelion import Dandelion
 from network.proxy import ProxyError
 from node import Node, Peer
 from objectracker import ObjectTracker, missingObjects
-from queues import addrQueue, invQueue, objectProcessorQueue, portCheckerQueue
+from queues import invQueue, objectProcessorQueue, portCheckerQueue
 from randomtrackingdict import RandomTrackingDict
 
 logger = logging.getLogger('default')
@@ -466,8 +466,9 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
                             }
                     # since we don't track peers outside of knownnodes,
                     # only spread if in knownnodes to prevent flood
-                    addrQueue.put((stream, peer, seenTime,
-                                   self.destination))
+                    # DISABLED TO WORKAROUND FLOOD/LEAK
+                    # addrQueue.put((stream, peer, seenTime,
+                    #               self.destination))
         return True
 
     def bm_command_portcheck(self):


### PR DESCRIPTION
- attempt to fix #1598
- seems to work
- addresses won't be uploaded/announced anymore other than after connecting, Later I need to find out how to announce them without causing problems, but for the time disabling this seems an acceptable drawback