### PR TITLE
Make it possible to disable UDP announcing in settings

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -321,9 +321,10 @@ class Main(object):
                 receiveQueueThread = ReceiveQueueThread(i)
                 receiveQueueThread.daemon = True
                 receiveQueueThread.start()
-            announceThread = AnnounceThread()
-            announceThread.daemon = True
-            announceThread.start()
+            if config.safeGetBoolean('bitmessagesettings', 'udp'):
+                state.announceThread = AnnounceThread()
+                state.announceThread.daemon = True
+                state.announceThread.start()
             state.invThread = InvThread()
             state.invThread.daemon = True
             state.invThread.start()

--- a/src/bitmessageqt/settings.py
+++ b/src/bitmessageqt/settings.py
@@ -19,7 +19,7 @@ import widgets
 from bmconfigparser import BMConfigParser
 from helper_sql import sqlExecute, sqlStoredProcedure
 from helper_startup import start_proxyconfig
-from network import knownnodes
+from network import knownnodes, AnnounceThread
 from network.asyncore_pollchoose import set_rates
 from tr import _translate
 
@@ -138,6 +138,8 @@ class SettingsDialog(QtGui.QDialog):
             config.get('bitmessagesettings', 'port')))
         self.checkBoxUPnP.setChecked(
             config.safeGetBoolean('bitmessagesettings', 'upnp'))
+        self.checkBoxUDP.setChecked(
+            config.safeGetBoolean('bitmessagesettings', 'udp'))
         self.checkBoxAuthentication.setChecked(
             config.getboolean('bitmessagesettings', 'socksauthentication'))
         self.checkBoxSocksListen.setChecked(
@@ -326,7 +328,8 @@ class SettingsDialog(QtGui.QDialog):
                 self.lineEditTCPPort.text()):
             self.config.set(
                 'bitmessagesettings', 'port', str(self.lineEditTCPPort.text()))
-            if not self.config.safeGetBoolean('bitmessagesettings', 'dontconnect'):
+            if not self.config.safeGetBoolean(
+                    'bitmessagesettings', 'dontconnect'):
                 self.net_restart_needed = True
 
         if self.checkBoxUPnP.isChecked() != self.config.safeGetBoolean(
@@ -339,11 +342,26 @@ class SettingsDialog(QtGui.QDialog):
                 upnpThread = upnp.uPnPThread()
                 upnpThread.start()
 
+        udp_enabled = self.checkBoxUDP.isChecked()
+        if udp_enabled != self.config.safeGetBoolean(
+                'bitmessagesettings', 'udp'):
+            self.config.set('bitmessagesettings', 'udp', str(udp_enabled))
+            if udp_enabled:
+                announceThread = AnnounceThread()
+                announceThread.daemon = True
+                announceThread.start()
+            else:
+                try:
+                    state.announceThread.stopThread()
+                except AttributeError:
+                    pass
+
         proxytype_index = self.comboBoxProxyType.currentIndex()
         if proxytype_index == 0:
             if self._proxy_type and state.statusIconColor != 'red':
                 self.net_restart_needed = True
-        elif state.statusIconColor == 'red' and self.config.safeGetBoolean('bitmessagesettings', 'dontconnect'):
+        elif state.statusIconColor == 'red' and self.config.safeGetBoolean(
+                'bitmessagesettings', 'dontconnect'):
             self.net_restart_needed = False
         elif self.comboBoxProxyType.currentText() != self._proxy_type:
             self.net_restart_needed = True
@@ -369,8 +387,11 @@ class SettingsDialog(QtGui.QDialog):
             self.lineEditSocksPassword.text()))
         self.config.set('bitmessagesettings', 'sockslisten', str(
             self.checkBoxSocksListen.isChecked()))
-        if self.checkBoxOnionOnly.isChecked() \
-                and not self.config.safeGetBoolean('bitmessagesettings', 'onionservicesonly'):
+        if (
+            self.checkBoxOnionOnly.isChecked()
+            and not self.config.safeGetBoolean(
+                'bitmessagesettings', 'onionservicesonly')
+        ):
             self.net_restart_needed = True
         self.config.set('bitmessagesettings', 'onionservicesonly', str(
             self.checkBoxOnionOnly.isChecked()))
@@ -432,8 +453,8 @@ class SettingsDialog(QtGui.QDialog):
         acceptableDifficultyChanged = False
 
         if (
-                float(self.lineEditMaxAcceptableTotalDifficulty.text()) >= 1
-                or float(self.lineEditMaxAcceptableTotalDifficulty.text()) == 0
+            float(self.lineEditMaxAcceptableTotalDifficulty.text()) >= 1
+            or float(self.lineEditMaxAcceptableTotalDifficulty.text()) == 0
         ):
             if self.config.get(
                     'bitmessagesettings', 'maxacceptablenoncetrialsperbyte'
@@ -449,8 +470,8 @@ class SettingsDialog(QtGui.QDialog):
                         * defaults.networkDefaultProofOfWorkNonceTrialsPerByte))
                 )
         if (
-                float(self.lineEditMaxAcceptableSmallMessageDifficulty.text()) >= 1
-                or float(self.lineEditMaxAcceptableSmallMessageDifficulty.text()) == 0
+            float(self.lineEditMaxAcceptableSmallMessageDifficulty.text()) >= 1
+            or float(self.lineEditMaxAcceptableSmallMessageDifficulty.text()) == 0
         ):
             if self.config.get(
                     'bitmessagesettings', 'maxacceptablepayloadlengthextrabytes'
@@ -541,8 +562,8 @@ class SettingsDialog(QtGui.QDialog):
         self.parent.updateStartOnLogon()
 
         if (
-                state.appdata != paths.lookupExeFolder()
-                and self.checkBoxPortableMode.isChecked()
+            state.appdata != paths.lookupExeFolder()
+            and self.checkBoxPortableMode.isChecked()
         ):
             # If we are NOT using portable mode now but the user selected
             # that we should...
@@ -564,8 +585,8 @@ class SettingsDialog(QtGui.QDialog):
                 pass
 
         if (
-                state.appdata == paths.lookupExeFolder()
-                and not self.checkBoxPortableMode.isChecked()
+            state.appdata == paths.lookupExeFolder()
+            and not self.checkBoxPortableMode.isChecked()
         ):
             # If we ARE using portable mode now but the user selected
             # that we shouldn't...

--- a/src/bitmessageqt/settings.ui
+++ b/src/bitmessageqt/settings.ui
@@ -231,7 +231,7 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
           <string>Bandwidth limit</string>
@@ -322,7 +322,7 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Proxy server / Tor</string>
@@ -432,7 +432,14 @@
          </layout>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="checkBoxUDP">
+         <property name="text">
+          <string>Announce self by UDP</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/bitmessageqt/tests/__init__.py
+++ b/src/bitmessageqt/tests/__init__.py
@@ -2,6 +2,10 @@
 
 from addressbook import TestAddressbook
 from main import TestMain, TestUISignaler
+from settings import TestSettings
 from support import TestSupport
 
-__all__ = ["TestAddressbook", "TestMain", "TestSupport", "TestUISignaler"]
+__all__ = [
+    "TestAddressbook", "TestMain", "TestSettings", "TestSupport",
+    "TestUISignaler"
+]

--- a/src/bitmessageqt/tests/settings.py
+++ b/src/bitmessageqt/tests/settings.py
@@ -1,0 +1,34 @@
+import threading
+import time
+
+from main import TestBase
+from bmconfigparser import BMConfigParser
+from bitmessageqt import settings
+
+
+class TestSettings(TestBase):
+    """A test case for the "Settings" dialog"""
+    def setUp(self):
+        super(TestSettings, self).setUp()
+        self.dialog = settings.SettingsDialog(self.window)
+
+    def test_udp(self):
+        """Test the effect of checkBoxUDP"""
+        udp_setting = BMConfigParser().safeGetBoolean(
+            'bitmessagesettings', 'udp')
+        self.assertEqual(udp_setting, self.dialog.checkBoxUDP.isChecked())
+        self.dialog.checkBoxUDP.setChecked(not udp_setting)
+        self.dialog.accept()
+        self.assertEqual(
+            not udp_setting,
+            BMConfigParser().safeGetBoolean('bitmessagesettings', 'udp'))
+        time.sleep(5)
+        for thread in threading.enumerate():
+            if thread.name == 'Announcer':  # find Announcer thread
+                if udp_setting:
+                    self.fail(
+                        'Announcer thread is running while udp set to False')
+                break
+        else:
+            if not udp_setting:
+                self.fail('No Announcer thread found while udp set to True')

--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -19,24 +19,25 @@ BMConfigDefaults = {
         "maxtotalconnections": 200,
         "maxuploadrate": 0,
         "apiinterface": "127.0.0.1",
-        "apiport": 8442
+        "apiport": 8442,
+        "udp": "True"
     },
     "threads": {
         "receive": 3,
     },
     "network": {
-        "bind": '',
+        "bind": "",
         "dandelion": 90,
     },
     "inventory": {
         "storage": "sqlite",
-        "acceptmismatch": False,
+        "acceptmismatch": "False",
     },
     "knownnodes": {
         "maxnodes": 20000,
     },
     "zlib": {
-        'maxsize': 1048576
+        "maxsize": 1048576
     }
 }
 

--- a/src/network/announcethread.py
+++ b/src/network/announcethread.py
@@ -7,7 +7,6 @@ import state
 from bmconfigparser import BMConfigParser
 from network.assemble import assemble_addr
 from network.connectionpool import BMConnectionPool
-from network.udp import UDPSocket
 from node import Peer
 from threads import StoppableThread
 
@@ -15,12 +14,13 @@ from threads import StoppableThread
 class AnnounceThread(StoppableThread):
     """A thread to manage regular announcing of this node"""
     name = "Announcer"
+    announceInterval = 60
 
     def run(self):
         lastSelfAnnounced = 0
         while not self._stopped and state.shutdown == 0:
             processed = 0
-            if lastSelfAnnounced < time.time() - UDPSocket.announceInterval:
+            if lastSelfAnnounced < time.time() - self.announceInterval:
                 self.announceSelf()
                 lastSelfAnnounced = time.time()
             if processed == 0:

--- a/src/network/udp.py
+++ b/src/network/udp.py
@@ -18,7 +18,6 @@ logger = logging.getLogger('default')
 class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
     """Bitmessage protocol over UDP (class)"""
     port = 8444
-    announceInterval = 60
 
     def __init__(self, host=None, sock=None, announcing=False):
         # pylint: disable=bad-super-call

--- a/src/network/udp.py
+++ b/src/network/udp.py
@@ -125,9 +125,9 @@ class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
 
     def handle_read(self):
         try:
-            (recdata, addr) = self.socket.recvfrom(self._buf_len)
-        except socket.error as e:
-            logger.error("socket error: %s", e)
+            recdata, addr = self.socket.recvfrom(self._buf_len)
+        except socket.error:
+            logger.error("socket error on recvfrom:", exc_info=True)
             return
 
         self.destination = Peer(*addr)
@@ -143,7 +143,7 @@ class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
         try:
             retval = self.socket.sendto(
                 self.write_buf, ('<broadcast>', self.port))
-        except socket.error as e:
-            logger.error("socket error on sendto: %s", e)
+        except socket.error:
+            logger.error("socket error on sendto:", exc_info=True)
             retval = len(self.write_buf)
         self.slice_write_buf(retval)

--- a/src/network/udp.py
+++ b/src/network/udp.py
@@ -8,6 +8,7 @@ import time
 import protocol
 import state
 from bmproto import BMProto
+from constants import MAX_TIME_OFFSET
 from node import Peer
 from objectracker import ObjectTracker
 from queues import receiveDataQueue
@@ -81,8 +82,8 @@ class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
             decodedIP = protocol.checkIPAddress(str(ip))
             if stream not in state.streamsInWhichIAmParticipating:
                 continue
-            if (seenTime < time.time() - self.maxTimeOffset
-                    or seenTime > time.time() + self.maxTimeOffset):
+            if (seenTime < time.time() - MAX_TIME_OFFSET
+                    or seenTime > time.time() + MAX_TIME_OFFSET):
                 continue
             if decodedIP is False:
                 # if the address isn't local, interpret it as
@@ -93,9 +94,8 @@ class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
         logger.debug(
             "received peer discovery from %s:%i (port %i):",
             self.destination.host, self.destination.port, remoteport)
-        if self.local:
-            state.discoveredPeers[Peer(self.destination.host, remoteport)] = \
-                time.time()
+        state.discoveredPeers[Peer(self.destination.host, remoteport)] = \
+            time.time()
         return True
 
     def bm_command_portcheck(self):


### PR DESCRIPTION
Hello!

UDP announcing is useless without LAN. Users with unstable wi-fi or mobile broadband connection are probably experiencing 
continuous log warnings about `socket.error` even if they have no bitmessage nodes in their LAN. It may be annoying so I suggest add an option to disable UDP announcing in settings.


