### PR TITLE
Fix backward compatibility in pickle_deserialize_old_knownnodes()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,12 @@ addons:
       - xvfb
 install:
   - pip install -r requirements.txt
-  - ln -s src pybitmessage  # tests environment
   - python setup.py install
 script:
   - python checkdeps.py
+  - git clone -b v0.6.3 https://github.com/Bitmessage/PyBitmessage.git old;
+    cd old; src/bitmessagemain.py -d; sleep 10; cd ..;
+    kill -QUIT $(ps ax | grep bitmessagemain | cut -d ' ' -f 2);
+    sleep 10;
   - xvfb-run src/bitmessagemain.py -t
   - python setup.py test

--- a/src/network/knownnodes.py
+++ b/src/network/knownnodes.py
@@ -17,6 +17,9 @@ import state
 from bmconfigparser import BMConfigParser
 from network.node import Peer
 
+
+state.Peer = Peer
+
 knownNodesLock = threading.RLock()
 """Thread lock for knownnodes modification"""
 knownNodes = {stream: {} for stream in range(1, 4)}

--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -231,7 +231,8 @@ class TestCore(unittest.TestCase):
         msg = protocol.assembleVersionMessage('127.0.0.1', 8444, [1])
         decoded = self._decode_msg(msg, "IQQiiQlsLv")
         peer, _, ua, streams = self._decode_msg(msg, "IQQiiQlsLv")[4:]
-        self.assertEqual(peer, Node(3, '127.0.0.1', 8444))
+        self.assertEqual(
+            peer, Node(11 if state.dandelion else 3, '127.0.0.1', 8444))
         self.assertEqual(ua, '/PyBitmessage:' + softwareVersion + '/')
         self.assertEqual(streams, [1])
         # with multiple streams


### PR DESCRIPTION
Hello!

#1662 is caused by changed package structure.

Here I've set up a minimal upgrade from v0.6.3 to reproduce the bug. Using v0.6.2 would be difficult, because it has no command line args.