### PR TITLE
Add support for portable mode and startonlogon in appimage

### DIFF
--- a/packages/AppImage/PyBitmessage.yml
+++ b/packages/AppImage/PyBitmessage.yml
@@ -14,6 +14,7 @@ ingredients:
     - python-setuptools
     - python-sip
     - python-six
+    - python-xdg
     - sni-qt
   exclude:
     - libdb5.3

--- a/src/paths.py
+++ b/src/paths.py
@@ -21,14 +21,15 @@ def lookupExeFolder():
     if frozen:
         exeFolder = (
             # targetdir/Bitmessage.app/Contents/MacOS/Bitmessage
-            os.path.dirname(sys.executable).split(os.path.sep)[0] + os.path.sep
-            if frozen == "macosx_app" else
-            os.path.dirname(sys.executable) + os.path.sep)
+            os.path.dirname(sys.executable).split(os.path.sep)[0]
+            if frozen == "macosx_app" else os.path.dirname(sys.executable))
+    elif os.getenv('APPIMAGE'):
+        exeFolder = os.path.dirname(os.getenv('APPIMAGE'))
     elif __file__:
-        exeFolder = os.path.dirname(__file__) + os.path.sep
+        exeFolder = os.path.dirname(__file__)
     else:
-        exeFolder = ''
-    return exeFolder
+        return ''
+    return exeFolder + os.path.sep
 
 
 def lookupAppdataFolder():

--- a/src/plugins/desktop_xdg.py
+++ b/src/plugins/desktop_xdg.py
@@ -11,6 +11,9 @@ class DesktopXDG(object):
         menu_entry = Menu.parse().getMenu('Office').getMenuEntry(
             'pybitmessage.desktop')
         self.desktop = menu_entry.DesktopEntry if menu_entry else None
+        appimage = os.getenv('APPIMAGE')
+        if appimage:
+            self.desktop.set('Exec', appimage)
 
     def adjust_startonlogon(self, autostart=False):
         """Configure autostart according to settings"""


### PR DESCRIPTION
Hi!

AppimageKit sets environment variable `APPIMAGE` pointing to the appimage file from which the app started. Based on it I added the support for portable mode and startonlogon in appimage.