### PR TITLE
fixed socket error on sendato

### DIFF
--- a/src/network/udp.py
+++ b/src/network/udp.py
@@ -145,8 +145,5 @@ class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
                 self.write_buf, ('<broadcast>', self.port))
         except socket.error as e:
             logger.error("socket error on sendto: %s", e)
-            if e.errno == 101:
-                self.announcing = False
-                self.socket.close()
-            retval = 0
+            retval = len(self.write_buf)
         self.slice_write_buf(retval)


### PR DESCRIPTION
here when the internet connection is disconnected then the socket connection starts giving an exception so in the previous code socket was closed when socket.error produces but it creates an issue because when the user again connects with the internet then it is not connecting with sockets so it causes and issues so I have commented socket close line then it starts working fine.