### PR TITLE
Fix mistake in TestAPI.test_send_broadcast

### DIFF
--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -279,8 +279,8 @@ class TestAPI(TestAPIProto):
             status = self.api.getStatus(ackdata)
             if status == 'notfound':
                 raise KeyError
-            self.assertIn(
-                status, ('broadcastqueued', 'broadcastsent', 'doingmsgpow'))
+            self.assertIn(status, (
+                'doingbroadcastpow', 'broadcastqueued', 'broadcastsent'))
             # Find the message and its ID in sent
             for m in json.loads(self.api.getAllSentMessages())['sentMessages']:
                 if m['ackData'] == ackdata:


### PR DESCRIPTION
Hello!

Today I found my mistake in statuses tuple in the `test_send_broadcast`: broadcasts have 'doingbroadcastpow' instead of 'doingmsgpow' which I used. Posting quickfix.

See: https://travis-ci.org/github/g1itch/PyBitmessage/jobs/738909198