### PR TITLE
Rein in 49f9620

### DIFF
--- a/src/helper_random.py
+++ b/src/helper_random.py
@@ -2,11 +2,8 @@
 
 import os
 import random
-import sys
-if sys.version_info[0] == 3:
-    from .pyelliptic.openssl import OpenSSL
-else:
-    from pyelliptic.openssl import OpenSSL
+
+from pyelliptic.openssl import OpenSSL
 
 NoneType = type(None)
 

--- a/src/tests/common.py
+++ b/src/tests/common.py
@@ -22,6 +22,15 @@ def cleanup(home=None, files=_files):
             pass
 
 
+def checkup():
+    """Checkup files in the src dir"""
+    src_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), os.pardir))
+    for f in _files:
+        if os.path.isfile(os.path.join(src_dir, f)):
+            return 'Found application file %s in src dir' % f
+
+
 def skip_python3():
     """Raise unittest.SkipTest() if detected python3"""
     if sys.hexversion >= 0x3000000:

--- a/src/tests/sql/create_function.sql
+++ b/src/tests/sql/create_function.sql
@@ -1,9 +1,0 @@
-CREATE TABLE `testhash` (
-    `addressversion` int DEFAULT NULL,
-    `hash` blob DEFAULT NULL,
-    `address` text DEFAULT NULL,
-    UNIQUE(address) ON CONFLICT IGNORE
-);
-
-INSERT INTO testhash (addressversion, hash) VALUES(4, "21122112211221122112");
-

--- a/src/tests/test_sqlthread.py
+++ b/src/tests/test_sqlthread.py
@@ -1,24 +1,19 @@
-"""
-    Test for sqlThread
-"""
+"""Tests for SQL thread"""
 
 import os
-import unittest
-from ..helper_sql import sqlStoredProcedure, sql_ready, sqlExecute, SqlBulkExecute, sqlQuery, sqlExecuteScript
-from ..class_sqlThread import (sqlThread)
-from ..addresses import encodeAddress
-
+import tempfile
 import threading
+import unittest
+
+os.environ['BITMESSAGE_HOME'] = tempfile.gettempdir()  # noqa:E402
+
+from pybitmessage.helper_sql import sqlQuery, sql_ready, sqlStoredProcedure
+from pybitmessage.class_sqlThread import sqlThread
+from pybitmessage.addresses import encodeAddress
+
 
 class TestSqlThread(unittest.TestCase):
-    """
-        Test case for SQLThread
-    """
-
-    # query file path
-    root_path = os.path.dirname(os.path.dirname(__file__))
-
-
+    """Test case for SQL thread"""
 
     @classmethod
     def setUpClass(cls):
@@ -28,18 +23,6 @@ class TestSqlThread(unittest.TestCase):
         sqlLookup.start()
         sql_ready.wait()
 
-
-    @classmethod
-    def setUp(cls):
-        tables = list(sqlQuery("select name from sqlite_master where type is 'table'"))
-        with SqlBulkExecute() as sql:
-            for q in tables:
-                sql.execute("drop table if exists %s" % q)
-
-    @classmethod
-    def tearDown(cls):
-        pass
-
     @classmethod
     def tearDownClass(cls):
         sqlStoredProcedure('exit')
@@ -47,29 +30,10 @@ class TestSqlThread(unittest.TestCase):
             if thread.name == "SQL":
                 thread.join()
 
-    def initialise_database(self, file):
-        """
-            Initialise DB
-        """
-        with open(os.path.join(self.root_path, "tests/sql/{}.sql".format(file)), 'r') as sql_as_string:
-            # sql_as_string = open(os.path.join(self.root_path, "tests/sql/{}.sql".format(file))).read()
-            sql_as_string = sql_as_string.read()
-        sqlExecuteScript(sql_as_string)
-
     def test_create_function(self):
-        # call create function
+        """Check the result of enaddr function"""
         encoded_str = encodeAddress(4, 1, "21122112211221122112")
 
-        # Initialise Database
-        self.initialise_database("create_function")
-
-        sqlExecute('''INSERT INTO testhash (addressversion, hash) VALUES(4, "21122112211221122112")''')
-        # call function in query
-
-        # sqlExecute('''UPDATE testhash SET address=(enaddr(testhash.addressversion, 1, hash)) WHERE hash=testhash.hash''')
-        sqlExecute('''UPDATE testhash SET address=(enaddr(testhash.addressversion, 1, hash));''')
-
-        # Assertion
-        query = sqlQuery('''select * from testhash;''')
-        self.assertEqual(query[0][-1], encoded_str, "test case fail for create_function")
-        sqlExecute('''DROP TABLE testhash''')
+        query = sqlQuery('SELECT enaddr(4, 1, "21122112211221122112")')
+        self.assertEqual(
+            query[0][-1], encoded_str, "test case fail for create_function")

--- a/src/tests/test_sqlthread.py
+++ b/src/tests/test_sqlthread.py
@@ -1,15 +1,20 @@
 """Tests for SQL thread"""
-
+# flake8: noqa:E402
 import os
 import tempfile
 import threading
 import unittest
 
-os.environ['BITMESSAGE_HOME'] = tempfile.gettempdir()  # noqa:E402
+from .common import skip_python3
 
-from pybitmessage.helper_sql import sqlQuery, sql_ready, sqlStoredProcedure
-from pybitmessage.class_sqlThread import sqlThread
-from pybitmessage.addresses import encodeAddress
+skip_python3()
+
+os.environ['BITMESSAGE_HOME'] = tempfile.gettempdir()
+
+from pybitmessage.helper_sql import (
+    sqlQuery, sql_ready, sqlStoredProcedure)  # noqa:E402
+from pybitmessage.class_sqlThread import sqlThread  # noqa:E402
+from pybitmessage.addresses import encodeAddress  # noqa:E402
 
 
 class TestSqlThread(unittest.TestCase):

--- a/src/tr.py
+++ b/src/tr.py
@@ -3,11 +3,10 @@ Translating text
 """
 import os
 
-import sys
-if sys.version_info[0] == 3:
-    from . import state
-else:
+try:
     import state
+except ImportError:
+    from . import state
 
 
 class translateClass:

--- a/tests.py
+++ b/tests.py
@@ -18,5 +18,17 @@ def unittest_discover():
 
 
 if __name__ == "__main__":
-    result = unittest.TextTestRunner(verbosity=2).run(unittest_discover())
-    sys.exit(not result.wasSuccessful())
+    success = unittest.TextTestRunner(verbosity=2).run(
+        unittest_discover()).wasSuccessful()
+    try:
+        from src.tests import common
+    except ImportError:
+        checkup = False
+        print('ImportError from src.tests')
+    else:
+        checkup = common.checkup()
+
+    if checkup and not success:
+        print(checkup)
+
+    sys.exit(not success or checkup)


### PR DESCRIPTION
Hello!

Here I've left minimum formatting changes to fix issues with windows bundle in my qt5-wip branch (broken: https://travis-ci.org/github/g1itch/PyBitmessage/jobs/771253480, fixed: https://travis-ci.org/github/g1itch/PyBitmessage/jobs/772768459), introduced in 49f9620 and emphasize the issues with style and formatting.

I'm also adding the check for application files in src dir and skipping of `test_sqlthread` for python3 (#1765). I'm tired of deleting keys.dat after running tests ):