### PR TITLE
Reworked snapcraft recipe

### DIFF
--- a/.buildbot/snap/Dockerfile
+++ b/.buildbot/snap/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:bionic
+
+ENV SKIPCACHE=2022-07-12
+
+RUN apt-get update
+
+RUN apt-get install -yq --no-install-suggests --no-install-recommends snapcraft

--- a/.buildbot/snap/test.sh
+++ b/.buildbot/snap/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cd packages && snapcraft

--- a/packages/snap/snapcraft.yaml
+++ b/packages/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ apps:
 parts:
   pybitmessage:
     # https://wiki.ubuntu.com/snapcraft/parts
-    after: [qt4conf, desktop-qt4, indicator-qt4]
+    after: [qt4conf, desktop-qt4, indicator-qt4, tor]
     source: https://github.com/Bitmessage/PyBitmessage.git
     override-pull: |
       snapcraftctl pull
@@ -38,10 +38,25 @@ parts:
       - jsonrpclib
       - qrcode
       - pyxdg
+      - stem
     stage-packages:
       - python-qt4
       - python-sip
     # parse-info: [setup.py]
+  tor:
+    source: https://dist.torproject.org/tor-0.4.6.9.tar.gz
+    source-checksum: sha256/c7e93380988ce20b82aa19c06cdb2f10302b72cfebec7c15b5b96bcfc94ca9a9
+    source-type: tar
+    plugin: autotools
+    build-packages:
+      - libssl-dev
+      - zlib1g-dev
+    after: [libevent]
+  libevent:
+    source: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
+    source-checksum: sha256/92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+    source-type: tar
+    plugin: autotools
   cleanup:
     after: [pybitmessage]
     plugin: nil

--- a/packages/snap/snapcraft.yaml
+++ b/packages/snap/snapcraft.yaml
@@ -1,0 +1,61 @@
+name: pybitmessage
+base: core18
+grade: devel
+confinement: strict
+summary: Reference client for Bitmessage, a P2P communications protocol
+description: |
+  Bitmessage is a P2P communication protocol used to send encrypted messages to
+  another person or to many subscribers. It is decentralized and trustless,
+  meaning that you need-not inherently trust any entities like root certificate
+  authorities. It uses strong authentication, which means that the sender of a
+  message cannot be spoofed. BM aims to hide metadata from passive
+  eavesdroppers like those ongoing warrantless wiretapping programs. Hence
+  the sender and receiver of Bitmessages stay anonymous.
+adopt-info: pybitmessage
+
+apps:
+  pybitmessage:
+    command: desktop-launch pybitmessage
+    plugs: [desktop, home, network-bind, unity7]
+    desktop: share/applications/pybitmessage.desktop
+    passthrough:
+      autostart: pybitmessage.desktop
+
+parts:
+  pybitmessage:
+    # https://wiki.ubuntu.com/snapcraft/parts
+    after: [qt4conf, desktop-qt4, indicator-qt4]
+    source: https://github.com/Bitmessage/PyBitmessage.git
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version $(git describe --tags --abbrev=0 | tr -d v)
+    plugin: python
+    python-version: python2
+    build-packages:
+      - libssl-dev
+      - python-all-dev
+    python-packages:
+      - jsonrpclib
+      - qrcode
+      - pyxdg
+    stage-packages:
+      - python-qt4
+      - python-sip
+    # parse-info: [setup.py]
+  cleanup:
+    after: [pybitmessage]
+    plugin: nil
+    override-prime: |
+      set -eux
+      sed -ie \
+      's|.*Icon=.*|Icon=${SNAP}/share/icons/hicolor/scalable/apps/pybitmessage.svg|g' \
+      $SNAPCRAFT_PRIME/share/applications/pybitmessage.desktop
+      rm -rf $SNAPCRAFT_PRIME/lib/python2.7/site-packages/pip
+      for DIR in doc man icons themes fonts mime; do
+        rm -rf $SNAPCRAFT_PRIME/usr/share/$DIR/*
+      done
+      LIBS="libQtDeclarative libQtDesigner libQtHelp libQtScript libQtSql \
+        libQtXmlPatterns libdb-5 libicu libgdk libgio libglib libcairo"
+      for LIBGLOB in $LIBS; do
+        rm $SNAPCRAFT_PRIME/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/${LIBGLOB}*
+      done


### PR DESCRIPTION
Hi!

This is the best I could do with the snapcraft recipe so far. The resulting snap is about 45 MB. It doesn't raise the locale related exceptions and shows tray icon and notifications.

GTK themes are still not working, I still couldn't properly connect `gtk-common-themes` and `gnome-3-34-1804` plugs. Not works:

```
plugs:
 gnome-3-34-1804:
 interface: content
 target: gnome-platform
 default-provider: gnome-3-34-1804:gnome-3-34-1804
 gtk-3-themes:
 interface: content
 target: $SNAP/share/themes
 default-provider: gtk-common-themes
 icon-themes:
 interface: content
 target: $SNAP/share/icons
 default-provider: gtk-common-themes
```

Simply adding `libgtk2.0-0` to the `stage-packages` also doesn't help - it becomes more ugly.

It also has an issue with fontconfig like [here](https://github.com/octave-snap/octave-snap/issues/67) which could be fixed by `gnome-3-34-1804` used as extension (`extensions: [gnome-3-34]`), but in that case you need to use `snapcore/snapcraft` as docker base and rewrite qt4 parts.

~~The last commit should be squashed with the first. But while it's not merged you need to drop it to test the snap building.~~ I suspect that `parse-info: [setup.py]` doesn't work at all maybe because of the `setup()` defined under the script condition. Though setup.py is not recommended [in the snapcraft doc](https://snapcraft.io/docs/using-external-metadata#heading--setup-py). It's a shame for the python app to be unable to use a setuptools package ); I thought also about writing a script to generate the appstream xml.