### PR TITLE
Minimal useragent validation

### DIFF
--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -5,6 +5,7 @@ Class BMProto defines bitmessage's network protocol workflow.
 import base64
 import hashlib
 import logging
+import re
 import socket
 import struct
 import time
@@ -535,6 +536,10 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
             return True
         self.append_write_buf(protocol.CreatePacket('verack'))
         self.verackSent = True
+        ua_valid = re.match(
+            r'^/[a-zA-Z]+:[0-9]+\.?[\w\s\(\)\./:;-]*/$', self.userAgent)
+        if not ua_valid:
+            self.userAgent = '/INVALID:0/'
         if not self.isOutbound:
             self.append_write_buf(protocol.assembleVersionMessage(
                 self.destination.host, self.destination.port,


### PR DESCRIPTION
Hello!

This may seem a bit controversial patch, but the Protocol [specifies](https://pybitmessage-test.readthedocs.io/en/doc/useragent.html) the exact format for the user agent which turns out to be a [BIP14](https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) blueprint, and it in turn refers to RFC1945.

