### PR TITLE
Fixing the bug with PyQt5 in qidenticon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - build-essential
       - libcap-dev
       - python-qt4
+      - python-pyqt5
       - tor
       - xvfb
 install:

--- a/src/qidenticon.py
+++ b/src/qidenticon.py
@@ -44,7 +44,7 @@ from six.moves import range
 
 try:
     from PyQt5 import QtCore, QtGui
-except ImportError:
+except (ImportError, RuntimeError):
     from PyQt4 import QtCore, QtGui
 
 


### PR DESCRIPTION
Hi!

I'm trying to reproduce the #1901 here. The fix is simply

```diff
diff --git a/src/qidenticon.py b/src/qidenticon.py
index 30b61b9b..13be3578 100644
--- a/src/qidenticon.py
+++ b/src/qidenticon.py
@@ -44,7 +44,7 @@ from six.moves import range
 
 try:
     from PyQt5 import QtCore, QtGui
-except ImportError:
+except (ImportError, RuntimeError):
     from PyQt4 import QtCore, QtGui
 
```