### PR TITLE
Python 2 -> 3 part 1

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -58,7 +58,11 @@ For further examples please reference `.tests.test_api`.
 """
 
 import base64
-import ConfigParser
+try:
+	import ConfigParser
+except ModuleNotFoundError:
+	import configparser as ConfigParser
+	ConfigParser.SafeConfigParser = ConfigParser.ConfigParser
 import errno
 import hashlib
 import httplib

--- a/src/bitmessagecurses/__init__.py
+++ b/src/bitmessagecurses/__init__.py
@@ -10,7 +10,11 @@ Bitmessage commandline interface
 #     * python2-pythondialog
 #  * dialog
 
-import ConfigParser
+try:
+	import ConfigParser
+except ModuleNotFoundError:
+	import configparser as ConfigParser
+	ConfigParser.SafeConfigParser = ConfigParser.ConfigParser
 import curses
 import os
 import sys

--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -68,8 +68,12 @@ class BMConfigParser(ConfigParser.SafeConfigParser):
         # pylint: disable=arguments-differ
         try:
             if section == "bitmessagesettings" and option == "timeformat":
-                return ConfigParser.ConfigParser.get(
-                    self, section, option, raw=raw, vars=vars, fallback=fallback)
+                try:
+                    return ConfigParser.ConfigParser.get(
+                        self, section, option, raw=raw, vars=vars, fallback=fallback)
+                except TypeError:
+                    return ConfigParser.ConfigParser.get(
+                        self, section, option, raw=raw, vars=vars)
             try:
                 return self._temp[section][option]
             except KeyError:

--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -2,7 +2,11 @@
 BMConfigParser class definition and default configuration settings
 """
 
-import ConfigParser
+try:
+	import ConfigParser
+except ModuleNotFoundError:
+	import configparser as ConfigParser
+	ConfigParser.SafeConfigParser = ConfigParser.ConfigParser
 import os
 import shutil
 from datetime import datetime

--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -64,21 +64,21 @@ class BMConfigParser(ConfigParser.SafeConfigParser):
             raise ValueError("Invalid value %s" % value)
         return ConfigParser.ConfigParser.set(self, section, option, value)
 
-    def get(self, section, option, raw=False, variables=None):
+    def get(self, section, option, raw=False, vars=None, fallback=None):
         # pylint: disable=arguments-differ
         try:
             if section == "bitmessagesettings" and option == "timeformat":
                 return ConfigParser.ConfigParser.get(
-                    self, section, option, raw, variables)
+                    self, section, option, raw=raw, vars=vars, fallback=fallback)
             try:
                 return self._temp[section][option]
             except KeyError:
                 pass
             return ConfigParser.ConfigParser.get(
-                self, section, option, True, variables)
+                self, section, option, raw=True, vars=vars, fallback=fallback)
         except ConfigParser.InterpolationError:
             return ConfigParser.ConfigParser.get(
-                self, section, option, True, variables)
+                self, section, option, raw=True, vars=vars, fallback=fallback)
         except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as e:
             try:
                 return BMConfigDefaults[section][option]

--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -74,11 +74,19 @@ class BMConfigParser(ConfigParser.SafeConfigParser):
                 return self._temp[section][option]
             except KeyError:
                 pass
-            return ConfigParser.ConfigParser.get(
-                self, section, option, raw=True, vars=vars, fallback=fallback)
+            try:
+	            return ConfigParser.ConfigParser.get(
+                    self, section, option, raw=True, vars=vars, fallback=fallback)
+            except TypeError:
+	            return ConfigParser.ConfigParser.get(
+                    self, section, option, raw=True, vars=vars)
         except ConfigParser.InterpolationError:
-            return ConfigParser.ConfigParser.get(
-                self, section, option, raw=True, vars=vars, fallback=fallback)
+            try:
+                return ConfigParser.ConfigParser.get(
+                    self, section, option, raw=True, vars=vars, fallback=fallback)
+            except TypeError:
+                return ConfigParser.ConfigParser.get(
+                    self, section, option, raw=True, vars=vars)
         except (ConfigParser.NoSectionError, ConfigParser.NoOptionError) as e:
             try:
                 return BMConfigDefaults[section][option]

--- a/src/debug.py
+++ b/src/debug.py
@@ -35,7 +35,11 @@ Logging is thread-safe so you don't have to worry about locks,
 just import and log.
 """
 
-import ConfigParser
+try:
+	import ConfigParser
+except ModuleNotFoundError:
+	import configparser as ConfigParser
+	ConfigParser.SafeConfigParser = ConfigParser.ConfigParser
 import logging
 import logging.config
 import os

--- a/src/depends.py
+++ b/src/depends.py
@@ -301,7 +301,7 @@ def check_openssl():
                 ' OpenSSL 0.9.8b or later with AES, Elliptic Curves (EC),'
                 ' ECDH, and ECDSA enabled.')
             return False
-        matches = cflags_regex.findall(openssl_cflags)
+        matches = cflags_regex.findall(openssl_cflags.decode())
         if matches:
             logger.error(
                 'This OpenSSL library is missing the following required'

--- a/src/depends.py
+++ b/src/depends.py
@@ -7,10 +7,10 @@ import sys
 
 # Only really old versions of Python don't have sys.hexversion. We don't
 # support them. The logging module was introduced in Python 2.3
-if not hasattr(sys, 'hexversion'):
+if not hasattr(sys, 'hexversion') or sys.hexversion < 0x20300F0:
     sys.exit(
         'Python version: %s\n'
-        'PyBitmessage requires Python 2.7.4 or greater'
+        'PyBitmessage requires Python 2.7.4 or greater (but not Python 3)'
         % sys.version
     )
 
@@ -410,12 +410,19 @@ def check_dependencies(verbose=False, optional=False):
 
     # Python 2.7.4 is the required minimum.
     # (https://bitmessage.org/forum/index.php?topic=4081.0)
+    # Python 3+ is not supported, but it is still useful to provide
+    # information about our other requirements.
     logger.info('Python version: %s', sys.version)
     if sys.hexversion < 0x20704F0:
         logger.error(
             'PyBitmessage requires Python 2.7.4 or greater'
             ' (but not Python 3+)')
         has_all_dependencies = False
+    if sys.hexversion >= 0x3000000:
+        logger.error(
+            'PyBitmessage does not support Python 3+. Python 2.7.4'
+            ' or greater is required. Python 2.7.18 is recommended.')
+        sys.exit()
 
     check_functions = [check_ripemd160, check_sqlite, check_openssl]
     if optional:

--- a/src/depends.py
+++ b/src/depends.py
@@ -7,10 +7,10 @@ import sys
 
 # Only really old versions of Python don't have sys.hexversion. We don't
 # support them. The logging module was introduced in Python 2.3
-if not hasattr(sys, 'hexversion') or sys.hexversion < 0x20300F0:
+if not hasattr(sys, 'hexversion'):
     sys.exit(
         'Python version: %s\n'
-        'PyBitmessage requires Python 2.7.4 or greater (but not Python 3)'
+        'PyBitmessage requires Python 2.7.4 or greater'
         % sys.version
     )
 
@@ -410,19 +410,12 @@ def check_dependencies(verbose=False, optional=False):
 
     # Python 2.7.4 is the required minimum.
     # (https://bitmessage.org/forum/index.php?topic=4081.0)
-    # Python 3+ is not supported, but it is still useful to provide
-    # information about our other requirements.
     logger.info('Python version: %s', sys.version)
     if sys.hexversion < 0x20704F0:
         logger.error(
             'PyBitmessage requires Python 2.7.4 or greater'
             ' (but not Python 3+)')
         has_all_dependencies = False
-    if sys.hexversion >= 0x3000000:
-        logger.error(
-            'PyBitmessage does not support Python 3+. Python 2.7.4'
-            ' or greater is required. Python 2.7.18 is recommended.')
-        sys.exit()
 
     check_functions = [check_ripemd160, check_sqlite, check_openssl]
     if optional:


### PR DESCRIPTION
Few changes to support python 3. Supercedes https://github.com/Bitmessage/PyBitmessage/pull/1745. Works with python 2.7.15 in fedora 29.