### PR TITLE
Return support for GTK theme in appimage on distros other than Ubuntu

### DIFF
--- a/packages/AppImage/PyBitmessage.yml
+++ b/packages/AppImage/PyBitmessage.yml
@@ -16,6 +16,7 @@ ingredients:
     - python-six
     - sni-qt
   exclude:
+    - libglib2.0-0
     - libmng2
     - libncursesw5
     - libqt4-declarative
@@ -31,5 +32,6 @@ ingredients:
     - ../deb_dist/pybitmessage_*_amd64.deb
 
 script:
+  - rm -rf usr/share/glib-2.0/schemas
   - cp usr/share/icons/hicolor/scalable/apps/pybitmessage.svg .
   - mv usr/bin/python2.7 usr/bin/python2

--- a/packages/AppImage/PyBitmessage.yml
+++ b/packages/AppImage/PyBitmessage.yml
@@ -16,6 +16,7 @@ ingredients:
     - python-six
     - sni-qt
   exclude:
+    - libdb5.3
     - libglib2.0-0
     - libmng2
     - libncursesw5
@@ -25,6 +26,7 @@ ingredients:
     - libqt4-script
     - libqt4-scripttools
     - libqt4-sql
+    - libqt4-test
     - libqt4-xmlpatterns
     - libqtassistantclient4
     - libreadline7

--- a/packages/docker/Dockerfile.bionic
+++ b/packages/docker/Dockerfile.bionic
@@ -27,7 +27,6 @@ RUN apt-get install -yq --no-install-suggests --no-install-recommends \
     dh-apparmor debhelper dh-python python-msgpack python-qt4 git python-stdeb \
     python-all-dev python-crypto python-psutil \
     fakeroot python-pytest python3-wheel \
-    libglib2.0-dev \
     # Code quality
     pylint python-pycodestyle python3-pycodestyle pycodestyle python-flake8 \
     python3-flake8 flake8 python-pyflakes python3-pyflakes pyflakes pyflakes3 \


### PR DESCRIPTION
Hi!

Apparently https://github.com/Bitmessage/PyBitmessage/issues/1941 was fixed by https://github.com/AppImage/pkg2appimage/commit/1e3ecde6b92ef198405463415b8090a4435d0cb0. But that fix also removed support for the GTK theme on some distros other than Ubuntu.

Here I'm returning the support for GTK theme by explicitly excluding the `libglib2.0-0` deb in an appimage recipe. This also removes other unused debs and the need for libglib2 while building the appimage. It's typical for pkg2appimage recipes, e.g. see: https://github.com/AppImage/pkg2appimage/blob/master/recipes/Quodlibet.yml#L18.