### PR TITLE
Compatibility tests

### DIFF
--- a/src/network/addrthread.py
+++ b/src/network/addrthread.py
@@ -3,12 +3,13 @@ Announce addresses as they are received from other hosts
 """
 from six.moves import queue
 
-
+# magic imports!
 import state
 from helper_random import randomshuffle
-from network.assemble import assemble_addr
+from protocol import assembleAddrMessage
+from queues import addrQueue  # FIXME: init with queue
 from network.connectionpool import BMConnectionPool
-from queues import addrQueue
+
 from threads import StoppableThread
 
 
@@ -41,7 +42,7 @@ class AddrThread(StoppableThread):
                             continue
                         filtered.append((stream, peer, seen))
                     if filtered:
-                        i.append_write_buf(assemble_addr(filtered))
+                        i.append_write_buf(assembleAddrMessage(filtered))
 
             addrQueue.iterate()
             for i in range(len(chunk)):

--- a/src/network/announcethread.py
+++ b/src/network/announcethread.py
@@ -3,10 +3,12 @@ Announce myself (node address)
 """
 import time
 
+# magic imports!
 import state
 from bmconfigparser import BMConfigParser
-from network.assemble import assemble_addr
+from protocol import assembleAddrMessage
 from network.connectionpool import BMConnectionPool
+
 from node import Peer
 from threads import StoppableThread
 
@@ -40,4 +42,4 @@ class AnnounceThread(StoppableThread):
                         BMConfigParser().safeGetInt(
                             'bitmessagesettings', 'port')),
                     time.time())
-                connection.append_write_buf(assemble_addr([addr]))
+                connection.append_write_buf(assembleAddrMessage([addr]))

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -25,7 +25,7 @@ from network.bmobject import (
     BMObjectInvalidError, BMObjectUnwantedStreamError
 )
 from network.constants import (
-    ADDRESS_ALIVE, MAX_MESSAGE_SIZE, MAX_OBJECT_COUNT,
+    ADDRESS_ALIVE, MAX_MESSAGE_SIZE,
     MAX_OBJECT_PAYLOAD_SIZE, MAX_TIME_OFFSET
 )
 from network.dandelion import Dandelion
@@ -350,7 +350,7 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
         """
         items = self.decode_payload_content("l32s")
 
-        if len(items) > MAX_OBJECT_COUNT:
+        if len(items) > protocol.MAX_OBJECT_COUNT:
             logger.error(
                 'Too many items in %sinv message!', 'd' if dandelion else '')
             raise BMProtoExcessiveDataError()

--- a/src/network/constants.py
+++ b/src/network/constants.py
@@ -5,8 +5,6 @@ Network protocol constants
 
 #: address is online if online less than this many seconds ago
 ADDRESS_ALIVE = 10800
-#: protocol specification says max 1000 addresses in one addr command
-MAX_ADDR_COUNT = 1000
 #: ~1.6 MB which is the maximum possible size of an inv message.
 MAX_MESSAGE_SIZE = 1600100
 #: 2**18 = 256kB is the maximum size of an object payload

--- a/src/network/tcp.py
+++ b/src/network/tcp.py
@@ -20,9 +20,7 @@ from bmconfigparser import BMConfigParser
 from helper_random import randomBytes
 from inventory import Inventory
 from network.advanceddispatcher import AdvancedDispatcher
-from network.assemble import assemble_addr
 from network.bmproto import BMProto
-from network.constants import MAX_OBJECT_COUNT
 from network.dandelion import Dandelion
 from network.objectracker import ObjectTracker
 from network.socks4a import Socks4aConnection
@@ -205,7 +203,7 @@ class TCPConnection(BMProto, TLSDispatcher):
             for peer, params in addrs[substream]:
                 templist.append((substream, peer, params["lastseen"]))
         if templist:
-            self.append_write_buf(assemble_addr(templist))
+            self.append_write_buf(protocol.assembleAddrMessage(templist))
 
     def sendBigInv(self):
         """
@@ -244,7 +242,7 @@ class TCPConnection(BMProto, TLSDispatcher):
             # Remove -1 below when sufficient time has passed for users to
             # upgrade to versions of PyBitmessage that accept inv with 50,000
             # items
-            if objectCount >= MAX_OBJECT_COUNT - 1:
+            if objectCount >= protocol.MAX_OBJECT_COUNT - 1:
                 sendChunk()
                 payload = b''
                 objectCount = 0


### PR DESCRIPTION
Hello!

Let's introduce some simple compatibility tests, based on a sample data and well known values. I wish them to cover the implementations of all the functionality, defined in the protocol. So that an alternative implementation can take the samples to check it's compatibility.

It's also helpful for the ongoing python3 porting. Because most of the developers are not writing any tests. And I've already found [a feature](https://github.com/g1itch/PyBitmessage/runs/3116252583?check_suite_focus=true) in `highlevelcrypto` module, which I don't yet understand, but I think that such incompatibilities is better to reveal soon. The test shows that not all the subset of `pyelliptic` is used in `highlevelcrypto` in compatible way with python3.