### PR TITLE
Omit bitmessagekivy in coverage run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ source = src
 omit =
     tests.py
     */tests/*
+    src/bitmessagekivy/*
     src/version.py
     src/fallback/umsgpack/*
 


### PR DESCRIPTION
Hi!

Since kivy tests are not ran from tox, it's better to omit the `bitmessagekivy` package from coverage count to maintain consistent percentage.