### PR TITLE
Bug found in the new api code reported in chan

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -930,7 +930,7 @@ class BMRPCDispatcher(object):
             except IndexError:
                 pass
         queryreturn = sqlQuery(
-            "SELECT toaddress, fromaddress, subject, received, message,"
+            "SELECT msgid, toaddress, fromaddress, subject, received, message,"
             " encodingtype, read FROM inbox WHERE msgid=?", msgid
         )
         try:


### PR DESCRIPTION
Inconsistent query in HandleGetInboxMessageById():

> The current head of the master branch has a broken API, specifically when calling getInboxMessageById() the following error is produced:
> 
> Unexpected API Failure - _dump_inbox_message() takes exactly 8 arguments (7 given)
> 
> This is the result of the SQL query returning 7 values instead of 8. It is missing the msgid as the first value. See the following line that is the issue:
> 
> https://github.com/Bitmessage/PyBitmessage/blob/380530c839b489fb7dc8f9177d87b47a4c13cd0b/src/api.py#L933
> 
> The following code:
> 
>         queryreturn = sqlQuery(
>             "SELECT toaddress, fromaddress, subject, received, message,"
>             " encodingtype, read FROM inbox WHERE msgid=?", msgid
>         )
> 
> Should be changed to:
> 
>         queryreturn = sqlQuery(
>             "SELECT msgid, toaddress, fromaddress, subject, received, message,"
>             " encodingtype, read FROM inbox WHERE msgid=?", msgid
>         )