### PR TITLE
Fix for another unicode bug from #1633

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ addons:
     packages:
       - build-essential
       - libcap-dev
+      - python-qt4
       - tor
+      - xvfb
 install:
   - pip install -r requirements.txt
   - ln -s src pybitmessage  # tests environment
   - python setup.py install
 script:
   - python checkdeps.py
-  - src/bitmessagemain.py -t
+  - xvfb-run src/bitmessagemain.py -t
   - python setup.py test

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -363,11 +363,12 @@ class Main(object):
             while state.shutdown == 0:
                 time.sleep(1)
                 if (
-                    state.testmode and time.time() -
-                    state.last_api_response >= 30
+                    state.testmode
+                    and time.time() - state.last_api_response >= 30
                 ):
                     self.stop()
         elif not state.enableGUI:
+            state.enableGUI = True
             # pylint: disable=relative-import
             from tests import core as test_core
             test_core_result = test_core.run()

--- a/src/bitmessageqt/support.py
+++ b/src/bitmessageqt/support.py
@@ -88,7 +88,7 @@ def createAddressIfNeeded(myapp):
     if not checkHasNormalAddress():
         queues.addressGeneratorQueue.put((
             'createRandomAddress', 4, 1,
-            SUPPORT_MY_LABEL.toUtf8(),
+            str(SUPPORT_MY_LABEL.toUtf8()),
             1, "", False,
             defaults.networkDefaultProofOfWorkNonceTrialsPerByte,
             defaults.networkDefaultPayloadLengthExtraBytes

--- a/src/bitmessageqt/tests/__init__.py
+++ b/src/bitmessageqt/tests/__init__.py
@@ -1,0 +1,6 @@
+"""bitmessageqt tests"""
+
+from main import TestMain
+from support import TestSupport
+
+__all__ = ["TestMain", "TestSupport"]

--- a/src/bitmessageqt/tests/main.py
+++ b/src/bitmessageqt/tests/main.py
@@ -1,0 +1,30 @@
+"""Common definitions for bitmessageqt tests"""
+
+import unittest
+
+from PyQt4 import QtCore, QtGui
+
+import bitmessageqt
+from tr import _translate
+
+
+class TestBase(unittest.TestCase):
+    """Base class for bitmessageqt test case"""
+
+    def setUp(self):
+        self.app = QtGui.QApplication([])
+        self.window = bitmessageqt.MyForm()
+
+    def tearDown(self):
+        self.app.deleteLater()
+
+
+class TestMain(unittest.TestCase):
+    """Test case for main window - basic features"""
+
+    def test_translate(self):
+        """Check the results of _translate() with various args"""
+        self.assertIsInstance(
+            _translate("MainWindow", "Test"),
+            QtCore.QString
+        )

--- a/src/bitmessageqt/tests/support.py
+++ b/src/bitmessageqt/tests/support.py
@@ -1,0 +1,33 @@
+# from PyQt4 import QtTest
+
+import sys
+
+from shared import isAddressInMyAddressBook
+
+from main import TestBase
+
+
+class TestSupport(TestBase):
+    """A test case for support module"""
+    SUPPORT_ADDRESS = 'BM-2cUdgkDDAahwPAU6oD2A7DnjqZz3hgY832'
+    SUPPORT_SUBJECT = 'Support request'
+
+    def test(self):
+        """trigger menu action "Contact Support" and check the result"""
+        ui = self.window.ui
+        self.assertEqual(ui.lineEditTo.text(), '')
+        self.assertEqual(ui.lineEditSubject.text(), '')
+
+        ui.actionSupport.trigger()
+
+        self.assertTrue(
+            isAddressInMyAddressBook(self.SUPPORT_ADDRESS))
+
+        self.assertEqual(
+            ui.tabWidget.currentIndex(), ui.tabWidget.indexOf(ui.send))
+        self.assertEqual(
+            ui.lineEditTo.text(), self.SUPPORT_ADDRESS)
+        self.assertEqual(
+            ui.lineEditSubject.text(), self.SUPPORT_SUBJECT)
+        self.assertIn(
+            sys.version, ui.textEditMessage.toPlainText())

--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     stem_version = None
 
-
 knownnodes_file = os.path.join(state.appdata, 'knownnodes.dat')
 
 
@@ -245,7 +244,14 @@ class TestCore(unittest.TestCase):
 
 def run():
     """Starts all tests defined in this module"""
-    loader = unittest.TestLoader()
+    loader = unittest.defaultTestLoader
     loader.sortTestMethodsUsing = None
     suite = loader.loadTestsFromTestCase(TestCore)
+    try:
+        import bitmessageqt.tests
+    except ImportError:
+        pass
+    else:
+        qt_tests = loader.loadTestsFromModule(bitmessageqt.tests)
+        suite.addTests(qt_tests)
     return unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Hello!

Here is a quick fix for current unicode bug in the "Settings" dialog and a minimal test which barely reproduces the issue: https://travis-ci.org/github/g1itch/PyBitmessage/builds/696495365.

To reproduce properly I should rewrite `class_addressGenerator` to put any exception into `excQueue`.
