### PR TITLE
Start the network unbundling

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -235,17 +235,8 @@ class Main(object):
         # start network components if networking is enabled
         if state.enableNetwork:
             start_proxyconfig()
-            network.start()
+            network.start(config, state)
 
-            # Optional components
-            for i in range(config.getint('threads', 'receive')):
-                receiveQueueThread = network.ReceiveQueueThread(i)
-                receiveQueueThread.daemon = True
-                receiveQueueThread.start()
-            if config.safeGetBoolean('bitmessagesettings', 'udp'):
-                state.announceThread = network.AnnounceThread()
-                state.announceThread.daemon = True
-                state.announceThread.start()
             if config.safeGetBoolean('bitmessagesettings', 'upnp'):
                 import upnp
                 upnpThread = upnp.uPnPThread()

--- a/src/class_singleCleaner.py
+++ b/src/class_singleCleaner.py
@@ -108,7 +108,8 @@ class singleCleaner(StoppableThread):
             try:
                 # Cleanup knownnodes and handle possible severe exception
                 # while writing it to disk
-                knownnodes.cleanupKnownNodes()
+                if state.enableNetwork:
+                    knownnodes.cleanupKnownNodes()
             except Exception as err:
                 if "Errno 28" in str(err):
                     self.logger.fatal(

--- a/src/helper_startup.py
+++ b/src/helper_startup.py
@@ -241,8 +241,6 @@ def updateConfig():
                 * defaults.networkDefaultPayloadLengthExtraBytes)
         )
 
-    if not config.has_option('bitmessagesettings', 'onionhostname'):
-        config.set('bitmessagesettings', 'onionhostname', '')
     if not config.has_option('bitmessagesettings', 'onionport'):
         config.set('bitmessagesettings', 'onionport', '8444')
     if not config.has_option('bitmessagesettings', 'onionbindip'):

--- a/src/network/__init__.py
+++ b/src/network/__init__.py
@@ -1,20 +1,47 @@
 """
-Network subsystem packages
+Network subsystem package
 """
-from addrthread import AddrThread
+
 from announcethread import AnnounceThread
 from connectionpool import BMConnectionPool
-from dandelion import Dandelion
-from downloadthread import DownloadThread
-from invthread import InvThread
-from networkthread import BMNetworkThread
 from receivequeuethread import ReceiveQueueThread
 from threads import StoppableThread
-from uploadthread import UploadThread
 
 
 __all__ = [
-    "BMConnectionPool", "Dandelion",
-    "AddrThread", "AnnounceThread", "BMNetworkThread", "DownloadThread",
-    "InvThread", "ReceiveQueueThread", "UploadThread", "StoppableThread"
+    "AnnounceThread", "BMConnectionPool",
+    "ReceiveQueueThread", "StoppableThread"
+    # "AddrThread", "AnnounceThread", "BMNetworkThread", "Dandelion",
+    # "DownloadThread", "InvThread", "UploadThread",
 ]
+
+
+def start():
+    """Start network threads"""
+    from addrthread import AddrThread
+    from dandelion import Dandelion
+    from downloadthread import DownloadThread
+    from invthread import InvThread
+    from networkthread import BMNetworkThread
+    from knownnodes import readKnownNodes
+    from uploadthread import UploadThread
+
+    readKnownNodes()
+    # init, needs to be early because other thread may access it early
+    Dandelion()
+    BMConnectionPool().connectToStream(1)
+    asyncoreThread = BMNetworkThread()
+    asyncoreThread.daemon = True
+    asyncoreThread.start()
+    invThread = InvThread()
+    invThread.daemon = True
+    invThread.start()
+    addrThread = AddrThread()
+    addrThread.daemon = True
+    addrThread.start()
+    downloadThread = DownloadThread()
+    downloadThread.daemon = True
+    downloadThread.start()
+    uploadThread = UploadThread()
+    uploadThread.daemon = True
+    uploadThread.start()

--- a/src/network/__init__.py
+++ b/src/network/__init__.py
@@ -2,17 +2,21 @@
 Network subsystem package
 """
 
-from .connectionpool import BMConnectionPool
+try:
+    from .announcethread import AnnounceThread
+    from .connectionpool import BMConnectionPool
+except ImportError:
+    AnnounceThread = None
+    BMConnectionPool = None
 from .threads import StoppableThread
 
 
-__all__ = ["BMConnectionPool", "StoppableThread"]
+__all__ = ["AnnounceThread", "BMConnectionPool", "StoppableThread"]
 
 
 def start(config, state):
     """Start network threads"""
     from .addrthread import AddrThread
-    from .announcethread import AnnounceThread
     from .dandelion import Dandelion
     from .downloadthread import DownloadThread
     from .invthread import InvThread

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -164,7 +164,7 @@ class BMConnectionPool(object):
     def getListeningIP():
         """What IP are we supposed to be listening on?"""
         if config.safeGet(
-                "bitmessagesettings", "onionhostname").endswith(".onion"):
+                "bitmessagesettings", "onionhostname", "").endswith(".onion"):
             host = config.safeGet(
                 "bitmessagesettings", "onionbindip")
         else:

--- a/src/state.py
+++ b/src/state.py
@@ -40,11 +40,6 @@ maximumNumberOfHalfOpenConnections = 0
 
 maximumLengthOfTimeToBotherResendingMessages = 0
 
-invThread = None
-addrThread = None
-downloadThread = None
-uploadThread = None
-
 ownAddresses = {}
 
 discoveredPeers = {}

--- a/src/tests/partial.py
+++ b/src/tests/partial.py
@@ -1,0 +1,35 @@
+"""A test case for partial run class definition"""
+
+import os
+import sys
+import unittest
+
+from pybitmessage import pathmagic
+
+
+class TestPartialRun(unittest.TestCase):
+    """
+    A base class for test cases running some parts of the app,
+    e.g. separate threads or packages.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dirs = (os.path.abspath(os.curdir), pathmagic.setup())
+
+        import bmconfigparser
+        import state
+
+        from debug import logger  # noqa:F401 pylint: disable=unused-variable
+
+        state.shutdown = 0
+        cls.state = state
+        bmconfigparser.config = cls.config = bmconfigparser.BMConfigParser()
+        cls.config.read()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.state.shutdown = 1
+        # deactivate pathmagic
+        os.chdir(cls.dirs[0])
+        sys.path.remove(cls.dirs[1])

--- a/src/tests/test_network.py
+++ b/src/tests/test_network.py
@@ -1,0 +1,74 @@
+"""Test network module"""
+
+import threading
+import time
+
+from .common import skip_python3
+from .partial import TestPartialRun
+
+skip_python3()
+
+
+class TestNetwork(TestPartialRun):
+    """A test case for running the network subsystem"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestNetwork, cls).setUpClass()
+
+        cls.state.maximumNumberOfHalfOpenConnections = 4
+
+        cls.config.set('bitmessagesettings', 'sendoutgoingconnections', 'True')
+
+        # config variable is still used inside of the network ):
+        import network
+        from network import connectionpool, stats
+
+        # beware of singleton
+        connectionpool.config = cls.config
+        cls.pool = network.BMConnectionPool()
+        cls.stats = stats
+
+        network.start(cls.config, cls.state)
+
+    def test_threads(self):
+        """Ensure all the network threads started"""
+        threads = {
+            "AddrBroadcaster", "Asyncore", "Downloader", "InvBroadcaster",
+            "Uploader"}
+        extra = (
+            self.config.getint('threads', 'receive')
+            + self.config.safeGetBoolean('bitmessagesettings', 'udp'))
+        for thread in threading.enumerate():
+            try:
+                threads.remove(thread.name)
+            except KeyError:
+                extra -= (
+                    thread.name == "Announcer"
+                    or thread.name.startswith("ReceiveQueue_"))
+
+        self.assertEqual(len(threads), 0)
+        self.assertEqual(extra, 0)
+
+    def test_stats(self):
+        """Check that network starts connections and updates stats"""
+        pl = 0
+        for _ in range(30):
+            if pl == 0:
+                pl = len(self.pool)
+            if (
+                self.stats.receivedBytes() > 0 and self.stats.sentBytes() > 0
+                and pl > 0
+                # and len(self.stats.connectedHostsList()) > 0
+            ):
+                break
+            time.sleep(1)
+        else:
+            self.fail('Have not started any connection in 30 sec')
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestNetwork, cls).tearDownClass()
+        for thread in threading.enumerate():
+            if thread.name == "Asyncore":
+                thread.stopThread()


### PR DESCRIPTION
Hi!

This is an initial limited changeset making it possible to start the network subsystem by a single function call, `network.start()` in `bitmessagemain`. The test case essentially mimics the `bitmessagemain` and shows the limitations: `network` is supposed to use `config` and `state` got as the `.start()` arguments and not import from the outer package. 