### PR TITLE
flatpak-builder support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/flatpak/shared-modules"]
+	path = packages/flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,7 +113,7 @@ Once you have `flatpak` and `flatpak-builder` installed:
 git clone git://github.com/Bitmessage/PyBitmessage.git
 cd PyBitmessage/
 git submodule add https://github.com/flathub/shared-modules.git
-flatpak-builder --install build/_flatpak -install-deps-from=flathub --force-clean --user org.bitmessage.PyBitmessage.json
+flatpak-builder --install -install-deps-from=flathub --force-clean --user build/_flatpak org.bitmessage.PyBitmessage.json
 ```
 This will install PyBitmessage to your local flatpak user repository, but it 
 takes a while to compile because QT4 and PyQt4 have to be build, among others.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -103,26 +103,7 @@ slack.sh - create a package for Slackware
 ```
 
 #### Linux flatpak
-First make sure you have `flatpak` and `flatpak-builder` installed. Follow the
-instructions for your distribution on [flathub](https://flatpak.org/setup/). The
-instructions there only cover the installation of `flatpak`, but 
-`flatpak-builder` should be the same.
-
-Once you have `flatpak` and `flatpak-builder` installed:
-```
-git clone git://github.com/Bitmessage/PyBitmessage.git
-cd PyBitmessage/
-git submodule add https://github.com/flathub/shared-modules.git
-flatpak-builder --install --user -install-deps-from=flathub --force-clean --state-dir=build/.flatpak-builder build/_flatpak org.bitmessage.PyBitmessage.json
-```
-This will install PyBitmessage to your local flatpak user repository, but it 
-takes a while to compile because QT4 and PyQt4 have to be build, among others.
-
-When done you can launch PyBitmessage via:
-`flatpak run -v org.bitmessage.PyBitmessage`
-
-If you want to free up disk space you can remove the `Sdk` runtime again:
-`flatpak uninstall org.freedesktop.Sdk//18.08`
+See [packages/flatpak/README.md](packages/flatpak/README.md)
 
 #### OS X
 Please refer to

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,7 +113,7 @@ Once you have `flatpak` and `flatpak-builder` installed:
 git clone git://github.com/Bitmessage/PyBitmessage.git
 cd PyBitmessage/
 git submodule add https://github.com/flathub/shared-modules.git
-flatpak-builder --install -install-deps-from=flathub --force-clean --user build/_flatpak org.bitmessage.PyBitmessage.json
+flatpak-builder --install --user -install-deps-from=flathub --force-clean --state-dir=build/.flatpak-builder build/_flatpak org.bitmessage.PyBitmessage.json
 ```
 This will install PyBitmessage to your local flatpak user repository, but it 
 takes a while to compile because QT4 and PyQt4 have to be build, among others.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -112,6 +112,7 @@ Once you have `flatpak` and `flatpak-builder` installed:
 ```
 git clone git://github.com/Bitmessage/PyBitmessage.git
 cd PyBitmessage/
+git submodule add https://github.com/flathub/shared-modules.git
 flatpak-builder --install _flatpak -install-deps-from=flathub --force-clean --user org.bitmessage.PyBitmessage.json
 ```
 This will install PyBitmessage to your local flatpak user repository, but it 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,6 +40,11 @@ python bitmessagemain.py
 Voilà! Bitmessage is updated!
 
 #### Linux
+_Some recent Linux distributions don't support QT4 anymore, hence PyBitmessage
+won't run with a GUI. However, if you build PyBitmessage as a flatpak, it will
+run in a sandbox which provides QT4. See the **Linux flatpak** instructions 
+in the **Creating a package for installation** section of this document._
+
 To run PyBitmessage from the command-line, you must download the source, then
 run `src/bitmessagemain.py`.
 ```
@@ -96,6 +101,27 @@ puppy.sh - create a package for Puppy Linux
 rpm.sh - create a RPM package
 slack.sh - create a package for Slackware
 ```
+
+#### Linux flatpak
+First make sure you have `flatpak` and `flatpak-builder` installed. Follow the
+instructions for your distribution on [flathub](https://flatpak.org/setup/). The
+instructions there only cover the installation of `flatpak`, but 
+`flatpak-builder` should be the same.
+
+Once you have `flatpak` and `flatpak-builder` installed:
+```
+git clone git://github.com/Bitmessage/PyBitmessage.git
+cd PyBitmessage/
+flatpak-builder --install _flatpak -install-deps-from=flathub --force-clean --user org.bitmessage.PyBitmessage.json
+```
+This will install PyBitmessage to your local flatpak user repository, but it 
+takes a while to compile because QT4 and PyQt4 have to be build, among others.
+
+When done you can launch PyBitmessage via:
+`flatpak run -v org.bitmessage.PyBitmessage`
+
+If you want to free up disk space you can remove the `Sdk` runtime again:
+`flatpak uninstall org.freedesktop.Sdk//18.08`
 
 #### OS X
 Please refer to

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,7 +113,7 @@ Once you have `flatpak` and `flatpak-builder` installed:
 git clone git://github.com/Bitmessage/PyBitmessage.git
 cd PyBitmessage/
 git submodule add https://github.com/flathub/shared-modules.git
-flatpak-builder --install _flatpak -install-deps-from=flathub --force-clean --user org.bitmessage.PyBitmessage.json
+flatpak-builder --install build/_flatpak -install-deps-from=flathub --force-clean --user org.bitmessage.PyBitmessage.json
 ```
 This will install PyBitmessage to your local flatpak user repository, but it 
 takes a while to compile because QT4 and PyQt4 have to be build, among others.

--- a/org.bitmessage.PyBitmessage.json
+++ b/org.bitmessage.PyBitmessage.json
@@ -1,0 +1,89 @@
+{
+  "app-id": "org.bitmessage.PyBitmessage",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "18.08",
+  "sdk": "org.freedesktop.Sdk",
+  "command": "pybitmessage",
+  "finish-args" : [
+    "--share=network",
+    "--socket=x11",
+    "--share=ipc",
+    "--filesystem=xdg-config/PyBitmessage:create"
+  ],
+  "modules": [
+    "shared-modules/python2.7/python-2.7.json",
+    "shared-modules/qt4/qt4-4.8.7-minimal.json",
+    {
+      "name": "python-sip",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.22/sip-4.19.22.tar.gz",
+          "sha256": "e1b768824ec1a2ee38dd536b6b6b3d06de27b00a2f5f55470d1b512306e3be45"
+        }
+      ],
+      "buildsystem": "simple",
+      "build-commands": [
+        "python configure.py --sip-module PyQt4.sip --no-dist-info",
+        "make",
+        "make install"
+      ]
+    },
+    {
+      "name": "python-qt4",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.12.3/PyQt4_gpl_x11-4.12.3.tar.gz",
+          "sha256": "a00f5abef240a7b5852b7924fa5fdf5174569525dc076cd368a566619e56d472"
+        }
+      ],
+      "buildsystem": "simple",
+      "build-commands": [
+        "python configure.py -w --confirm-license",
+        "make",
+        "make install"
+      ]
+    },
+    {
+      "name" : "PyBitmessage-dependencies",
+      "buildsystem" : "simple",
+      "build-options": {
+        "build-args": [
+          "--share=network"
+        ]
+      },
+      "build-commands": [
+        "pip --version",
+        "pip install setuptools msgpack"
+      ]
+    },
+    {
+      "name" : "PyBitmessage",
+      "buildsystem" : "simple",
+      "build-options": {
+        "build-args": [
+          "--share=network"
+        ]
+      },
+      "build-commands": [
+        "python --version",
+        "python checkdeps.py",
+        "python setup.py install --prefix=/app --exec-prefix=/app",
+        "sed -i 's~/usr/bin/~/app/bin/~' /app/bin/pybitmessage",
+        "cat /app/bin/pybitmessage",
+        "mv /app/share/applications/pybitmessage.desktop /app/share/applications/org.bitmessage.PyBitmessage.desktop",
+        "sed -i 's~Icon=pybitmessage~Icon=org.bitmessage.PyBitmessage~' /app/share/applications/org.bitmessage.PyBitmessage.desktop",
+        "mv /app/share/icons/hicolor/scalable/apps/pybitmessage.svg /app/share/icons/hicolor/scalable/apps/org.bitmessage.PyBitmessage.svg",
+        "mv /app/share/icons/hicolor/24x24/apps/pybitmessage.png /app/share/icons/hicolor/24x24/apps/org.bitmessage.PyBitmessage.png",
+        "which pybitmessage"
+      ],
+      "sources" : [
+        {
+          "type" : "dir",
+          "path" : "."
+        }
+      ]
+    }
+  ]
+}

--- a/packages/flatpak/README.md
+++ b/packages/flatpak/README.md
@@ -1,0 +1,68 @@
+# PyBitmessage Linux flatpak instructions
+_Some recent Linux distributions don't support QT4 anymore, hence PyBitmessage
+won't run with a GUI. However, if you build PyBitmessage as a flatpak, it will
+run in a sandbox which provides QT4.__
+
+## Requirements
+First make sure you have `flatpak` and `flatpak-builder` installed. Follow the
+instructions for your distribution on [flathub](https://flatpak.org/setup/). The
+instructions there only cover the installation of `flatpak`, but 
+`flatpak-builder` should be the same.
+
+## Build and Install
+Once you have `flatpak` and `flatpak-builder` installed:
+```
+git clone git://github.com/Bitmessage/PyBitmessage.git
+cd PyBitmessage/
+git submodule add https://github.com/flathub/shared-modules.git
+flatpak-builder --install --user -install-deps-from=flathub --force-clean --state-dir=build/.flatpak-builder build/_flatpak org.bitmessage.PyBitmessage.json
+```
+This will install PyBitmessage to your local flatpak user repository, but it 
+takes a while to compile because QT4 and PyQt4 have to be build, among others.
+
+# Run
+When installation is done you can launch PyBitmessage via the **command line**:
+`flatpak run -v org.bitmessage.PyBitmessage`
+
+Flatpak also exports a `.desktop` file, so you should be able to find and launch
+PyBitmessage via the **application launcher** of your Desktop (Gnome, KDE, ...).
+
+# Export
+You can create a single file "bundle", which allows you to copy and install the
+PyBitmessage flatpak on other devices of the same architecture as the build machine.
+
+## Create a local flatpak repository
+```
+flatpak-builder --repo=build/_flatpak_repo --force-clean --state-dir=build/.flatpak-builder build/_flatpak packages/flatpak/org.bitmessage.PyBitmessage.json
+```
+This will create a local flatpak repository in `build/_flatpak_repo/`.
+
+## Create a bundle
+```
+flatpak build-bundle build/_flatpak_repo build/pybitmessage.flatpak org.bitmessage.PyBitmessage
+```
+This will create a `pybitmessage.flatpak` bundle file in the `build/` directory. 
+
+This bundle can be copied to other systems or installed locally:
+```
+flatpak install pybitmessage.flatpak
+```
+
+The application can be run using flatpak:
+```
+flatpak run org.bitmessage.PyBitmessage
+```
+
+It can then be uninstalled with this command:
+```
+flatpak uninstall org.bitmessage.PyBitmessage
+```
+
+This way of building an application is very convenient when preparing flatpaks
+for testing on another system of the same processor architecture.
+
+## Cleanup
+If you want to free up disk space you can remove the `Sdk` runtime again:
+`flatpak uninstall org.freedesktop.Sdk//18.08`
+
+You can also delete the `build` directory again.

--- a/packages/flatpak/README.md
+++ b/packages/flatpak/README.md
@@ -14,7 +14,7 @@ Once you have `flatpak` and `flatpak-builder` installed:
 ```
 git clone git://github.com/Bitmessage/PyBitmessage.git
 cd PyBitmessage/
-git submodule add https://github.com/flathub/shared-modules.git
+git submodule update --init --recursive
 flatpak-builder --install --user -install-deps-from=flathub --force-clean --state-dir=build/.flatpak-builder build/_flatpak org.bitmessage.PyBitmessage.json
 ```
 This will install PyBitmessage to your local flatpak user repository, but it 

--- a/packages/flatpak/org.bitmessage.PyBitmessage.json
+++ b/packages/flatpak/org.bitmessage.PyBitmessage.json
@@ -81,7 +81,7 @@
       "sources" : [
         {
           "type" : "dir",
-          "path" : "."
+          "path" : "../../"
         }
       ]
     }


### PR DESCRIPTION
Recent distributions like `Debian bullseye` don't support QT4 anymore. This pull request provides a `flatpak-builder` configuration and instructions how to package PyBitmessage as a flatpak application which bundles QT4.

This pull request is also a necessary requirement for https://github.com/Bitmessage/PyBitmessage/issues/1607

