### PR TITLE
Mock multiqueue

### DIFF
--- a/src/mock/kivy_main.py
+++ b/src/mock/kivy_main.py
@@ -1,7 +1,11 @@
 """Mock kivy app with mock threads."""
+# pylint: disable=unused-import
+# flake8: noqa:E401
 
 from pybitmessage import state
 from pybitmessage.bitmessagekivy.mpybit import NavigateApp
+
+import multiqueue
 from class_addressGenerator import FakeAddressGenerator
 
 

--- a/src/mock/multiqueue.py
+++ b/src/mock/multiqueue.py
@@ -1,0 +1,7 @@
+"""
+Mock MultiQueue (just normal Queue)
+"""
+
+from six.moves import queue
+
+MultiQueue = queue.Queue

--- a/src/queues.py
+++ b/src/queues.py
@@ -8,13 +8,7 @@ from six.moves import queue
 try:
     from multiqueue import MultiQueue
 except ImportError:
-    try:
-        from .multiqueue import MultiQueue
-    except ImportError:
-        import sys
-        if 'bitmessagemock' not in sys.modules:
-            raise
-        MultiQueue = queue.Queue
+    from .multiqueue import MultiQueue
 
 
 class ObjectProcessorQueue(queue.Queue):


### PR DESCRIPTION
- kivy mock now uses a mock multiqueue, as the existing code didn't handle all problems. For example, trying to load OpenSSL currently crashes on my M1 Mac, so I can't even add an exception handler to fall back. With this patch, the kivy_mock simply forces a fallback to Queue