### PR TITLE
Updated code quality to handle bare except warning changes in class_singleCleaner.py

### DIFF
--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -142,6 +142,15 @@ class BMConfigParser(SafeConfigParser):
                 ValueError, AttributeError):
             return default
 
+    def safeGetFloat(self, section, field, default=0.0):
+        """Return value as float, default on exceptions,
+        0.0 if default missing"""
+        try:
+            return self.getfloat(section, field)
+        except (configparser.NoSectionError, configparser.NoOptionError,
+                ValueError, AttributeError):
+            return default
+
     def safeGet(self, section, option, default=None):
         """Return value as is, default on exceptions, None if default missing"""
         try:

--- a/src/class_singleCleaner.py
+++ b/src/class_singleCleaner.py
@@ -50,14 +50,14 @@ class singleCleaner(StoppableThread):
         timeWeLastClearedInventoryAndPubkeysTables = 0
         try:
             state.maximumLengthOfTimeToBotherResendingMessages = (
-                float(BMConfigParser().get(
-                    'bitmessagesettings', 'stopresendingafterxdays'))
+                BMConfigParser().getfloat(
+                    'bitmessagesettings', 'stopresendingafterxdays')
                 * 24 * 60 * 60
             ) + (
-                float(BMConfigParser().get(
-                    'bitmessagesettings', 'stopresendingafterxmonths'))
+                BMConfigParser().getfloat(
+                    'bitmessagesettings', 'stopresendingafterxmonths')
                 * (60 * 60 * 24 * 365) / 12)
-        except:
+        except:  # noqa:E722
             # Either the user hasn't set stopresendingafterxdays and
             # stopresendingafterxmonths yet or the options are missing
             # from the config file.
@@ -156,8 +156,11 @@ class singleCleaner(StoppableThread):
             # is already present and will not do the POW and send the message
             # because it assumes that it has already done it recently.
             del state.neededPubkeys[address]
-        except:
+        except KeyError:
             pass
+        except RuntimeError:
+            self.logger.warning(
+                "Can't remove %s from neededPubkeys, requesting pubkey will be delayed", address, exc_info=True)
 
         queues.UISignalQueue.put((
             'updateStatusBar',

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -34,3 +34,10 @@ class TestConfig(unittest.TestCase):
             BMConfigParser().safeGetInt('nonexistent', 'nonexistent'), 0)
         self.assertEqual(
             BMConfigParser().safeGetInt('nonexistent', 'nonexistent', 42), 42)
+
+    def test_safeGetFloat(self):
+        """safeGetFloat retuns provided default for nonexistent option or 0.0"""
+        self.assertEqual(
+            BMConfigParser().safeGetFloat('nonexistent', 'nonexistent'), 0.0)
+        self.assertEqual(
+            BMConfigParser().safeGetFloat('nonexistent', 'nonexistent', 42.0), 42.0)


### PR DESCRIPTION
Added KeyError & RuntimeError for `del state.neededPubkeys[address]`
Added BMConfigParser.safeGetFloat method & test case for it
Added bare except ignore warning