### PR TITLE
Refactor Kivy login screen

### DIFF
--- a/src/bitmessagekivy/kv/login.kv
+++ b/src/bitmessagekivy/kv/login.kv
@@ -80,7 +80,7 @@
                                 icon: "chevron-double-right"
                                 text: app.tr._("Proceed Next")
                                 on_release:
-                                    app.root.ids.scr_mngr.current = 'random'
+                                    app.set_screen('random')
                                 on_press:
                                     app.root.ids.sc7.reset_address_label()
 


### PR DESCRIPTION
Updated `login.kv`, calling a method instead of assigning a screen name.