### PR TITLE
Remove unnecessary newline characters from the error log

### DIFF
--- a/src/shared.py
+++ b/src/shared.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Some shared functions
 
 .. deprecated:: 0.6.3
@@ -139,7 +139,7 @@ def reloadMyAddressHashes():
             else:
                 logger.error(
                     'Error in reloadMyAddressHashes: Can\'t handle'
-                    ' address versions other than 2, 3, or 4.\n'
+                    ' address versions other than 2, 3, or 4.'
                 )
 
     if not keyfileSecure:


### PR DESCRIPTION
Remove any extra blank lines in the log file.
Also remove the BOM from the UTF-8 with BOM.
![08138d14068a1b2de42c923fede1ec4c](https://user-images.githubusercontent.com/8587246/145804253-ad16f8c5-a3b1-4052-89d9-314998b69dab.png)
