### PR TITLE
Fix dependency checks for optional modules

### DIFF
--- a/checkdeps.py
+++ b/checkdeps.py
@@ -144,20 +144,23 @@ for lhs, rhs in EXTRAS_REQUIRE.items():
         for x in rhs
         if x in EXTRAS_REQUIRE_DEPS
     ]):
-        rhs_cmd = ''.join([
-            CMD,
-            ' ',
-            ' '.join([
-                ''. join([
-                    xx for xx in EXTRAS_REQUIRE_DEPS[x][OPSYS]
-                ])
-                for x in rhs
-                if x in EXTRAS_REQUIRE_DEPS
-            ]),
-        ])
-        print(
-            "Optional dependency `pip install .[{}]` would require `{}`"
-            " to be run as root".format(lhs, rhs_cmd))
+        try:
+            import_module(lhs)
+        except Exception as e:
+            rhs_cmd = ''.join([
+                CMD,
+                ' ',
+                ' '.join([
+                    ''. join([
+                        xx for xx in EXTRAS_REQUIRE_DEPS[x][OPSYS]
+                    ])
+                    for x in rhs
+                    if x in EXTRAS_REQUIRE_DEPS
+                ]),
+            ])
+            print(
+                "Optional dependency `pip install .[{}]` would require `{}`"
+                " to be run as root".format(lhs, rhs_cmd))
 
 if (not compiler or prereqs) and OPSYS in PACKAGE_MANAGER:
     print("You can install the missing dependencies by running, as root:")


### PR DESCRIPTION
I have put import_module for checking already installed dependency in checkdeps module so with the use of it buildbot checks get 
improve and fix so issues of  #1316