### PR TITLE
implemented filter query in sent table on the bases of folder= 'sent'

### DIFF
--- a/src/class_singleCleaner.py
+++ b/src/class_singleCleaner.py
@@ -179,7 +179,7 @@ class singleCleaner(StoppableThread):
             'Doing work necessary to again attempt to request a public key...'
         ))
         sqlExecute(
-            '''UPDATE sent SET status='msgqueued' WHERE toaddress=?''',
+            '''UPDATE sent SET status='msgqueued' WHERE toaddress=? AND folder='sent' ''',
             address)
         queues.workerQueue.put(('sendmessage', ''))
 
@@ -190,7 +190,7 @@ class singleCleaner(StoppableThread):
             ' to our msg. Sending again.'
         )
         sqlExecute(
-            '''UPDATE sent SET status='msgqueued' WHERE ackdata=?''',
+            '''UPDATE sent SET status='msgqueued' WHERE ackdata=? AND folder='sent' ''',
             ackdata)
         queues.workerQueue.put(('sendmessage', ''))
         queues.UISignalQueue.put((

--- a/src/class_singleWorker.py
+++ b/src/class_singleWorker.py
@@ -109,7 +109,7 @@ class singleWorker(StoppableThread):
                 newack = '\x00\x00\x00\x02\x01\x01' + oldack
                 state.ackdataForWhichImWatching[newack] = 0
                 sqlExecute(
-                    'UPDATE sent SET ackdata=? WHERE ackdata=? AND folder = "sent" ',
+                    '''UPDATE sent SET ackdata=? WHERE ackdata=? AND folder = 'sent' ''',
                     newack, oldack
                 )
                 del state.ackdataForWhichImWatching[oldack]
@@ -682,8 +682,8 @@ class singleWorker(StoppableThread):
             # Update the status of the message in the 'sent' table to have
             # a 'broadcastsent' status
             sqlExecute(
-                'UPDATE sent SET msgid=?, status=?, lastactiontime=?'
-                ' WHERE ackdata=? AND folder="sent" ',
+                '''UPDATE sent SET msgid=?, status=?, lastactiontime=? '''
+                ''' WHERE ackdata=? AND folder='sent' ''',
                 inventoryHash, 'broadcastsent', int(time.time()), ackdata
             )
 
@@ -1304,6 +1304,7 @@ class singleWorker(StoppableThread):
                 inventoryHash, newStatus, retryNumber + 1,
                 sleepTill, int(time.time()), ackdata
             )
+
             # If we are sending to ourselves or a chan, let's put
             # the message in our own inbox.
             if BMConfigParser().has_section(toaddress):

--- a/src/class_singleWorker.py
+++ b/src/class_singleWorker.py
@@ -557,10 +557,10 @@ class singleWorker(StoppableThread):
                 continue
 
             if not sqlExecute(
-                '''UPDATE sent SET status='doingbroadcastpow' '''
-                ''' WHERE ackdata=? AND status='broadcastqueued' '''
-                ''' AND folder='sent' ''',
-                ackdata):
+                    '''UPDATE sent SET status='doingbroadcastpow' '''
+                    ''' WHERE ackdata=? AND status='broadcastqueued' '''
+                    ''' AND folder='sent' ''',
+                    ackdata):
                 continue
 
             # At this time these pubkeys are 65 bytes long
@@ -1298,7 +1298,7 @@ class singleWorker(StoppableThread):
                 newStatus = 'msgsent'
             # wait 10% past expiration
             sleepTill = int(time.time() + TTL * 1.1)
-            au = sqlExecute(
+            sqlExecute(
                 '''UPDATE sent SET msgid=?, status=?, retrynumber=?, '''
                 ''' sleeptill=?, lastactiontime=? WHERE ackdata=? AND folder='sent' ''',
                 inventoryHash, newStatus, retryNumber + 1,


### PR DESCRIPTION
I have implemented a filter query for the sent table on the bases of folder ='sent' because in  kivy app there is one more feature draft message so for storing draft message they are using the same table sent only the folder value is change on the bases of folder type so I have implemented all the sent table filter query in class_singleWorker.py and class_singleCleaner.py files.