### PR TITLE
Add `enaddr` sqlite function for encoding a bitmessage address

### DIFF
--- a/src/helper_sql.py
+++ b/src/helper_sql.py
@@ -16,8 +16,15 @@ SQLite objects can only be used from one thread.
    or isn't thread-safe.
 """
 
-import Queue
+
+# import Queue
+try:
+    import queue as Queue #python3
+except ImportError:
+    import Queue #python2
+
 import threading
+
 
 sqlSubmitQueue = Queue.Queue()
 """the queue for SQL"""
@@ -103,6 +110,15 @@ def sqlExecute(sql_statement, *args):
     sqlSubmitQueue.put('commit')
     sql_lock.release()
     return rowcount
+
+
+def sqlExecuteScript(sql_statement):
+    """Execute SQL script statement"""
+
+    statements = sql_statement.split(";")
+    with SqlBulkExecute() as sql:
+        for q in statements:
+            sql.execute("{}".format(q))
 
 
 def sqlStoredProcedure(procName):

--- a/src/tests/sql/create_function.sql
+++ b/src/tests/sql/create_function.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `testhash` (
+    `addressversion` int DEFAULT NULL,
+    `hash` blob DEFAULT NULL,
+    `address` text DEFAULT NULL,
+    UNIQUE(address) ON CONFLICT IGNORE
+);
+
+
+
+INSERT INTO testhash (addressversion, hash) VALUES(4, "21122112211221122112");
+

--- a/src/tests/test_sqlthread.py
+++ b/src/tests/test_sqlthread.py
@@ -1,0 +1,73 @@
+"""
+    Test for sqlThread
+"""
+
+import os
+import unittest
+from ..helper_sql import sqlStoredProcedure, sql_ready, sqlExecute, SqlBulkExecute, sqlQuery, sqlExecuteScript
+from ..class_sqlThread import (sqlThread)
+from ..addresses import encodeAddress
+from .common import skip_python3
+
+
+skip_python3()
+
+
+class TestSqlThread(unittest.TestCase):
+    """
+        Test case for SQLThread
+    """
+
+    # query file path
+    root_path = os.path.dirname(os.path.dirname(__file__))
+
+    @classmethod
+    def setUpClass(cls):
+        # Start SQL thread
+        sqlLookup = sqlThread()
+        sqlLookup.daemon = False
+        sqlLookup.start()
+        sql_ready.wait()
+
+    @classmethod
+    def setUp(cls):
+        tables = list(sqlQuery("select name from sqlite_master where type is 'table'"))
+        with SqlBulkExecute() as sql:
+            for q in tables:
+                sql.execute("drop table if exists %s" % q)
+
+    @classmethod
+    def tearDown(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        # Stop sql thread
+        sqlStoredProcedure('exit')
+
+    def initialise_database(self, file):
+        """
+            Initialise DB
+        """
+
+        sql_as_string = open(os.path.join(self.root_path, "tests/sql/{}.sql".format(file))).read()
+        sqlExecuteScript(sql_as_string)
+
+
+    def test_create_function(self):
+        # call create function
+
+        encoded_str = encodeAddress(4, 1, "21122112211221122112")
+
+        # Initialise Database
+        self.initialise_database("create_function")
+
+        sqlExecute('''INSERT INTO testhash (addressversion, hash) VALUES(4, "21122112211221122112")''')
+        # call function in query
+
+        sqlExecute('''UPDATE testhash SET address=(enaddr(testhash.addressversion, 1, hash)) WHERE hash=testhash.hash''')
+
+        # Assertion
+        query = sqlQuery('''select * from testhash;''')
+        self.assertEqual(query[0][-1], encoded_str, "test case fail for create_function")
+        sqlExecute('''DROP TABLE testhash''')


### PR DESCRIPTION
Add `enaddr` sqlite function so that this operation (encoding addresses) can be performed inside sql statements.