### PR TITLE
Closes #1538. Refactors 'onionservicesonly' to 'onlynet=onion', prevents bootstrapping from non-onion nodes when true, and prevents bootstrapping from any node but the trusted peer (when set)

### DIFF
--- a/src/network/connectionchooser.py
+++ b/src/network/connectionchooser.py
@@ -31,8 +31,11 @@ def chooseConnection(stream):
     """Returns an appropriate connection"""
     haveOnion = BMConfigParser().safeGet(
         "bitmessagesettings", "socksproxytype")[0:5] == 'SOCKS'
-    onionOnly = BMConfigParser().safeGetBoolean(
+    onionOnly_deprecated = BMConfigParser().safeGetBoolean(
         "bitmessagesettings", "onionservicesonly")
+    onionOnly = BMConfigParser().safeGet(
+        "bitmessagesettings", "onlynet") == "onion"
+    onionOnly = onionOnly or onionOnly_deprecated
     try:
         retval = portCheckerQueue.get(False)
         portCheckerQueue.task_done()

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -51,6 +51,12 @@ class BMConnectionPool(object):
             BMConfigParser().safeGetInt(
                 "bitmessagesettings", "maxuploadrate")
         )
+        onionOnly_deprecated = BMConfigParser().safeGetBoolean(
+            "bitmessagesettings", "onionservicesonly")
+        onionOnly = BMConfigParser().safeGet(
+            "bitmessagesettings", "onlynet") == "onion"
+
+        self.onionOnly = onionOnly or onionOnly_deprecated
         self.outboundConnections = {}
         self.inboundConnections = {}
         self.listeningSockets = {}
@@ -205,17 +211,17 @@ class BMConnectionPool(object):
 
     def startBootstrappers(self):
         """Run the process of resolving bootstrap hostnames"""
+        onion_seed = 'quzwelsuziwqgpt2.onion' #FIXME onion bootstrap server is down
         proxy_type = BMConfigParser().safeGet(
             'bitmessagesettings', 'socksproxytype')
         # A plugins may be added here
         hostname = None
+        port = 8444
+
         if not proxy_type or proxy_type == 'none':
             connection_base = TCPConnection
         elif proxy_type == 'SOCKS5':
             connection_base = Socks5BMConnection
-            hostname = helper_random.randomchoice([
-                'quzwelsuziwqgpt2.onion', None
-            ])
         elif proxy_type == 'SOCKS4a':
             connection_base = Socks4aBMConnection  # FIXME: I cannot test
         else:
@@ -223,12 +229,22 @@ class BMConnectionPool(object):
             # is handled in bitmessagemain before starting the connectionpool
             return
 
-        bootstrapper = bootstrap(connection_base)
-        if not hostname:
+        if self.trustedPeer is not None:
+            hostname = self.trustedPeer.host
+            port = self.trustedPeer.port
+        elif proxy_type == "SOCKS5" or self.onionOnly:
+            if self.onionOnly:
+                hostname = onion_seed
+            else:
+                hostname = helper_random.randomchoice([
+                onion_seed, None
+                ])
+
+        if hostname is None:
             port = helper_random.randomchoice([8080, 8444])
             hostname = 'bootstrap%s.bitmessage.org' % port
-        else:
-            port = 8444
+
+        bootstrapper = bootstrap(connection_base)
         self.addConnection(bootstrapper(hostname, port))
 
     def loop(self):  # pylint: disable=too-many-branches,too-many-statements

--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -194,14 +194,7 @@ class TestCore(unittest.TestCase):
         start_proxyconfig()
         self._check_bootstrap()
 
-    @unittest.skipUnless(stem_version, 'No stem, skipping tor dependent test')
-    def test_onionservicesonly(self):  # this should start after bootstrap
-        """
-        set onionservicesonly, wait for 3 connections and check them all
-        are onions
-        """
-        BMConfigParser().set('bitmessagesettings', 'socksproxytype', 'SOCKS5')
-        BMConfigParser().set('bitmessagesettings', 'onionservicesonly', 'true')
+    def _check_exclusively_onion_networking(self):
         self._initiate_bootstrap()
         BMConfigParser().remove_option('bitmessagesettings', 'dontconnect')
         for _ in range(360):
@@ -217,6 +210,25 @@ class TestCore(unittest.TestCase):
                         'Found non onion hostname %s in outbound connections!'
                         % peer.host)
         self.fail('Failed to connect to at least 3 nodes within 360 sec')
+
+    @unittest.skipUnless(stem_version, 'No stem, skipping tor dependent test')
+    def test_onionservicesonly(self):  # this should start after bootstrap
+        """
+        set onionservicesonly (deprecated), wait for 3 connections and check
+        that all are onions
+        """
+        BMConfigParser().set('bitmessagesettings', 'socksproxytype', 'SOCKS5')
+        BMConfigParser().set('bitmessagesettings', 'onionservicesonly', 'true')
+        self._check_exclusively_onion_networking()
+
+    @unittest.skipUnless(stem_version, 'No stem, skipping tor dependent test')
+    def test_onlynetonion(self):  # this should start after bootstrap
+        """
+        set onlynet=onion, wait for 3 connections and check that all are onions
+        """
+        BMConfigParser().set('bitmessagesettings', 'socksproxytype', 'SOCKS5')
+        BMConfigParser().set('bitmessagesettings', 'onlynet', 'onion')
+        self._check_exclusively_onion_networking()
 
     @staticmethod
     def _decode_msg(data, pattern):


### PR DESCRIPTION
This PR fixes #1538.  It:
- Gracefully changes the config option 'onionservicesonly=true' to 'onlynet=onion', upgrading old config directives upon GUI settings dialog "OK"
- When onion services only is requested, prevents bootstrapping from a non-onion node
- When a trusted peer is set, prevents bootstrapping from any other node 

This PR *does not* add any warning or error dialogs, which would be useful for a user unknowingly unable to bootstrap because they set 'onlynet=onion'.

(Please ignore #1693. I accidentally hit <ENTER> when typing the title, which GitHub oh-so-helpfully interpreted as a click on "Create pull request".)