### PR TITLE
Remove "@skip_screen_checks" to run the telenium test case

### DIFF
--- a/src/bitmessagekivy/tests/telenium_process.py
+++ b/src/bitmessagekivy/tests/telenium_process.py
@@ -73,13 +73,13 @@ class TeleniumTestProcess(TeleniumTestCase):
             try:
                 if self.cli.getattr(selector, 'current') == value:
                     self.assertTrue(selector, value)
-                    break
+                    return
             except TeleniumHttpException:
                 sleep(0.1)
                 continue
             finally:
-                # Finally Sleep is used to make the menu button funcationlly available for the click process.
-                # (because Transition is little bit slow)
+                # Finally Sleep is used to make the menu button functionally available for the click process.
+                # (because screen transition is little bit slow)
                 sleep(0.2)
         raise AssertionError("Timeout")
 

--- a/src/bitmessagekivy/tests/test_create_random_address.py
+++ b/src/bitmessagekivy/tests/test_create_random_address.py
@@ -3,7 +3,6 @@ from random import choice
 from string import ascii_lowercase
 from telenium.client import TeleniumHttpException
 from .telenium_process import TeleniumTestProcess
-from .common import skip_screen_checks
 from .common import ordered
 
 
@@ -14,7 +13,6 @@ class CreateRandomAddress(TeleniumTestProcess):
     def populate_test_data():
         pass
 
-    @skip_screen_checks
     @ordered
     # This method tests the landing screen when the app runs first time and
     # the landing screen should be "login" where we can create new address
@@ -35,7 +33,6 @@ class CreateRandomAddress(TeleniumTestProcess):
                 self.assertExists("//ScreenManager[@current=\"random\"]", timeout=5)
         self.assertExists("//ScreenManager[@current=\"random\"]", timeout=5)
 
-    @skip_screen_checks
     @ordered
     def test_generate_random_address_label(self):
         """Creating New Adress For New User."""
@@ -60,7 +57,6 @@ class CreateRandomAddress(TeleniumTestProcess):
         # Checking the new address is created
         self.assertExists('//MDList[0]/CustomTwoLineAvatarIconListItem', timeout=10)
 
-    @skip_screen_checks
     @ordered
     def test_set_default_address(self):
         """Select First Address From Drawer-Box"""

--- a/src/bitmessagekivy/tests/test_create_random_address.py
+++ b/src/bitmessagekivy/tests/test_create_random_address.py
@@ -1,8 +1,11 @@
-from time import time
+"""
+    Test for creating new identity
+"""
+
 from random import choice
 from string import ascii_lowercase
-from telenium.client import TeleniumHttpException
 from .telenium_process import TeleniumTestProcess
+from .common import skip_screen_checks
 from .common import ordered
 
 
@@ -22,15 +25,9 @@ class CreateRandomAddress(TeleniumTestProcess):
         self.assert_wait_no_except('//ScreenManager[@current]', timeout=15, value='login')
         # Click on "Proceed Next" Button to "generate random label for address" screen
         # Some widgets cannot renders suddenly and become not functional so we used loop with a timeout.
-        start = time()
-        deadline = start + 2
-        while time() < deadline:
-            try:
-                # Clicking on Proceed Next Button to redirect to "random" screen
-                self.cli.wait_click('//Screen[0]//MDFillRoundFlatIconButton[@text=\"Proceed Next\"]', timeout=5)
-            except TeleniumHttpException:
-                # Checking Current Screen(Random Screen) after Clicking on "Proceed Next" Button
-                self.assertExists("//ScreenManager[@current=\"random\"]", timeout=5)
+        self.assertExists("//Screen[0]//MDFillRoundFlatIconButton[@text=\"Proceed Next\"]", timeout=5)
+        # Clicking on Proceed Next Button to redirect to "random" screen
+        self.cli.wait_click('//Screen[0]//MDFillRoundFlatIconButton[@text=\"Proceed Next\"]', timeout=5)
         self.assertExists("//ScreenManager[@current=\"random\"]", timeout=5)
 
     @ordered
@@ -57,6 +54,7 @@ class CreateRandomAddress(TeleniumTestProcess):
         # Checking the new address is created
         self.assertExists('//MDList[0]/CustomTwoLineAvatarIconListItem', timeout=10)
 
+    @skip_screen_checks
     @ordered
     def test_set_default_address(self):
         """Select First Address From Drawer-Box"""


### PR DESCRIPTION
Remove "@skip_screen_checks" to run the telenium test case for Generating a new identity.
**Expected fail because we have not merged the updated `mpybit.py`. and #1950 myaddress screen**