### PR TITLE
Handle missing settingsversion.

### DIFF
--- a/src/helper_startup.py
+++ b/src/helper_startup.py
@@ -128,6 +128,8 @@ def loadConfig():
 def updateConfig():
     """Save the config"""
     config = BMConfigParser()
+    if not config.has_option('bitmessagesettings', 'settingsversion'):
+        config.set('bitmessagesettings', 'settingsversion', 1)
     settingsversion = config.getint('bitmessagesettings', 'settingsversion')
     if settingsversion == 1:
         config.set('bitmessagesettings', 'socksproxytype', 'none')


### PR DESCRIPTION
Otherwise I get this with python 3.8.7 when starting BM: TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType' (assuming changes in https://github.com/Bitmessage/PyBitmessage/pull/1746)