### PR TITLE
Add missing TTL to API sendMessage

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1112,7 +1112,7 @@ class BMRPCDispatcher(object):
 
         ackdata = helper_sent.insert(
             toAddress=toAddress, fromAddress=fromAddress,
-            subject=subject, message=message, encoding=encodingType)
+            subject=subject, message=message, encoding=encodingType, ttl=TTL)
 
         toLabel = ''
         queryreturn = sqlQuery(


### PR DESCRIPTION
I noticed that the TTL was being set to 4 days when sendMessage was being called with the API, despite a TTL of a different time being used. It appears TTL was not incorporated into one of the latest changes. This PR should restore TTL-setting functionality.