### PR TITLE
Fix the issue with python2 in the appimage

### DIFF
--- a/packages/AppImage/PyBitmessage.yml
+++ b/packages/AppImage/PyBitmessage.yml
@@ -1,4 +1,5 @@
 app: PyBitmessage
+binpatch: true
 
 ingredients:
   dist: bionic
@@ -27,3 +28,4 @@ ingredients:
 
 script:
   - cp usr/share/icons/hicolor/scalable/apps/pybitmessage.svg .
+  - mv usr/bin/python2.7 usr/bin/python2

--- a/packages/AppImage/PyBitmessage.yml
+++ b/packages/AppImage/PyBitmessage.yml
@@ -12,9 +12,10 @@ ingredients:
     - python-setuptools
     - python-sip
     - python-six
-    - python-stem
+    - sni-qt
   exclude:
     - libmng2
+    - libncursesw5
     - libqt4-declarative
     - libqt4-designer
     - libqt4-help
@@ -23,6 +24,7 @@ ingredients:
     - libqt4-sql
     - libqt4-xmlpatterns
     - libqtassistantclient4
+    - libreadline7
   debs:
     - ../deb_dist/pybitmessage_*_amd64.deb
 

--- a/src/bitmessageqt/settings.py
+++ b/src/bitmessageqt/settings.py
@@ -57,9 +57,16 @@ class SettingsDialog(QtGui.QDialog):
             pass
         else:
             # Append proxy types defined in plugins
+            # FIXME: this should be a function in mod:`plugin`
             for ep in pkg_resources.iter_entry_points(
                     'bitmessage.proxyconfig'):
-                self.comboBoxProxyType.addItem(ep.name)
+                try:
+                    ep.load()
+                except Exception:  # it should add only functional plugins
+                    # many possible exceptions, which are don't matter
+                    pass
+                else:
+                    self.comboBoxProxyType.addItem(ep.name)
 
         self.lineEditMaxOutboundConnections.setValidator(
             QtGui.QIntValidator(0, 8, self.lineEditMaxOutboundConnections))


### PR DESCRIPTION
Hello!

These changes should fix the issue with python2 and enable tray icon and notifications.

I checked on a fresh Focal installation after applying all updates and `apt install python-is-python3`.