### PR TITLE
Marked tests known to not work on various platforms

### DIFF
--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -39,6 +39,7 @@ class TestConfig(unittest.TestCase):
             BMConfigParser().safeGetInt('nonexistent', 'nonexistent', 42), 42)
 
 
+@unittest.skipUnless(os.getenv('TRAVIS_DIST') == 'xenial', 'appdata confusion')
 class TestProcessConfig(TestProcessProto):
     """A test case for keys.dat"""
 

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 
 
+@unittest.skipUnless(os.getenv('TRAVIS_DIST') == 'xenial', 'appdata confusion')
 class TestLogger(unittest.TestCase):
     """A test case for bmconfigparser"""
 


### PR DESCRIPTION
Hello!

These changes should fix PyBitmessage-travis-migrate.

`TestProcessConfig` and `TestLogger` work as expected only on Ubuntu Xenial. I marked them for skipping on other platforms.