### PR TITLE
Changes for testing with wine

### DIFF
--- a/buildscripts/winbuild.sh
+++ b/buildscripts/winbuild.sh
@@ -96,16 +96,18 @@ function install_openssl(){
 
 function install_pyinstaller()
 {
-	cd "${BASE_DIR}" || exit 1
-	echo "Installing PyInstaller"
-	if [ "${MACHINE_TYPE}" == 'x86_64' ]; then
-                # 3.6 is the last version to support python 2.7
-		wine python -m pip install -I pyinstaller==3.6
-	else
-		# 3.2.1 is the last version to work on XP
-		# see https://github.com/pyinstaller/pyinstaller/issues/2931
-		wine python -m pip install -I pyinstaller==3.2.1
-	fi
+    cd "${BASE_DIR}" || exit 1
+    echo "Installing PyInstaller"
+    if [ "${MACHINE_TYPE}" == 'x86_64' ]; then
+        # 3.6 is the last version to support python 2.7
+	# but the resulting executable cannot run in wine
+	# see https://github.com/pyinstaller/pyinstaller/issues/4628
+	wine python -m pip install -I pyinstaller==3.5
+    else
+	# 3.2.1 is the last version to work on XP
+	# see https://github.com/pyinstaller/pyinstaller/issues/2931
+	wine python -m pip install -I pyinstaller==3.2.1
+    fi
 }
 
 function install_pip_depends()
@@ -169,11 +171,14 @@ function build_exe(){
 }
 
 function dryrun_exe(){
-       cd "${BASE_DIR}" || exit 1
-       if [ ! "${MACHINE_TYPE}" == 'x86_64' ]; then
-	   local VERSION=$(python setup.py --version)
-	   wine packages/pyinstaller/dist/Bitmessage_x86_$VERSION.exe -t
-       fi
+    cd "${BASE_DIR}" || exit 1
+    local VERSION=$(python setup.py --version)
+    if [ "${MACHINE_TYPE}" == 'x86_64' ]; then
+	EXE=Bitmessage_x64_$VERSION.exe
+    else
+	EXE=Bitmessage_x86_$VERSION.exe
+    fi
+    wine packages/pyinstaller/dist/$EXE -t
 }
 
 # prepare on ubuntu

--- a/packages/pyinstaller/bitmessagemain.spec
+++ b/packages/pyinstaller/bitmessagemain.spec
@@ -7,6 +7,7 @@ import time
 from PyInstaller.utils.hooks import copy_metadata
 
 
+DEBUG = False
 site_root = os.path.abspath(HOMEPATH)
 spec_root = os.path.abspath(SPECPATH)
 arch = 32 if ctypes.sizeof(ctypes.c_voidp) == 4 else 64
@@ -25,6 +26,10 @@ snapshot = False
 
 hookspath = os.path.join(spec_root, 'hooks')
 
+excludes = ['bsddb', 'bz2', 'tcl', 'tk', 'Tkinter', 'tests']
+if not DEBUG:
+    excludes += ['pybitmessage.tests', 'pyelliptic.tests']
+
 a = Analysis(
     [os.path.join(srcPath, 'bitmessagemain.py')],
     datas=[
@@ -39,7 +44,7 @@ a = Analysis(
         'plugins.menu_qrcode', 'plugins.proxyconfig_stem'
     ],
     runtime_hooks=[os.path.join(hookspath, 'pyinstaller_rthook_plugins.py')],
-    excludes=['bsddb', 'bz2', 'tcl', 'tk', 'Tkinter', 'tests']
+    excludes=excludes
 )
 
 
@@ -122,10 +127,10 @@ exe = EXE(
     a.zipfiles,
     a.datas,
     name=fname,
-    debug=False,
+    debug=DEBUG,
     strip=None,
     upx=False,
-    console=False, icon=os.path.join(srcPath, 'images', 'can-icon.ico')
+    console=DEBUG, icon=os.path.join(srcPath, 'images', 'can-icon.ico')
 )
 
 coll = COLLECT(

--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -313,8 +313,11 @@ class Main(object):
                 # pylint: disable=relative-import
                 from tests import core as test_core
             except ImportError:
-                self.stop()
-                return
+                try:
+                    from pybitmessage.tests import core as test_core
+                except ImportError:
+                    self.stop()
+                    return
 
             test_core_result = test_core.run()
             self.stop()

--- a/src/paths.py
+++ b/src/paths.py
@@ -49,11 +49,8 @@ def lookupAppdataFolder():
             sys.exit(
                 'Could not find home folder, please report this message'
                 ' and your OS X version to the BitMessage Github.')
-    elif 'win32' in sys.platform or 'win64' in sys.platform:
-        dataFolder = os.path.join(
-            os.environ['APPDATA'].decode(
-                sys.getfilesystemencoding(), 'ignore'), APPNAME
-        ) + os.path.sep
+    elif sys.platform.startswith('win'):
+        dataFolder = os.path.join(os.environ['APPDATA'], APPNAME) + os.path.sep
     else:
         try:
             dataFolder = os.path.join(os.environ['XDG_CONFIG_HOME'], APPNAME)

--- a/src/pyelliptic/tests/__init__.py
+++ b/src/pyelliptic/tests/__init__.py
@@ -1,0 +1,8 @@
+import sys
+
+if getattr(sys, 'frozen', None):
+    from test_arithmetic import TestArithmetic
+    from test_blindsig import TestBlindSig
+    from test_openssl import TestOpenSSL
+
+    __all__ = ["TestArithmetic", "TestBlindSig", "TestOpenSSL"]

--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,0 +1,13 @@
+import sys
+
+if getattr(sys, 'frozen', None):
+    from test_addresses import TestAddresses
+    from test_crypto import TestHighlevelcrypto
+    from test_l10n import TestL10n
+    from test_packets import TestSerialize
+    from test_protocol import TestProtocol
+
+    __all__ = [
+        "TestAddresses", "TestHighlevelcrypto", "TestL10n",
+        "TestProtocol", "TestSerialize"
+    ]

--- a/src/tests/test_packets.py
+++ b/src/tests/test_packets.py
@@ -1,14 +1,15 @@
+"""Test packets creation and parsing"""
 
-import unittest
 from binascii import unhexlify
 from struct import pack
 
 from pybitmessage import addresses, protocol
 
 from .samples import magic
+from .test_protocol import TestSocketInet
 
 
-class TestSerialize(unittest.TestCase):
+class TestSerialize(TestSocketInet):
     """Test serializing and deserializing packet data"""
 
     def test_varint(self):

--- a/src/tests/test_process.py
+++ b/src/tests/test_process.py
@@ -205,6 +205,8 @@ class TestProcess(TestProcessProto):
         self.assertEqual(
             self.process.environ().get('BITMESSAGE_HOME'), self.home)
 
+    @unittest.skipIf(
+        os.getenv('WINEPREFIX'), "process.connections() doesn't work on wine")
     def test_listening(self):
         """Check that pybitmessage listens on port 8444"""
         for c in self.process.connections():

--- a/src/tests/test_protocol.py
+++ b/src/tests/test_protocol.py
@@ -9,13 +9,17 @@ from pybitmessage import protocol, state
 from pybitmessage.helper_startup import fixSocket
 
 
-class TestProtocol(unittest.TestCase):
-    """Main protocol test case"""
+class TestSocketInet(unittest.TestCase):
+    """Base class for test cases using protocol.encodeHost()"""
 
     @classmethod
     def setUpClass(cls):
         """Execute fixSocket() before start. Only for Windows?"""
         fixSocket()
+
+
+class TestProtocol(TestSocketInet):
+    """Main protocol test case"""
 
     def test_checkIPv4Address(self):
         """Check the results of protocol.checkIPv4Address()"""


### PR DESCRIPTION
Hi!

I've set up testing on wine by bundling selected test cases into exe if DEBUG=True is set in pyinstaller spec.

There are also minor fixes for running standalone tests on Windows:
 * another test which needs `helper_startup.fixSocket()` on Windows,
 * trying to decode str (`os.environ['APPDATA']`) in python3;

and on wine: psutil cannot return `process.connections()`.