### PR TITLE
Wrong arguments order in bitmessageqt.MyForm.updateStatusBar()

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -4099,7 +4099,7 @@ class MyForm(settingsmixin.SMainWindow):
 
     def updateStatusBar(self, data):
         try:
-            option, message = data
+            message, option = data
         except ValueError:
             option = 0
             message = data

--- a/src/bitmessageqt/tests/__init__.py
+++ b/src/bitmessageqt/tests/__init__.py
@@ -1,6 +1,6 @@
 """bitmessageqt tests"""
 
-from main import TestMain
+from main import TestMain, TestUISignaler
 from support import TestSupport
 
-__all__ = ["TestMain", "TestSupport"]
+__all__ = ["TestMain", "TestSupport", "TestUISignaler"]

--- a/src/bitmessageqt/tests/main.py
+++ b/src/bitmessageqt/tests/main.py
@@ -1,10 +1,13 @@
 """Common definitions for bitmessageqt tests"""
 
+import Queue
+import sys
 import unittest
 
 from PyQt4 import QtCore, QtGui
 
 import bitmessageqt
+import queues
 from tr import _translate
 
 
@@ -12,11 +15,23 @@ class TestBase(unittest.TestCase):
     """Base class for bitmessageqt test case"""
 
     def setUp(self):
-        self.app = QtGui.QApplication([])
-        self.window = bitmessageqt.MyForm()
+        self.app = (
+            QtGui.QApplication.instance()
+            or bitmessageqt.BitmessageQtApplication(sys.argv))
+        self.window = self.app.activeWindow()
+        if not self.window:
+            self.window = bitmessageqt.MyForm()
+            self.window.appIndicatorInit(self.app)
 
     def tearDown(self):
-        self.app.deleteLater()
+        # self.app.deleteLater()
+        while True:
+            try:
+                thread, exc = queues.excQueue.get(block=False)
+            except Queue.Empty:
+                return
+            if thread == 'tests':
+                self.fail('Exception in the main thread: %s' % exc)
 
 
 class TestMain(unittest.TestCase):
@@ -28,3 +43,18 @@ class TestMain(unittest.TestCase):
             _translate("MainWindow", "Test"),
             QtCore.QString
         )
+
+
+class TestUISignaler(TestBase):
+    """Test case for UISignalQueue"""
+
+    def test_updateStatusBar(self):
+        """Check arguments order of updateStatusBar command"""
+        queues.UISignalQueue.put((
+            'updateStatusBar', (
+                _translate("test", "Testing updateStatusBar..."), 1)
+        ))
+
+        QtCore.QTimer.singleShot(60, self.app.quit)
+        self.app.exec_()
+        # self.app.processEvents(QtCore.QEventLoop.AllEvents, 60)

--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -8,6 +8,7 @@ import pickle  # nosec
 import Queue
 import random  # nosec
 import string
+import sys
 import time
 import unittest
 
@@ -250,4 +251,11 @@ def run():
     else:
         qt_tests = loader.loadTestsFromModule(bitmessageqt.tests)
         suite.addTests(qt_tests)
+
+    def keep_exc(ex_cls, exc, tb):  # pylint: disable=unused-argument
+        """Own exception hook for test cases"""
+        excQueue.put(('tests', exc))
+
+    sys.excepthook = keep_exc
+
     return unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Hello!

I found that `proofofwork.notifyBuild()` puts arguments into `UISignalQueue` in the wrong order. I added a pseudo test so you can see error message, but to write a proper test I need some special technique, maybe involving `excQueue`.