### PR TITLE
SQL operations asserts and code quality

### DIFF
--- a/src/class_singleWorker.py
+++ b/src/class_singleWorker.py
@@ -16,6 +16,7 @@ import defaults
 import helper_inbox
 import helper_msgcoding
 import helper_random
+import helper_sql
 import highlevelcrypto
 import l10n
 import proofofwork
@@ -62,8 +63,8 @@ class singleWorker(StoppableThread):
     def run(self):
         # pylint: disable=attribute-defined-outside-init
 
-        while not state.sqlReady and state.shutdown == 0:
-            self.stop.wait(2)
+        while not helper_sql.sql_ready.wait(1.0) and state.shutdown == 0:
+            self.stop.wait(1.0)
         if state.shutdown > 0:
             return
 

--- a/src/class_sqlThread.py
+++ b/src/class_sqlThread.py
@@ -28,6 +28,7 @@ class sqlThread(threading.Thread):
 
     def run(self):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         """Process SQL queries from `.helper_sql.sqlSubmitQueue`"""
+        helper_sql.sql_available = True
         self.conn = sqlite3.connect(state.appdata + 'messages.dat')
         self.conn.text_factory = str
         self.cur = self.conn.cursor()
@@ -464,7 +465,7 @@ class sqlThread(threading.Thread):
                 parameters = (int(time.time()),)
                 self.cur.execute(item, parameters)
 
-        state.sqlReady = True
+        helper_sql.sql_ready.set()
 
         while True:
             item = helper_sql.sqlSubmitQueue.get()

--- a/src/state.py
+++ b/src/state.py
@@ -34,9 +34,6 @@ enableSTDIO = False
 """enable STDIO threads"""
 curses = False
 
-sqlReady = False
-"""set to true by `.threads.sqlThread` when ready for processing"""
-
 maximumNumberOfHalfOpenConnections = 0
 
 maximumLengthOfTimeToBotherResendingMessages = 0


### PR DESCRIPTION
- complain if trying to execute SQL statements without a running `.threads.sqlThread`. This is to give better test feedback if used incorrectly
- refactor `.helper_sql.sql_ready` as a `threading.Event`
- code quality
