### PR TITLE
A standalone test case for the API thread

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -67,7 +67,7 @@ import time
 from binascii import hexlify, unhexlify
 from struct import pack
 
-from six.moves import configparser, http_client, queue, xmlrpc_server
+from six.moves import configparser, http_client, xmlrpc_server
 
 import defaults
 import helper_inbox
@@ -1455,25 +1455,11 @@ class BMRPCDispatcher(object):
         """Test two numeric params"""
         return a + b
 
-    @testmode('clearUISignalQueue')
-    def HandleclearUISignalQueue(self):
-        """clear UISignalQueue"""
-        queues.UISignalQueue.queue.clear()
-        return "success"
-
     @command('statusBar')
     def HandleStatusBar(self, message):
         """Update GUI statusbar message"""
         queues.UISignalQueue.put(('updateStatusBar', message))
-
-    @testmode('getStatusBar')
-    def HandleGetStatusBar(self):
-        """Get GUI statusbar message"""
-        try:
-            _, data = queues.UISignalQueue.get(block=False)
-        except queue.Empty:
-            return None
-        return data
+        return "success"
 
     @testmode('undeleteMessage')
     def HandleUndeleteMessage(self, msgid):

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -12,7 +12,7 @@ from six.moves import xmlrpc_client  # nosec
 import psutil
 
 from .samples import (
-    sample_seed, sample_deterministic_addr3, sample_deterministic_addr4, sample_statusbar_msg,
+    sample_seed, sample_deterministic_addr3, sample_deterministic_addr4,
     sample_inbox_msg_ids, sample_test_subscription_address, sample_subscription_name)
 
 from .test_process import TestProcessProto
@@ -84,18 +84,6 @@ class TestAPI(TestAPIProto):
         self.assertEqual(
             self.api.test(),
             'API Error 0020: Invalid method: test'
-        )
-
-    def test_statusbar_method(self):
-        """Test statusbar method"""
-        self.api.clearUISignalQueue()
-        self.assertEqual(
-            self.api.statusBar(sample_statusbar_msg),
-            'null'
-        )
-        self.assertEqual(
-            self.api.getStatusBar(),
-            sample_statusbar_msg
         )
 
     def test_message_inbox(self):

--- a/src/tests/test_api_thread.py
+++ b/src/tests/test_api_thread.py
@@ -1,0 +1,53 @@
+import time
+import unittest
+
+from six.moves import xmlrpc_client
+
+from pybitmessage import pathmagic
+
+
+class TestAPIThread(unittest.TestCase):
+    """Test case running the API thread"""
+
+    @classmethod
+    def setUpClass(cls):
+        pathmagic.setup()  # need this because of import state in network ):
+
+        import helper_sql
+        import helper_startup
+        import state
+        from bmconfigparser import BMConfigParser
+
+        class SqlReadyMock(object):
+            @staticmethod
+            def wait():
+                return
+
+        helper_sql.sql_ready = SqlReadyMock
+        cls.state = state
+        helper_startup.loadConfig()
+        # helper_startup.fixSocket()
+        config = BMConfigParser()
+
+        config.set(
+            'bitmessagesettings', 'apiusername', 'username')
+        config.set(
+            'bitmessagesettings', 'apipassword', 'password')
+        config.save()
+
+        import api
+        cls.thread = api.singleAPI()
+        cls.thread.daemon = True
+        cls.thread.start()
+        time.sleep(3)
+        cls.api = xmlrpc_client.ServerProxy(
+            "http://username:password@127.0.0.1:8442/")
+
+    def test_connection(self):
+        """API command 'helloWorld'"""
+        self.assertEqual(
+            self.api.helloWorld('hello', 'world'), 'hello-world')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.state.shutdown = 1

--- a/src/tests/test_api_thread.py
+++ b/src/tests/test_api_thread.py
@@ -1,9 +1,11 @@
 import time
 import unittest
 
-from six.moves import xmlrpc_client
+from six.moves import queue, xmlrpc_client
 
 from pybitmessage import pathmagic
+
+from .samples import sample_statusbar_msg  # any
 
 
 class TestAPIThread(unittest.TestCase):
@@ -15,16 +17,22 @@ class TestAPIThread(unittest.TestCase):
 
         import helper_sql
         import helper_startup
+        import queues
         import state
         from bmconfigparser import BMConfigParser
 
+        #  pylint: disable=too-few-public-methods
         class SqlReadyMock(object):
+            """Mock helper_sql.sql_ready event with dummy class"""
             @staticmethod
             def wait():
+                """Don't wait, return immediately"""
                 return
 
         helper_sql.sql_ready = SqlReadyMock
         cls.state = state
+        cls.queues = queues
+
         helper_startup.loadConfig()
         # helper_startup.fixSocket()
         config = BMConfigParser()
@@ -47,6 +55,19 @@ class TestAPIThread(unittest.TestCase):
         """API command 'helloWorld'"""
         self.assertEqual(
             self.api.helloWorld('hello', 'world'), 'hello-world')
+
+    def test_statusbar(self):
+        """Check UISignalQueue after issuing the 'statusBar' command"""
+        self.queues.UISignalQueue.queue.clear()
+        self.assertEqual(
+            self.api.statusBar(sample_statusbar_msg), 'success')
+        try:
+            cmd, data = self.queues.UISignalQueue.get(block=False)
+        except queue.Empty:
+            self.fail('UISignalQueue is empty!')
+
+        self.assertEqual(cmd, 'updateStatusBar')
+        self.assertEqual(data, sample_statusbar_msg)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Hello!

I've started the standalone testcase for the API thread. IMHO it's the proper way to test the commands, which are not closely tied to the rest parts of PyBM (SQL, AddressGenerator, etc.). And it also brings the `api` module closer to the python3 compatibility.

So far it looks broken in the same way as #1895, but I think that merging the subset of my `network` branch may help better here. I'm going to write some tests for the network soon.
