### PR TITLE
Example rebased branch for broken tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import sys
 
 from setuptools import setup, Extension
 from setuptools.command.install import install
@@ -146,9 +147,9 @@ if __name__ == "__main__":
             'bitmessage.proxyconfig': [
                 'stem = pybitmessage.plugins.proxyconfig_stem [tor]'
             ],
-            # 'console_scripts': [
-            #        'pybitmessage = pybitmessage.bitmessagemain:main'
-            # ]
+            'console_scripts': [
+                'pybitmessage = pybitmessage.bitmessagemain:main'
+            ] if sys.platform[:3] == 'win' else []
         },
         scripts=['src/pybitmessage'],
         cmdclass={'install': InstallCmd},

--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -124,7 +124,16 @@ class BMConfigParser(ConfigParser.SafeConfigParser):
         return [
             x for x in BMConfigParser().sections() if x.startswith('BM-')]
 
+    def _reset(self):
+        """Reset current config. There doesn't appear to be a built in
+           method for this"""
+        sections = self.sections()
+        for x in sections:
+            self.remove_section(x)
+
     def read(self, filenames):
+        """Read config and populate defaults"""
+        self._reset()
         ConfigParser.ConfigParser.read(self, filenames)
         for section in self.sections():
             for option in self.options(section):

--- a/src/tests/common.py
+++ b/src/tests/common.py
@@ -1,0 +1,19 @@
+import os
+
+
+_files = (
+    'keys.dat', 'debug.log', 'messages.dat', 'knownnodes.dat',
+    '.api_started', 'unittest.lock'
+)
+
+
+def cleanup(home=None, files=_files):
+    """Cleanup application files"""
+    if not home:
+        import state
+        home = state.appdata
+    for pfile in files:
+        try:
+            os.remove(os.path.join(home, pfile))
+        except OSError:
+            pass

--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -24,6 +24,8 @@ from network.tcp import Socks4aBMConnection, Socks5BMConnection, TCPConnection
 from queues import excQueue
 from version import softwareVersion
 
+from common import cleanup
+
 try:
     import stem.version as stem_version
 except ImportError:
@@ -46,11 +48,6 @@ def pickle_knownnodes():
             }
             for stream in range(1, 4)  # 3 test streams
         }, dst)
-
-
-def cleanup():
-    """Cleanup application files"""
-    os.remove(knownnodes_file)
 
 
 class TestCore(unittest.TestCase):
@@ -132,7 +129,7 @@ class TestCore(unittest.TestCase):
 
     def test_knownnodes_default(self):
         """test adding default knownnodes if nothing loaded"""
-        cleanup()
+        cleanup(files=('knownnodes.dat',))
         self._wipe_knownnodes()
         knownnodes.readKnownNodes()
         self.assertGreaterEqual(

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -4,6 +4,7 @@ Various tests for config
 
 import os
 import unittest
+import tempfile
 
 from pybitmessage.bmconfigparser import BMConfigParser
 from test_process import TestProcessProto
@@ -41,6 +42,7 @@ class TestConfig(unittest.TestCase):
 
 class TestProcessConfig(TestProcessProto):
     """A test case for keys.dat"""
+    home = tempfile.mkdtemp()
 
     def test_config_defaults(self):
         """Test settings in the generated config"""

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -47,6 +47,7 @@ class TestProcessConfig(TestProcessProto):
     def test_config_defaults(self):
         """Test settings in the generated config"""
         self._stop_process()
+        self._kill_process()
         config = BMConfigParser()
         config.read(os.path.join(self.home, 'keys.dat'))
 

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -28,12 +28,16 @@ class TestProcessProto(unittest.TestCase):
         'keys.dat', 'debug.log', 'messages.dat', 'knownnodes.dat',
         '.api_started', 'unittest.lock'
     )
+    home = None
 
     @classmethod
     def setUpClass(cls):
         """Setup environment and start pybitmessage"""
         cls.flag = False
-        cls.home = os.environ['BITMESSAGE_HOME'] = tempfile.gettempdir()
+        if not cls.home:
+            cls.home = tempfile.gettempdir()
+            cls._cleanup_files()
+        os.environ['BITMESSAGE_HOME'] = cls.home
         put_signal_file(cls.home, 'unittest.lock')
         subprocess.Popen(
             cls._process_cmd,

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -11,6 +11,8 @@ import unittest
 
 import psutil
 
+from common import cleanup
+
 
 def put_signal_file(path, filename):
     """Creates file, presence of which is a signal about some event."""
@@ -73,11 +75,7 @@ class TestProcessProto(unittest.TestCase):
 
     @classmethod
     def _cleanup_files(cls):
-        for pfile in cls._files:
-            try:
-                os.remove(os.path.join(cls.home, pfile))
-            except OSError:
-                pass
+        cleanup(cls.home, cls._files)
 
     @classmethod
     def tearDownClass(cls):

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -5,6 +5,7 @@ Common reusable code for tests and tests for pybitmessage process.
 import os
 import signal
 import subprocess  # nosec
+import sys
 import tempfile
 import time
 import unittest
@@ -25,7 +26,26 @@ class TestProcessProto(unittest.TestCase):
     it starts pybitmessage in setUpClass() and stops it in tearDownClass()
     """
     _process_cmd = ['pybitmessage', '-d']
-    _threads_count = 15
+    _threads_count_min = 15
+    _threads_count_max = 16
+    _threads_names = [
+        'PyBitmessage',
+        'addressGenerato',
+        'singleWorker',
+        'SQL',
+        'objectProcessor',
+        'singleCleaner',
+        'singleAPI',
+        'Asyncore',
+        'ReceiveQueue_0',
+        'ReceiveQueue_1',
+        'ReceiveQueue_2',
+        'Announcer',
+        'InvBroadcaster',
+        'AddrBroadcaster',
+        'Downloader',
+        'Uploader'
+    ]
     _files = (
         'keys.dat', 'debug.log', 'messages.dat', 'knownnodes.dat',
         '.api_started', 'unittest.lock'
@@ -41,15 +61,28 @@ class TestProcessProto(unittest.TestCase):
             cls._cleanup_files()
         os.environ['BITMESSAGE_HOME'] = cls.home
         put_signal_file(cls.home, 'unittest.lock')
+        starttime = int(time.time())
         subprocess.Popen(
             cls._process_cmd,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)  # nosec
-        time.sleep(5)
-        try:
-            cls.pid = int(cls._get_readline('singleton.lock'))
-        except TypeError:
-            cls.flag = True
-            return
+        timeout = starttime + 30
+        while time.time() <= timeout:
+            try:
+                if os.path.exists(os.path.join(cls.home,
+                                               'singleton.lock')):
+                    pstat = os.stat(os.path.join(cls.home, 'singleton.lock'))
+                    if starttime <= pstat.st_mtime and pstat.st_size > 0:
+                        break
+            except OSError:
+                break
+            time.sleep(1)
+        if time.time() >= timeout:
+            raise psutil.TimeoutExpired(
+                "Timeout starting {}".format(cls._process_cmd))
+        # wait a bit for the program to fully start
+        # 10 sec should be enough
+        time.sleep(10)
+        cls.pid = int(cls._get_readline('singleton.lock'))
         cls.process = psutil.Process(cls.pid)
 
     def setUp(self):
@@ -74,6 +107,18 @@ class TestProcessProto(unittest.TestCase):
         return True
 
     @classmethod
+    def _kill_process(cls, timeout=5):
+        try:
+            cls.process.send_signal(signal.SIGKILL)
+            cls.process.wait(timeout)
+        # Windows or already dead
+        except (AttributeError, psutil.NoSuchProcess):
+            return True
+        # except psutil.TimeoutExpired propagates, it means something is very
+        # wrong
+        return True
+
+    @classmethod
     def _cleanup_files(cls):
         cleanup(cls.home, cls._files)
 
@@ -82,7 +127,6 @@ class TestProcessProto(unittest.TestCase):
         """Ensures that pybitmessage stopped and removes files"""
         try:
             if not cls._stop_process():
-                print(open(os.path.join(cls.home, 'debug.log'), 'rb').read())
                 cls.process.kill()
         except (psutil.NoSuchProcess, AttributeError):
             pass
@@ -90,25 +134,49 @@ class TestProcessProto(unittest.TestCase):
             cls._cleanup_files()
 
     def _test_threads(self):
-        # only count for now
-        # because of https://github.com/giampaolo/psutil/issues/613
-        # PyBitmessage
-        #   - addressGenerator
-        #   - singleWorker
-        #   - SQL
-        #   - objectProcessor
-        #   - singleCleaner
-        #   - singleAPI
-        #   - Asyncore
-        #   - ReceiveQueue_0
-        #   - ReceiveQueue_1
-        #   - ReceiveQueue_2
-        #   - Announcer
-        #   - InvBroadcaster
-        #   - AddrBroadcaster
-        #   - Downloader
-        self.assertEqual(
-            len(self.process.threads()), self._threads_count)
+        """Test number and names of threads"""
+
+        # pylint: disable=invalid-name
+        self.longMessage = True
+
+        try:
+            # using ps for posix platforms
+            # because of https://github.com/giampaolo/psutil/issues/613
+            thread_names = subprocess.check_output([
+                "ps", "-L", "-o", "comm=", "--pid",
+                str(self.process.pid)
+            ]).split()
+        except:  # pylint: disable=bare-except
+            thread_names = []
+
+        running_threads = len(thread_names)
+        if 0 < running_threads < 30:  # adequacy check
+            extra_threads = []
+            missing_threads = []
+            for thread_name in thread_names:
+                if thread_name not in self._threads_names:
+                    extra_threads.append(thread_name)
+            for thread_name in self._threads_names:
+                if thread_name not in thread_names:
+                    missing_threads.append(thread_name)
+
+            msg = "Missing threads: {}, Extra threads: {}".format(
+                ",".join(missing_threads), ",".join(extra_threads))
+        else:
+            running_threads = self.process.num_threads()
+            if sys.platform.startswith('win'):
+                running_threads -= 1  # one extra thread on Windows!
+            msg = "Unexpected running thread count"
+
+        self.assertGreaterEqual(
+            running_threads,
+            self._threads_count_min,
+            msg)
+
+        self.assertLessEqual(
+            running_threads,
+            self._threads_count_max,
+            msg)
 
 
 class TestProcessShutdown(TestProcessProto):
@@ -123,7 +191,14 @@ class TestProcessShutdown(TestProcessProto):
     @classmethod
     def tearDownClass(cls):
         """Special teardown because pybitmessage is already stopped"""
-        cls._cleanup_files()
+        try:
+            if cls.process.is_running():
+                cls.process.kill()
+                cls.process.wait(5)
+        except (psutil.TimeoutExpired, psutil.NoSuchProcess):
+            pass
+        finally:
+            cls._cleanup_files()
 
 
 class TestProcess(TestProcessProto):

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -35,7 +35,9 @@ class TestProcessProto(unittest.TestCase):
         cls.flag = False
         cls.home = os.environ['BITMESSAGE_HOME'] = tempfile.gettempdir()
         put_signal_file(cls.home, 'unittest.lock')
-        subprocess.call(cls._process_cmd)  # nosec
+        subprocess.Popen(
+            cls._process_cmd,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)  # nosec
         time.sleep(5)
         try:
             cls.pid = int(cls._get_readline('singleton.lock'))


### PR DESCRIPTION
Hello!

This is my rebased branch done after #1683. It has partially merged commit from your `teardown-test1` and many commits which should be squashed.

I think the final alert about `BMConfigParser()` should not appear if no tests import a module with side effects (`helper_startup.loadConfig()` I guess). Without that assertion the branch should pass on xenial and bionic. focal shows unexpected start of core tests in `pybitmessage -t`, other platforms have own problems which also seem to be related by detecting presence of certain files, particularly `singleton.lock`, `unittest.lock`.



