### PR TITLE
Allow testing with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
+cache: pip
+dist: bionic
 python:
-  - "2.7"
+  - "2.7_with_system_site_packages"
+  - "3.7"
 addons:
   apt:
     packages:
@@ -11,7 +14,6 @@ addons:
       - xvfb
 install:
   - pip install -r requirements.txt
-  - ln -s src pybitmessage  # tests environment
   - python setup.py install
 script:
   - python checkdeps.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ addons:
 install:
   - pip install -r requirements.txt
   - python setup.py install
+  - export PYTHONWARNINGS=all
 script:
   - python checkdeps.py
   - xvfb-run src/bitmessagemain.py -t
-  - python setup.py test
+  - python -bm tests

--- a/checkdeps.py
+++ b/checkdeps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
 Check dependencies and give recommendations about how to satisfy them
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+coverage
 python_prctl
 psutil
 pycrypto

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 import platform
 import shutil
 import sys
+import unittest
 
 from setuptools import setup, Extension
 from setuptools.command.install import install
@@ -43,6 +44,11 @@ class InstallCmd(install):
             'desktop/icon24.png', 'desktop/icons/24x24/pybitmessage.png')
 
         return install.run(self)
+
+
+def unittest_discover():
+    """Explicit test suite creation"""
+    return unittest.TestLoader().discover('pybitmessage.tests')
 
 
 if __name__ == "__main__":
@@ -116,6 +122,7 @@ if __name__ == "__main__":
         #keywords='',
         install_requires=installRequires,
         tests_require=requirements,
+        test_suite='setup.unittest_discover',
         extras_require=EXTRAS_REQUIRE,
         classifiers=[
             "License :: OSI Approved :: MIT License"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 import platform
 import shutil
 import sys
-import unittest
 
 from setuptools import setup, Extension
 from setuptools.command.install import install
@@ -44,14 +43,6 @@ class InstallCmd(install):
             'desktop/icon24.png', 'desktop/icons/24x24/pybitmessage.png')
 
         return install.run(self)
-
-
-def unittest_discover():
-    """Explicit test suite creation"""
-    if sys.hexversion >= 0x3000000:
-        from pybitmessage import pathmagic
-        pathmagic.setup()
-    return unittest.TestLoader().discover('pybitmessage.tests')
 
 
 if __name__ == "__main__":
@@ -125,7 +116,7 @@ if __name__ == "__main__":
         #keywords='',
         install_requires=installRequires,
         tests_require=requirements,
-        test_suite='setup.unittest_discover',
+        test_suite='tests.unittest_discover',
         extras_require=EXTRAS_REQUIRE,
         classifiers=[
             "License :: OSI Approved :: MIT License"

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ class InstallCmd(install):
 
 def unittest_discover():
     """Explicit test suite creation"""
+    if sys.hexversion >= 0x3000000:
+        from pybitmessage import pathmagic
+        pathmagic.setup()
     return unittest.TestLoader().discover('pybitmessage.tests')
 
 

--- a/setup.py
+++ b/setup.py
@@ -95,11 +95,14 @@ if __name__ == "__main__":
             ['desktop/icons/24x24/pybitmessage.png'])
     ]
 
-    if platform.dist()[0] in ('Debian', 'Ubuntu'):
-        data_files += [
-            ("etc/apparmor.d/",
-                ['packages/apparmor/pybitmessage'])
-        ]
+    try:
+        if platform.dist()[0] in ('Debian', 'Ubuntu'):
+            data_files += [
+                ("etc/apparmor.d/",
+                    ['packages/apparmor/pybitmessage'])
+            ]
+    except AttributeError:
+        pass  # FIXME: use distro for more recent python
 
     dist = setup(
         name='pybitmessage',

--- a/src/bitmessagecurses/__init__.py
+++ b/src/bitmessagecurses/__init__.py
@@ -983,7 +983,7 @@ def sendMessage(sender="", recv="", broadcast=None, subject="", body="", reply=F
 def loadInbox():
     """Load the list of messages"""
     sys.stdout = sys.__stdout__
-    print "Loading inbox messages..."
+    print("Loading inbox messages...")
     sys.stdout = printlog
 
     where = "toaddress || fromaddress || subject || message"
@@ -1035,7 +1035,7 @@ def loadInbox():
 def loadSent():
     """Load the messages that sent"""
     sys.stdout = sys.__stdout__
-    print "Loading sent messages..."
+    print("Loading sent messages...")
     sys.stdout = printlog
 
     where = "toaddress || fromaddress || subject || message"
@@ -1121,7 +1121,7 @@ def loadSent():
 def loadAddrBook():
     """Load address book"""
     sys.stdout = sys.__stdout__
-    print "Loading address book..."
+    print("Loading address book...")
     sys.stdout = printlog
 
     ret = sqlQuery("SELECT label, address FROM addressbook")
@@ -1228,7 +1228,7 @@ def run(stdscr):
 def doShutdown():
     """Shutting the app down"""
     sys.stdout = sys.__stdout__
-    print "Shutting down..."
+    print("Shutting down...")
     sys.stdout = printlog
     shutdown.doCleanShutdown()
     sys.stdout = sys.__stdout__

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/env python
 """
 The PyBitmessage startup script
 """

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -12,10 +12,11 @@ The PyBitmessage startup script
 import os
 import sys
 
-app_dir = os.path.dirname(os.path.abspath(__file__))
-os.chdir(app_dir)
-sys.path.insert(0, app_dir)
-
+try:
+    import pathmagic
+except ImportError:
+    from pybitmessage import pathmagic
+app_dir = pathmagic.setup()
 
 import depends
 depends.check_dependencies()

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -378,11 +378,7 @@ class Main(object):
             test_core_result = test_core.run()
             self.stop()
             test_core.cleanup()
-            sys.exit(
-                'Core tests failed!'
-                if test_core_result.errors or test_core_result.failures
-                else 0
-            )
+            sys.exit(not test_core_result.wasSuccessful())
 
     @staticmethod
     def daemonize():

--- a/src/depends.py
+++ b/src/depends.py
@@ -421,8 +421,8 @@ def check_dependencies(verbose=False, optional=False):
     if sys.hexversion >= 0x3000000:
         logger.error(
             'PyBitmessage does not support Python 3+. Python 2.7.4'
-            ' or greater is required.')
-        has_all_dependencies = False
+            ' or greater is required. Python 2.7.18 is recommended.')
+        sys.exit()
 
     check_functions = [check_ripemd160, check_sqlite, check_openssl]
     if optional:

--- a/src/network/asyncore_pollchoose.py
+++ b/src/network/asyncore_pollchoose.py
@@ -749,7 +749,7 @@ class dispatcher(object):
     def log_info(self, message, log_type='info'):
         """Conditionally print a message"""
         if log_type not in self.ignore_log_types:
-            print '%s: %s' % (log_type, message)
+            print('%s: %s' % (log_type, message))
 
     def handle_read_event(self):
         """Handle a read event"""

--- a/src/network/http.py
+++ b/src/network/http.py
@@ -18,19 +18,19 @@ class HttpConnection(AdvancedDispatcher):
         self.destination = (host, 80)
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
         self.connect(self.destination)
-        print "connecting in background to %s:%i" % (self.destination[0], self.destination[1])
+        print("connecting in background to %s:%i" % self.destination)
 
     def state_init(self):
         self.append_write_buf(
             "GET %s HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n" % (
                 self.path, self.destination[0]))
-        print "Sending %ib" % (len(self.write_buf))
+        print("Sending %ib" % len(self.write_buf))
         self.set_state("http_request_sent", 0)
         return False
 
     def state_http_request_sent(self):
         if self.read_buf:
-            print "Received %ib" % (len(self.read_buf))
+            print("Received %ib" % len(self.read_buf))
             self.read_buf = b""
         if not self.connected:
             self.set_state("close", 0)
@@ -62,13 +62,13 @@ if __name__ == "__main__":
     for host in ("bootstrap8080.bitmessage.org", "bootstrap8444.bitmessage.org"):
         proxy = Socks5Resolver(host=host)
         while asyncore.socket_map:
-            print "loop %s, len %i" % (proxy.state, len(asyncore.socket_map))
+            print("loop %s, len %i" % (proxy.state, len(asyncore.socket_map)))
             asyncore.loop(timeout=1, count=1)
         proxy.resolved()
 
         proxy = Socks4aResolver(host=host)
         while asyncore.socket_map:
-            print "loop %s, len %i" % (proxy.state, len(asyncore.socket_map))
+            print("loop %s, len %i" % (proxy.state, len(asyncore.socket_map)))
             asyncore.loop(timeout=1, count=1)
         proxy.resolved()
 

--- a/src/openclpow.py
+++ b/src/openclpow.py
@@ -1,16 +1,24 @@
-#!/usr/bin/env python2.7
 """
 Module for Proof of Work using OpenCL
 """
+import logging
 import os
 from struct import pack
 
 import paths
 from bmconfigparser import BMConfigParser
-from debug import logger
 from state import shutdown
 
-libAvailable = True
+try:
+    import numpy
+    import pyopencl as cl
+    libAvailable = True
+except ImportError:
+    libAvailable = False
+
+
+logger = logging.getLogger('default')
+
 ctx = False
 queue = False
 program = False
@@ -19,17 +27,10 @@ enabledGpus = []
 vendors = []
 hash_dt = None
 
-try:
-    import pyopencl as cl
-    import numpy
-except ImportError:
-    libAvailable = False
-
 
 def initCL():
     """Initlialise OpenCL engine"""
-    # pylint: disable=global-statement
-    global ctx, queue, program, hash_dt, libAvailable
+    global ctx, queue, program, hash_dt  # pylint: disable=global-statement
     if libAvailable is False:
         return
     del enabledGpus[:]

--- a/src/pathmagic.py
+++ b/src/pathmagic.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+
+def setup():
+    """Add path to this file to sys.path"""
+    app_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(app_dir)
+    sys.path.insert(0, app_dir)
+    return app_dir

--- a/src/pyelliptic/arithmetic.py
+++ b/src/pyelliptic/arithmetic.py
@@ -16,7 +16,7 @@ def inv(a, n):
     lm, hm = 1, 0
     low, high = a % n, n
     while low > 1:
-        r = high / low
+        r = high // low
         nm, new = hm - lm * r, high - low * r
         lm, low, hm, high = nm, new, lm, low
     return lm % n
@@ -43,8 +43,8 @@ def encode(val, base, minlen=0):
     code_string = get_code_string(base)
     result = ""
     while val > 0:
-        result = code_string[val % base] + result
-        val /= base
+        val, i = divmod(val, base)
+        result = code_string[i] + result
     if len(result) < minlen:
         result = code_string[0] * (minlen - len(result)) + result
     return result
@@ -101,10 +101,11 @@ def base10_multiply(a, n):
         return G
     if n == 1:
         return a
-    if (n % 2) == 0:
-        return base10_double(base10_multiply(a, n / 2))
-    if (n % 2) == 1:
-        return base10_add(base10_double(base10_multiply(a, n / 2)), a)
+    n, m = divmod(n, 2)
+    if m == 0:
+        return base10_double(base10_multiply(a, n))
+    if m == 1:
+        return base10_add(base10_double(base10_multiply(a, n)), a)
     return None
 
 

--- a/src/pyelliptic/cipher.py
+++ b/src/pyelliptic/cipher.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 Symmetric Encryption
 """
 #  Copyright (C) 2011 Yann GUIBET <yannguibet@gmail.com>
 #  See LICENSE for details.
 
-from openssl import OpenSSL
+from .openssl import OpenSSL
 
 
 # pylint: disable=redefined-builtin

--- a/src/pyelliptic/ecc.py
+++ b/src/pyelliptic/ecc.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 Asymmetric cryptography using elliptic curves
 """
@@ -10,9 +8,9 @@ Asymmetric cryptography using elliptic curves
 from hashlib import sha512
 from struct import pack, unpack
 
-from cipher import Cipher
-from hash import equals, hmac_sha256
-from openssl import OpenSSL
+from .cipher import Cipher
+from .hash import equals, hmac_sha256
+from .openssl import OpenSSL
 
 
 class ECC(object):

--- a/src/pyelliptic/eccblind.py
+++ b/src/pyelliptic/eccblind.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 ECC blind signature functionality based on
 "An Efficient Blind Signature Scheme
@@ -151,7 +150,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
                 # padding manually
                 bx = OpenSSL.malloc(0, OpenSSL.BN_num_bytes(x))
                 OpenSSL.BN_bn2bin(x, bx)
-                out = bx.raw.rjust(l_, chr(0))
+                out = bx.raw.rjust(l_, b'\x00')
             return pack(EC, y_byte, out)
 
         finally:
@@ -181,7 +180,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
         except AttributeError:
             o = OpenSSL.malloc(0, OpenSSL.BN_num_bytes(bn))
             OpenSSL.BN_bn2bin(bn, o)
-            return o.raw.rjust(l_, chr(0))
+            return o.raw.rjust(l_, b'\x00')
 
     def _bn_deserialize(self, data):
         """Make a BigNum out of string"""

--- a/src/pyelliptic/hash.py
+++ b/src/pyelliptic/hash.py
@@ -4,7 +4,7 @@ Wrappers for hash functions from OpenSSL.
 #  Copyright (C) 2011 Yann GUIBET <yannguibet@gmail.com>
 #  See LICENSE for details.
 
-from openssl import OpenSSL
+from .openssl import OpenSSL
 
 
 # For python3

--- a/src/pyelliptic/openssl.py
+++ b/src/pyelliptic/openssl.py
@@ -83,7 +83,7 @@ class _OpenSSL(object):
         """
         self._lib = ctypes.CDLL(library)
         self._version, self._hexversion, self._cflags = get_version(self._lib)
-        self._libreSSL = self._version.startswith("LibreSSL")
+        self._libreSSL = self._version.startswith(b"LibreSSL")
 
         self.pointer = ctypes.pointer
         self.c_int = ctypes.c_int

--- a/src/tests/apinotify_handler.py
+++ b/src/tests/apinotify_handler.py
@@ -7,7 +7,7 @@ when pybitmessage started in test mode.
 import sys
 import tempfile
 
-from test_process import put_signal_file
+from common import put_signal_file
 
 
 if __name__ == '__main__':

--- a/src/tests/common.py
+++ b/src/tests/common.py
@@ -1,4 +1,7 @@
 import os
+import sys
+import time
+import unittest
 
 
 _files = (
@@ -17,3 +20,15 @@ def cleanup(home=None, files=_files):
             os.remove(os.path.join(home, pfile))
         except OSError:
             pass
+
+
+def skip_python3():
+    """Raise unittest.SkipTest() if detected python3"""
+    if sys.hexversion >= 0x3000000:
+        raise unittest.SkipTest('Module is not ported to python3')
+
+
+def put_signal_file(path, filename):
+    """Creates file, presence of which is a signal about some event."""
+    with open(os.path.join(path, filename), 'wb') as outfile:
+        outfile.write(b'%i' % time.time())

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -5,9 +5,13 @@ Tests using API.
 import base64
 import json
 import time
-import xmlrpclib  # nosec
 
-from test_process import TestProcessProto, TestProcessShutdown
+try:  # nosec
+    from xmlrpclib import ServerProxy, ProtocolError
+except ImportError:
+    from xmlrpc.client import ServerProxy, ProtocolError
+
+from .test_process import TestProcessProto, TestProcessShutdown
 
 
 class TestAPIProto(TestProcessProto):
@@ -19,7 +23,7 @@ class TestAPIProto(TestProcessProto):
         """Setup XMLRPC proxy for pybitmessage API"""
         super(TestAPIProto, cls).setUpClass()
         cls.addresses = []
-        cls.api = xmlrpclib.ServerProxy(
+        cls.api = ServerProxy(
             "http://username:password@127.0.0.1:8442/")
         for _ in range(5):
             if cls._get_readline('.api_started'):
@@ -65,8 +69,8 @@ class TestAPI(TestAPIProto):
 
     def test_user_password(self):
         """Trying to connect with wrong username/password"""
-        api_wrong = xmlrpclib.ServerProxy("http://test:wrong@127.0.0.1:8442/")
-        with self.assertRaises(xmlrpclib.ProtocolError):
+        api_wrong = ServerProxy("http://test:wrong@127.0.0.1:8442/")
+        with self.assertRaises(ProtocolError):
             api_wrong.clientStatus()
 
     def test_connection(self):

--- a/src/tests/test_blindsig.py
+++ b/src/tests/test_blindsig.py
@@ -5,9 +5,7 @@ import os
 import unittest
 from hashlib import sha256
 
-from pybitmessage.pyelliptic.eccblind import ECCBlind
-from pybitmessage.pyelliptic.eccblindchain import ECCBlindChain
-from pybitmessage.pyelliptic.openssl import OpenSSL
+from pybitmessage.pyelliptic import ECCBlind, ECCBlindChain, OpenSSL
 
 # pylint: disable=protected-access
 
@@ -36,12 +34,12 @@ class TestBlindSig(unittest.TestCase):
 
         # (3) Signature Generation
         signature_blinded = signer_obj.blind_sign(msg_blinded)
-        assert isinstance(signature_blinded, str)
+        assert isinstance(signature_blinded, bytes)
         self.assertEqual(len(signature_blinded), 32)
 
         # (4) Extraction
         signature = requester_obj.unblind(signature_blinded)
-        assert isinstance(signature, str)
+        assert isinstance(signature, bytes)
         self.assertEqual(len(signature), 65)
 
         self.assertNotEqual(signature, signature_blinded)
@@ -163,7 +161,7 @@ class TestBlindSig(unittest.TestCase):
                 output.extend(pubkey)
             output.extend(signature)
             signer_obj = child_obj
-        verifychain = ECCBlindChain(ca=ca.pubkey(), chain=str(output))
+        verifychain = ECCBlindChain(ca=ca.pubkey(), chain=bytes(output))
         self.assertTrue(verifychain.verify(msg=msg, value=1))
 
     def test_blind_sig_chain_wrong_ca(self):  # pylint: disable=too-many-locals

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -6,8 +6,8 @@ import os
 import unittest
 import tempfile
 
+from .test_process import TestProcessProto
 from pybitmessage.bmconfigparser import BMConfigParser
-from test_process import TestProcessProto
 
 
 class TestConfig(unittest.TestCase):

--- a/src/tests/test_crypto.py
+++ b/src/tests/test_crypto.py
@@ -6,7 +6,9 @@ import hashlib
 import unittest
 from abc import ABCMeta, abstractmethod
 from binascii import hexlify, unhexlify
+
 from pybitmessage.pyelliptic import arithmetic
+
 
 try:
     from Crypto.Hash import RIPEMD

--- a/src/tests/test_crypto.py
+++ b/src/tests/test_crypto.py
@@ -23,13 +23,20 @@ sample_pubsigningkey = unhexlify(
 sample_pubencryptionkey = unhexlify(
     '044597d59177fc1d89555d38915f581b5ff2286b39d022ca0283d2bdd5c36be5d3c'
     'e7b9b97792327851a562752e4b79475d1f51f5a71352482b241227f45ed36a9')
-sample_privatesigningkey = \
+sample_privsigningkey = \
     '93d0b61371a54b53df143b954035d612f8efa8a3ed1cf842c2186bfd8f876665'
-sample_privateencryptionkey = \
+sample_privencryptionkey = \
     '4b0b73a54e19b059dc274ab69df095fe699f43b17397bca26fdf40f4d7400a3a'
-sample_ripe = '003cd097eb7f35c87b5dc8b4538c22cb55312a9f'
+sample_ripe = b'003cd097eb7f35c87b5dc8b4538c22cb55312a9f'
 # stream: 1, version: 2
 sample_address = 'BM-onkVu1KKL2UaUss5Upg9vXmqd3esTmV79'
+
+sample_factor = 66858749573256452658262553961707680376751171096153613379801854825275240965733
+# G * sample_factor
+sample_point = (
+    33567437183004486938355437500683826356288335339807546987348409590129959362313,
+    94730058721143827257669456336351159718085716196507891067256111928318063085006
+)
 
 _sha = hashlib.new('sha512')
 _sha.update(sample_pubsigningkey + sample_pubencryptionkey)
@@ -71,14 +78,20 @@ class TestCrypto(RIPEMD160TestCase, unittest.TestCase):
 
 class TestAddresses(unittest.TestCase):
     """Test addresses manipulations"""
+    def test_base10_multiply(self):
+        """Test arithmetic.base10_multiply"""
+        self.assertEqual(
+            sample_point,
+            arithmetic.base10_multiply(arithmetic.G, sample_factor))
+
     def test_privtopub(self):
         """Generate public keys and check the result"""
         self.assertEqual(
-            arithmetic.privtopub(sample_privatesigningkey),
+            arithmetic.privtopub(sample_privsigningkey).encode(),
             hexlify(sample_pubsigningkey)
         )
         self.assertEqual(
-            arithmetic.privtopub(sample_privateencryptionkey),
+            arithmetic.privtopub(sample_privencryptionkey).encode(),
             hexlify(sample_pubencryptionkey)
         )
 

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -5,7 +5,7 @@ Testing the logger configuration
 import os
 import tempfile
 
-from test_process import TestProcessProto
+from .test_process import TestProcessProto
 
 
 class TestLogger(TestProcessProto):

--- a/src/tests/test_networkgroup.py
+++ b/src/tests/test_networkgroup.py
@@ -3,6 +3,10 @@ Test for network group
 """
 import unittest
 
+from .common import skip_python3
+
+skip_python3()
+
 
 class TestNetworkGroup(unittest.TestCase):
     """

--- a/src/tests/test_openclpow.py
+++ b/src/tests/test_openclpow.py
@@ -3,8 +3,11 @@ Tests for openclpow module
 """
 import hashlib
 import unittest
-
 from struct import pack, unpack
+
+from .common import skip_python3
+
+skip_python3()  # noqa:E402
 
 from pybitmessage import openclpow
 

--- a/src/tests/test_openssl.py
+++ b/src/tests/test_openssl.py
@@ -49,6 +49,6 @@ class TestOpenSSL(unittest.TestCase):
             c = OpenSSL.malloc(0, OpenSSL.BN_num_bytes(a))
             OpenSSL.BN_bn2binpad(a, b, OpenSSL.BN_num_bytes(n))
             OpenSSL.BN_bn2bin(a, c)
-            if b.raw != c.raw.rjust(OpenSSL.BN_num_bytes(n), chr(0)):
+            if b.raw != c.raw.rjust(OpenSSL.BN_num_bytes(n), b'\x00'):
                 bad += 1
         self.assertEqual(bad, 0)

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -18,7 +18,7 @@ from common import cleanup
 def put_signal_file(path, filename):
     """Creates file, presence of which is a signal about some event."""
     with open(os.path.join(path, filename), 'wb') as outfile:
-        outfile.write(str(time.time()))
+        outfile.write(b'%i' % time.time())
 
 
 class TestProcessProto(unittest.TestCase):

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -12,13 +12,10 @@ import unittest
 
 import psutil
 
-from common import cleanup
+from .common import cleanup, put_signal_file, skip_python3
 
 
-def put_signal_file(path, filename):
-    """Creates file, presence of which is a signal about some event."""
-    with open(os.path.join(path, filename), 'wb') as outfile:
-        outfile.write(b'%i' % time.time())
+skip_python3()
 
 
 class TestProcessProto(unittest.TestCase):

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -195,6 +195,7 @@ class TestProcess(TestProcessProto):
         """Check PyBitmessage process name"""
         self.assertEqual(self.process.name(), 'PyBitmessage')
 
+    @unittest.skipIf(psutil.version_info < (4, 0), 'psutil is too old')
     def test_home(self):
         """Ensure BITMESSAGE_HOME is used by process"""
         self.assertEqual(
@@ -204,7 +205,7 @@ class TestProcess(TestProcessProto):
         """Check that pybitmessage listens on port 8444"""
         for c in self.process.connections():
             if c.status == 'LISTEN':
-                self.assertEqual(c.laddr.port, 8444)
+                self.assertEqual(c.laddr[1], 8444)
                 break
 
     def test_files(self):

--- a/src/tests/test_protocol.py
+++ b/src/tests/test_protocol.py
@@ -4,6 +4,10 @@ Tests for common protocol functions
 
 import unittest
 
+from .common import skip_python3
+
+skip_python3()
+
 
 class TestProtocol(unittest.TestCase):
     """Main protocol test case"""

--- a/src/tests/test_randomtrackingdict.py
+++ b/src/tests/test_randomtrackingdict.py
@@ -15,7 +15,7 @@ class TestRandomTrackingDict(unittest.TestCase):
     @staticmethod
     def randString():
         """helper function for tests, generates a random string"""
-        retval = b''
+        retval = ''
         for _ in range(32):
             retval += chr(random.randint(0, 255))
         return retval

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -6,3 +6,4 @@ Depends: openssl, python-setuptools
 Recommends: apparmor, python-msgpack, python-qt4, python-stem, tor
 Suggests: python-pyopencl, python-jsonrpclib, python-defusedxml, python-qrcode
 Suite: bionic
+Setup-Env-Vars: DEB_BUILD_OPTIONS=nocheck

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Custom tests runner script for tox and python3"""
+import random  # noseq
+import sys
+import unittest
+
+
+def unittest_discover():
+    """Explicit test suite creation"""
+    if sys.hexversion >= 0x3000000:
+        from pybitmessage import pathmagic
+        pathmagic.setup()
+    loader = unittest.defaultTestLoader
+    # randomize the order of tests in test cases
+    loader.sortTestMethodsUsing = lambda a, b: random.randint(-1, 1)
+    # pybitmessage symlink may disappear on Windows
+    return loader.discover('src.tests')
+
+
+if __name__ == "__main__":
+    result = unittest.TextTestRunner(verbosity=2).run(unittest_discover())
+    sys.exit(not result.wasSuccessful())

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+envlist = reset,py{27,37,38},stats
+skip_missing_interpreters = true
+
+[testenv]
+setenv =
+    BITMESSAGE_HOME = {envtmpdir}
+    PYTHONWARNINGS = all
+deps = -rrequirements.txt
+commands =
+    python checkdeps.py
+    coverage run -a src/bitmessagemain.py -t
+    coverage run -a -m tests
+
+[testenv:reset]
+commands = coverage erase
+
+[testenv:stats]
+commands =
+    coverage report
+    coverage xml
+
+[coverage:run]
+source = src
+omit =
+    */lib*
+    tests.py
+    */tests/*
+    src/version.py
+    */__init__.py
+    src/fallback/umsgpack/*
+
+[coverage:report]
+ignore_errors = true


### PR DESCRIPTION
Hello!

I'm trying to implement first step of #1712. Any tests module calling `tests.common.skip_python3()` upon import will be skipped when ran with python3. Currently all modules call it because of imports: for python3 you probably need another pathmagick. 