### PR TITLE
Fix building of the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,4 +6,4 @@ python:
     - requirements: docs/requirements.txt
     - method: setuptools
       path: .
-  system_packages: true
+  system_packages: false

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,8 +201,9 @@ epub_exclude_files = ['search.html']
 autodoc_mock_imports = [
     'debug',
     'pybitmessage.bitmessagekivy',
-    'pybitmessage.bitmessageqt.addressvalidator',
+    'pybitmessage.bitmessageqt.foldertree',
     'pybitmessage.helper_startup',
+    'pybitmessage.mock',
     'pybitmessage.network.httpd',
     'pybitmessage.network.https',
     'ctypes',
@@ -216,9 +217,10 @@ autodoc_mock_imports = [
     'pycanberra',
     'pyopencl',
     'PyQt4',
-    'pyxdg',
+    'PyQt5',
     'qrcode',
     'stem',
+    'xdg',
 ]
 autodoc_member_order = 'bysource'
 
@@ -227,10 +229,11 @@ apidoc_module_dir = '../pybitmessage'
 apidoc_output_dir = 'autodoc'
 apidoc_excluded_paths = [
     'bitmessagekivy', 'build_osx.py',
-    'bitmessageqt/addressvalidator.py', 'bitmessageqt/migrationwizard.py',
-    'bitmessageqt/newaddresswizard.py', 'helper_startup.py',
-    'kivymd', 'main.py', 'navigationdrawer', 'network/http*',
-    'pybitmessage', 'tests', 'version.py'
+    'bitmessageqt/addressvalidator.py', 'bitmessageqt/foldertree.py',
+    'bitmessageqt/migrationwizard.py', 'bitmessageqt/newaddresswizard.py',
+    'helper_startup.py',
+    'kivymd', 'mock', 'main.py', 'navigationdrawer', 'network/http*',
+    'src', 'tests', 'version.py'
 ]
 apidoc_module_first = True
 apidoc_separate_modules = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 m2r
 sphinxcontrib-apidoc
+docutils<=0.17.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from src.version import softwareVersion
 
 
 EXTRAS_REQUIRE = {
-    'docs': ['sphinx', 'sphinxcontrib-apidoc', 'm2r'],
+    'docs': ['sphinx', 'sphinx_rtd_theme'],
     'gir': ['pygobject'],
     'json': ['jsonrpclib'],
     'notify2': ['notify2'],

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,12 @@ commands =
     coverage run -a src/bitmessagemain.py -t
     coverage run -a -m tests
 
+[testenv:py27-doc]
+deps =
+    .[docs]
+    -r docs/requirements.txt
+commands = python setup.py build_sphinx
+
 [testenv:reset]
 commands = coverage erase
 


### PR DESCRIPTION
Hi!

These changes should fix the recent failed builds on RTFD and [empty pages](https://pybitmessage.readthedocs.io/en/v0.6/autodoc/pybitmessage.bitmessageqt.settings.html) under `pybitmessage.bitmessageqt` section.

[Preview](https://pybitmessage-test.readthedocs.io/en/doc-fix/autodoc/pybitmessage.bitmessageqt.settings.html)