### PR TITLE
Finalize invalid stream handling

### DIFF
--- a/src/network/bmobject.py
+++ b/src/network/bmobject.py
@@ -19,12 +19,6 @@ class BMObjectInsufficientPOWError(Exception):
     errorCodes = ("Insufficient proof of work")
 
 
-class BMObjectInvalidDataError(Exception):
-    """Exception indicating the data being parsed
-    does not match the specification."""
-    errorCodes = ("Data invalid")
-
-
 class BMObjectExpiredError(Exception):
     """Exception indicating the object's lifetime has expired."""
     errorCodes = ("Object expired")
@@ -34,12 +28,6 @@ class BMObjectUnwantedStreamError(Exception):
     """Exception indicating the object is in a stream
     we didn't advertise as being interested in."""
     errorCodes = ("Object in unwanted stream")
-
-
-class BMObjectInvalidStreamError(Exception):
-    """Exception indicating the object is in a stream
-    outside of specification."""
-    errorCodes = ("Object in invalid stream")
 
 
 class BMObjectInvalidError(Exception):
@@ -107,14 +95,16 @@ class BMObject(object):  # pylint: disable=too-many-instance-attributes
 
     def checkStream(self):
         """Check if object's stream matches streams we are interested in"""
+        if self.streamNumber < protocol.MIN_VALID_STREAM \
+           or self.streamNumber > protocol.MAX_VALID_STREAM:
+            logger.warning(
+                'The object has invalid stream: %s', self.streamNumber)
+            raise BMObjectInvalidError()
         if self.streamNumber not in state.streamsInWhichIAmParticipating:
             logger.debug(
                 'The streamNumber %i isn\'t one we are interested in.',
                 self.streamNumber)
             raise BMObjectUnwantedStreamError()
-        if self.streamNumber < protocol.MIN_VALID_STREAM \
-           or self.streamNumber > protocol.MAX_VALID_STREAM:
-            raise BMObjectInvalidStreamError()
 
     def checkAlreadyHave(self):
         """

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -21,9 +21,8 @@ from inventory import Inventory
 from network.advanceddispatcher import AdvancedDispatcher
 from network.bmobject import (
     BMObject, BMObjectAlreadyHaveError, BMObjectExpiredError,
-    BMObjectInsufficientPOWError, BMObjectInvalidDataError,
-    BMObjectInvalidError, BMObjectUnwantedStreamError,
-    BMObjectInvalidStreamError
+    BMObjectInsufficientPOWError, BMObjectInvalidError,
+    BMObjectUnwantedStreamError
 )
 from network.constants import (
     ADDRESS_ALIVE, MAX_MESSAGE_SIZE, MAX_OBJECT_COUNT,
@@ -130,8 +129,6 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
                 logger.debug('too much data, skipping')
             except BMObjectInsufficientPOWError:
                 logger.debug('insufficient PoW, skipping')
-            except BMObjectInvalidDataError:
-                logger.debug('object invalid data, skipping')
             except BMObjectExpiredError:
                 logger.debug('object expired, skipping')
             except BMObjectUnwantedStreamError:
@@ -410,9 +407,8 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
                 self.object.inventoryHash, acceptmismatch)
             if not acceptmismatch:
                 raise
-        except BMObjectInvalidStreamError:
-            BMProto.stopDownloadingObject(
-                self.object.inventoryHash)
+        except BMObjectInvalidError:
+            BMProto.stopDownloadingObject(self.object.inventoryHash)
             raise
 
         try:


### PR DESCRIPTION
Hi!

I found the mistake in the last commit: invalid stream is also not in participating streams, but the severe error should be handled first because only one exception is raised there.