### PR TITLE
Wine build fixes and version changes

### DIFF
--- a/packages/pyinstaller/bitmessagemain.spec
+++ b/packages/pyinstaller/bitmessagemain.spec
@@ -77,6 +77,7 @@ a.datas += addUIs()
 
 
 a.binaries += [('libeay32.dll', os.path.join(openSSLPath, 'libeay32.dll'), 'BINARY'),
+         ('msvcr120.dll', os.path.join(msvcrDllPath, 'msvcr120.dll'), 'BINARY'),
          ('python27.dll', os.path.join(pythonDllPath, 'python27.dll'), 'BINARY'),
          (os.path.join('bitmsghash', 'bitmsghash%i.dll' % (arch)), os.path.join(srcPath, 'bitmsghash', 'bitmsghash%i.dll' % (arch)), 'BINARY'),
          (os.path.join('bitmsghash', 'bitmsghash.cl'), os.path.join(srcPath, 'bitmsghash', 'bitmsghash.cl'), 'BINARY'),


### PR DESCRIPTION
- bump OpenSSL to 1.0.2u and remove the old one that is included in PyQt
- add msvcr120.dll (needed by the new OpenSSL)
- bump python to 2.7.18
- change OpenSSL download source to upstream
- downgrade PyInstaller for 64bit (was causing problems)