### PR TITLE
Fix new pickle issue on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Pickle files (for testing) should always have UNIX line endings.
+# Windows issue like here https://stackoverflow.com/questions/556269
+knownnodes.dat text eol=lf


### PR DESCRIPTION
Hello!

Using the `knownnodes.dat` test pattern triggers `ImportError` when testing on Windows: https://travis-ci.org/github/g1itch/PyBitmessage/jobs/758290564#L828 because it gets fetched from git with Windows style line endings.