### PR TITLE
Fix my silly bug preventing from sending IPv6 addresses in addr messages

### DIFF
--- a/src/network/tcp.py
+++ b/src/network/tcp.py
@@ -194,7 +194,7 @@ class TCPConnection(BMProto, TLSDispatcher):
                         (k, v) for k, v in nodes.iteritems()
                         if v["lastseen"] > int(time.time())
                         - maximumAgeOfNodesThatIAdvertiseToOthers
-                        and v["rating"] >= 0 and len(k.host) <= 22
+                        and v["rating"] >= 0 and not k.host.endswith('.onion')
                     ]
                     # sent 250 only if the remote isn't interested in it
                     elemCount = min(

--- a/src/protocol.py
+++ b/src/protocol.py
@@ -101,7 +101,7 @@ MAX_VALID_STREAM = 2**63 - 1
 
 def encodeHost(host):
     """Encode a given host to be used in low-level socket operations"""
-    if host.find('.onion') > -1:
+    if host.endswith('.onion'):
         return b'\xfd\x87\xd8\x7e\xeb\x43' + base64.b32decode(
             host.split(".")[0], True)
     elif host.find(':') == -1:
@@ -112,7 +112,7 @@ def encodeHost(host):
 
 def networkType(host):
     """Determine if a host is IPv4, IPv6 or an onion address"""
-    if host.find('.onion') > -1:
+    if host.endswith('.onion'):
         return 'onion'
     elif host.find(':') == -1:
         return 'IPv4'


### PR DESCRIPTION
Hi!

I just noticed that I introduced a bug in 453e045ae5c846b00be10fb397ec33907782cb0d.

Together with onion v3 hostnames it filters IPv6 addresses.