### PR TITLE
fixed unread trash message listing issue

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -3151,7 +3151,7 @@ class MyForm(settingsmixin.SMainWindow):
         idCount = len(inventoryHashesToTrash)
         sqlExecuteChunked(
             ("DELETE FROM inbox" if folder == "trash" or shifted else
-             "UPDATE inbox SET folder='trash'") +
+             "UPDATE inbox SET folder='trash', read=1") +
             " WHERE msgid IN ({0})", idCount, *inventoryHashesToTrash)
         tableWidget.selectRow(0 if currentRow == 0 else currentRow - 1)
         tableWidget.setUpdatesEnabled(True)


### PR DESCRIPTION
I have worked on updating the inbox table read value to 1(which means the message is read) so now when the user will move the unread inbox message to the trash message listing then he will not see the unread sign in the trash message listing.because all the message which moves in trash message listing should change the status from unread to read.