### PR TITLE
Fix doc build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+mistune<=0.8.4
 m2r
 sphinxcontrib-apidoc
 docutils<=0.17.1


### PR DESCRIPTION
Hi!

Apparently rtfd is [also failing](https://readthedocs.org/projects/pybitmessage/builds/17497570/) because of the incompatibility of recent mistune with m2r.