### PR TITLE
Docker compatibility for appimage build

### DIFF
--- a/buildscripts/appimage.sh
+++ b/buildscripts/appimage.sh
@@ -9,8 +9,14 @@ chmod a+x pkg2appimage
 
 echo "Building AppImage"
 
-./pkg2appimage packages/AppImage/PyBitmessage.yml
+if grep docker /proc/1/cgroup; then
+    export APPIMAGE_EXTRACT_AND_RUN=1
+    mkdir PyBitmessage
+    wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O PyBitmessage/appimagetool \
+    && chmod +x PyBitmessage/appimagetool
+fi
 
+./pkg2appimage packages/AppImage/PyBitmessage.yml
 
 if [ -f "out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage" ]; then
     echo "Build Successful";

--- a/packages/docker/Dockerfile.bionic
+++ b/packages/docker/Dockerfile.bionic
@@ -20,13 +20,13 @@ RUN apt-get -y install sudo
 
 RUN apt-get install -yq --no-install-suggests --no-install-recommends \
     # travis xenial bionic
-    python-setuptools libssl-dev libpq-dev python-prctl python-dev \
+    python-setuptools libssl-dev libpq-dev python-prctl \
     python-dev python-virtualenv python-pip virtualenv \
     # dpkg
-    python-minimal python-setuptools python-all python openssl libssl-dev \
-    dh-apparmor debhelper dh-python python-msgpack python-qt4 python-stdeb \
+    python-minimal python-all python openssl libssl-dev \
+    dh-apparmor debhelper dh-python python-msgpack python-qt4 git python-stdeb \
     python-all-dev python-crypto python-psutil \
-    fakeroot python-pytest \
+    fakeroot python-pytest python3-wheel \
     # Code quality
     pylint python-pycodestyle python3-pycodestyle pycodestyle python-flake8 \
     python3-flake8 flake8 python-pyflakes python3-pyflakes pyflakes pyflakes3 \
@@ -85,3 +85,20 @@ RUN echo 'buildbot ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER buildbot
 
 ENTRYPOINT /entrypoint.sh "$BUILDMASTER" "$WORKERNAME" "$WORKERPASS"
+
+#################################################################################################
+
+FROM base AS appimage
+
+COPY . /home/builder/src
+
+WORKDIR /home/builder/src
+
+RUN python setup.py -V
+
+RUN python setup.py sdist
+RUN python setup.py --command-packages=stdeb.command bdist_deb
+RUN dpkg-deb -I deb_dist/pybitmessage_0.6.3.2-1_amd64.deb
+
+RUN buildscripts/appimage.sh
+RUN out/PyBitmessage-0.6.3.2.glibc2.15-x86_64.AppImage --appimage-extract-and-run -t


### PR DESCRIPTION
Fixed the appimage.sh, created a dir named PyBitmessage and extracted appimagetool in it, now its working fine and appimage is in /out/ dir