### PR TITLE
Trivial changes in bitmessagemain for python3

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -424,9 +424,9 @@ class Main(object):
         sys.stdout.flush()
         sys.stderr.flush()
         if not sys.platform.startswith('win'):
-            si = file(os.devnull, 'r')
-            so = file(os.devnull, 'a+')
-            se = file(os.devnull, 'a+', 0)
+            si = open(os.devnull, 'r')
+            so = open(os.devnull, 'a+')
+            se = open(os.devnull, 'a+', 0)
             os.dup2(si.fileno(), sys.stdin.fileno())
             os.dup2(so.fileno(), sys.stdout.fileno())
             os.dup2(se.fileno(), sys.stderr.fileno())


### PR DESCRIPTION
The `file()` alias for `open()` is obsolete a long ago.

BTW: I use the workflow from my branch `ci-testing` to find such major issues: https://github.com/g1itch/PyBitmessage/runs/3433960729?check_suite_focus=true (the Lint step)