### PR TITLE
Redesign testing in docker container

### DIFF
--- a/buildscripts/appimage.sh
+++ b/buildscripts/appimage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Cleanup
 rm -rf PyBitmessage
@@ -18,10 +18,18 @@ fi
 
 ./pkg2appimage packages/AppImage/PyBitmessage.yml
 
-if [ -f "out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage" ]; then
+./pkg2appimage --appimage-extract
+
+. ./squashfs-root/usr/share/pkg2appimage/functions.sh
+
+GLIBC=$(glibc_needed)
+
+VERSION_EXPANDED=${VERSION}.glibc${GLIBC}-${SYSTEM_ARCH}
+
+if [ -f "out/PyBitmessage-${VERSION_EXPANDED}.AppImage" ]; then
     echo "Build Successful";
-    echo "Run out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage";
-    out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage -t
+    echo "Run out/PyBitmessage-${VERSION_EXPANDED}.AppImage";
+    out/PyBitmessage-${VERSION_EXPANDED}.AppImage -t
 else
     echo "Build Failed";
     exit 1

--- a/buildscripts/appimage.sh
+++ b/buildscripts/appimage.sh
@@ -20,7 +20,9 @@ fi
 
 if [ -f "out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage" ]; then
     echo "Build Successful";
-    echo "Run out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage"
+    echo "Run out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage";
+    out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage -t
 else
-    echo "Build Failed"
+    echo "Build Failed";
+    exit 1
 fi

--- a/packages/docker/Dockerfile.bionic
+++ b/packages/docker/Dockerfile.bionic
@@ -57,6 +57,18 @@ ENTRYPOINT ["tox"]
 
 ###############################################################################
 
+FROM base AS snap
+
+RUN apt-get install -yq --no-install-suggests --no-install-recommends snapcraft
+
+COPY . /home/builder/src
+
+WORKDIR /home/builder/src
+
+CMD cd packages && snapcraft && cp *.snap /dist/
+
+###############################################################################
+
 FROM base AS winebuild
 
 RUN dpkg --add-architecture i386

--- a/packages/docker/Dockerfile.bionic
+++ b/packages/docker/Dockerfile.bionic
@@ -20,10 +20,11 @@ COPY . /home/builder/src
 
 WORKDIR /home/builder/src
 
-RUN VERSION=$(python setup.py -V) \
-   && python setup.py sdist \
+CMD python setup.py sdist \
    && python setup.py --command-packages=stdeb.command bdist_deb \
-   && dpkg-deb -I deb_dist/pybitmessage_${VERSION}-1_amd64.deb \
+   && dpkg-deb -I deb_dist/*.deb \
+   && cp deb_dist/*.deb /dist/ \
+   && ln -s /dist out \
    && buildscripts/appimage.sh
 
 ###############################################################################

--- a/packages/docker/Dockerfile.bionic
+++ b/packages/docker/Dockerfile.bionic
@@ -57,6 +57,24 @@ ENTRYPOINT ["tox"]
 
 ###############################################################################
 
+FROM base AS winebuild
+
+RUN dpkg --add-architecture i386
+RUN apt-get update
+
+RUN apt-get install -yq --no-install-suggests --no-install-recommends \
+    mingw-w64 wine-stable winetricks wine32 wine64
+
+COPY . /home/builder/src
+
+WORKDIR /home/builder/src
+
+# xvfb-run -a buildscripts/winbuild.sh
+CMD xvfb-run -a i386 buildscripts/winbuild.sh \
+    && cp packages/pyinstaller/dist/*.exe /dist/
+
+###############################################################################
+
 FROM base AS buildbot 
 
 # cleanup

--- a/packages/docker/Dockerfile.bionic
+++ b/packages/docker/Dockerfile.bionic
@@ -1,61 +1,48 @@
 FROM ubuntu:bionic AS base
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV TRAVIS_SKIP_APT_UPDATE 1
-
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update
 
+# Common apt packages
 RUN apt-get install -yq --no-install-suggests --no-install-recommends \
-    software-properties-common
+    software-properties-common build-essential libcap-dev libssl-dev \
+    python-all-dev python-setuptools wget xvfb
 
-RUN dpkg --add-architecture i386
+###############################################################################
 
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN apt-get -y install sudo
+FROM base AS appimage
 
 RUN apt-get install -yq --no-install-suggests --no-install-recommends \
-    # travis xenial bionic
-    python-setuptools libssl-dev python-prctl \
-    python-dev python-virtualenv python-pip virtualenv \
-    # dpkg
-    python-minimal python-all python openssl libssl-dev \
-    dh-apparmor debhelper dh-python python-msgpack python-qt4 git python-stdeb \
-    python-all-dev python-crypto python-psutil \
-    fakeroot python-pytest python3-wheel \
-    # Code quality
-    pylint python-pycodestyle python3-pycodestyle pycodestyle python-flake8 \
-    python3-flake8 flake8 python-pyflakes python3-pyflakes pyflakes pyflakes3 \
-    curl \
-    # Wine
-    python python-pip wget wine-stable winetricks mingw-w64 wine32 wine64 xvfb \
-    # Buildbot
-    python3-dev libffi-dev python3-setuptools \
-    python3-pip \
-    # python 3.7
-    python3.7 python3.7-dev \
-    # .travis.yml
-    build-essential libcap-dev tor \
-    language-pack-en
+    debhelper dh-apparmor dh-python python-stdeb fakeroot
 
+COPY . /home/builder/src
 
-# cleanup
-RUN rm -rf /var/lib/apt/lists/*
+WORKDIR /home/builder/src
 
-#####################################################################################################
+RUN VERSION=$(python setup.py -V) \
+   && python setup.py sdist \
+   && python setup.py --command-packages=stdeb.command bdist_deb \
+   && dpkg-deb -I deb_dist/pybitmessage_${VERSION}-1_amd64.deb
 
-FROM base AS travis
+RUN buildscripts/appimage.sh
+RUN VERSION=$(python setup.py -V) \
+   && out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage \
+   --appimage-extract-and-run -t
 
-# travis2bash
-RUN wget -O /usr/local/bin/travis2bash.sh https://git.bitmessage.org/Bitmessage/buildbot-scripts/raw/branch/master/travis2bash.sh
-RUN chmod +x /usr/local/bin/travis2bash.sh
+###############################################################################
+
+FROM base AS tox
+
+RUN apt-get install -yq --no-install-suggests --no-install-recommends \
+    language-pack-en \
+    libffi-dev python3-dev python3-pip python3.8 python3.8-dev python3.8-venv \
+    python-msgpack python-pip python-qt4 python-six qt5dxcb-plugin tor
+
+RUN python3.8 -m pip install setuptools wheel
+RUN python3.8 -m pip install --upgrade pip tox virtualenv
 
 RUN useradd -m -U builder
-RUN echo 'builder ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # copy sources
 COPY . /home/builder/src
@@ -63,13 +50,20 @@ RUN chown -R builder.builder /home/builder/src
 
 USER builder
 
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 WORKDIR /home/builder/src
 
-ENTRYPOINT /usr/local/bin/travis2bash.sh
+ENTRYPOINT ["tox"]
 
-#####################################################################################################
+###############################################################################
 
 FROM base AS buildbot 
+
+# cleanup
+RUN rm -rf /var/lib/apt/lists/*
 
 # travis2bash
 RUN wget -O /usr/local/bin/travis2bash.sh https://git.bitmessage.org/Bitmessage/buildbot-scripts/raw/branch/master/travis2bash.sh
@@ -86,22 +80,7 @@ USER buildbot
 
 ENTRYPOINT /entrypoint.sh "$BUILDMASTER" "$WORKERNAME" "$WORKERPASS"
 
-#################################################################################################
-
-FROM base AS appimage
-
-COPY . /home/builder/src
-
-WORKDIR /home/builder/src
-
-RUN VERSION=$(python setup.py -V) \
-   && python setup.py sdist \
-   && python setup.py --command-packages=stdeb.command bdist_deb \
-   && dpkg-deb -I deb_dist/pybitmessage_${VERSION}-1_amd64.deb
-
-RUN buildscripts/appimage.sh
-RUN VERSION=$(python setup.py -V) \
-   && out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage --appimage-extract-and-run -t
+###############################################################################
 
 FROM base AS appandroid
 

--- a/packages/docker/Dockerfile.bionic
+++ b/packages/docker/Dockerfile.bionic
@@ -23,12 +23,8 @@ WORKDIR /home/builder/src
 RUN VERSION=$(python setup.py -V) \
    && python setup.py sdist \
    && python setup.py --command-packages=stdeb.command bdist_deb \
-   && dpkg-deb -I deb_dist/pybitmessage_${VERSION}-1_amd64.deb
-
-RUN buildscripts/appimage.sh
-RUN VERSION=$(python setup.py -V) \
-   && out/PyBitmessage-${VERSION}.glibc2.15-x86_64.AppImage \
-   --appimage-extract-and-run -t
+   && dpkg-deb -I deb_dist/pybitmessage_${VERSION}-1_amd64.deb \
+   && buildscripts/appimage.sh
 
 ###############################################################################
 

--- a/run-tests-in-docker.sh
+++ b/run-tests-in-docker.sh
@@ -1,5 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
-docker build --target travis -t pybm -f packages/docker/Dockerfile.bionic .
-docker run pybm
+DOCKERFILE=packages/docker/Dockerfile.bionic
 
+# explicitly mark appimage stage because it builds in any case
+docker build --target appimage -t pybm/appimage -f $DOCKERFILE .
+
+if [ $? -gt 0 ]; then
+    docker build --no-cache --target appimage -t pybm/appimage -f $DOCKERFILE .
+fi
+
+docker build --target tox -t pybm/tox -f $DOCKERFILE .
+docker run --rm -t pybm/tox


### PR DESCRIPTION
Hi!

I have improved experience of the `run-tests-in-docker.sh`, replaced travis2bash with tox and added building 32bit exe and snap. All the packages are built upon `docker run` and placed into `/dist`, so you can do, e.g.
```
$ ./run-tests-in-docker.sh
$ docker run -it --rm -v "$(pwd)"/dist:/dist pybm/appimage
```

See also: https://git.bitmessage.org/lee.miller/PyBitmessage/issues/5