### PR TITLE
Update: Kivy [Sent box screen test]

### DIFF
--- a/src/bitmessagekivy/tests/test_sent_message.py
+++ b/src/bitmessagekivy/tests/test_sent_message.py
@@ -123,9 +123,7 @@ class SendMessage(TeleniumTestProcess):
             Checking Message in Sent Screen after sending a Message.
         """
         # this is for opening Nav drawer
-        self.cli.wait_click('//MDActionTopAppBarButton[@icon=\"menu\"]', timeout=5)
-        # checking state of Nav drawer
-        self.assertExists("//MDNavigationDrawer[@state~=\"open\"]", timeout=5)
+        self.open_side_navbar()
         # Clicking on Sent Tab
         self.cli.wait_click('//NavigationItem[@text=\"Sent\"]', timeout=5)
         # Checking current screen; Sent


### PR DESCRIPTION
Used assertExists instead of assertEqual to check the widget is rendered, used `open` attribute to check dialog box is open or closed, added format() with assertExists.