### PR TITLE
Extend BMConfigParser.addresses() by a sort kwarg

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -22,6 +22,9 @@ import shared
 import state
 from debug import logger
 from tr import _translate
+from account import (
+    accountClass, getSortedSubscriptions,
+    BMAccount, GatewayAccount, MailchuckAccount, AccountColor)
 from addresses import decodeAddress, addBMIfNotPresent
 from bitmessageui import Ui_MainWindow
 from bmconfigparser import config
@@ -40,9 +43,6 @@ import helper_addressbook
 import helper_search
 import l10n
 from utils import str_broadcast_subscribers, avatarize
-from account import (
-    getSortedAccounts, getSortedSubscriptions, accountClass, BMAccount,
-    GatewayAccount, MailchuckAccount, AccountColor)
 import dialogs
 from network.stats import pendingDownload, pendingUpload
 from uisignaler import UISignaler
@@ -522,7 +522,7 @@ class MyForm(settingsmixin.SMainWindow):
         db = {}
         enabled = {}
 
-        for toAddress in getSortedAccounts():
+        for toAddress in config.addresses(True):
             isEnabled = config.getboolean(
                 toAddress, 'enabled')
             isChan = config.safeGetBoolean(
@@ -640,7 +640,7 @@ class MyForm(settingsmixin.SMainWindow):
 
         # Ask the user if we may delete their old version 1 addresses if they
         # have any.
-        for addressInKeysFile in getSortedAccounts():
+        for addressInKeysFile in config.addresses():
             status, addressVersionNumber, streamNumber, hash = decodeAddress(
                 addressInKeysFile)
             if addressVersionNumber == 1:
@@ -2020,8 +2020,7 @@ class MyForm(settingsmixin.SMainWindow):
             label, address = row
             newRows[address] = [label, AccountMixin.SUBSCRIPTION]
         # chans
-        addresses = getSortedAccounts()
-        for address in addresses:
+        for address in config.addresses(True):
             account = accountClass(address)
             if (account.type == AccountMixin.CHAN and config.safeGetBoolean(address, 'enabled')):
                 newRows[address] = [account.getLabel(), AccountMixin.CHAN]
@@ -2365,7 +2364,9 @@ class MyForm(settingsmixin.SMainWindow):
 
     def rerenderComboBoxSendFrom(self):
         self.ui.comboBoxSendFrom.clear()
-        for addressInKeysFile in getSortedAccounts():
+        for addressInKeysFile in config.addresses(True):
+            # I realize that this is poor programming practice but I don't care.
+            # It's easier for others to read.
             isEnabled = config.getboolean(
                 addressInKeysFile, 'enabled')
             isMaillinglist = config.safeGetBoolean(addressInKeysFile, 'mailinglist')
@@ -2389,7 +2390,7 @@ class MyForm(settingsmixin.SMainWindow):
 
     def rerenderComboBoxSendFromBroadcast(self):
         self.ui.comboBoxSendFromBroadcast.clear()
-        for addressInKeysFile in getSortedAccounts():
+        for addressInKeysFile in config.addresses(True):
             isEnabled = config.getboolean(
                 addressInKeysFile, 'enabled')
             isChan = config.safeGetBoolean(addressInKeysFile, 'chan')

--- a/src/bitmessageqt/account.py
+++ b/src/bitmessageqt/account.py
@@ -25,25 +25,6 @@ from .foldertree import AccountMixin
 from .utils import str_broadcast_subscribers
 
 
-def getSortedAccounts():
-    """Get a sorted list of configSections"""
-
-    configSections = config.addresses()
-    configSections.sort(
-        cmp=lambda x, y: cmp(
-            unicode(
-                config.get(
-                    x,
-                    'label'),
-                'utf-8').lower(),
-            unicode(
-                config.get(
-                    y,
-                    'label'),
-                'utf-8').lower()))
-    return configSections
-
-
 def getSortedSubscriptions(count=False):
     """
     Actually return a grouped dictionary rather than a sorted list

--- a/src/bitmessageqt/address_dialogs.py
+++ b/src/bitmessageqt/address_dialogs.py
@@ -11,7 +11,7 @@ import queues
 import widgets
 from account import AccountMixin, GatewayAccount, MailchuckAccount, accountClass
 from addresses import addBMIfNotPresent, decodeAddress, encodeVarint
-from bmconfigparser import config
+from bmconfigparser import config as global_config
 from inventory import Inventory
 from tr import _translate
 
@@ -121,7 +121,7 @@ class NewAddressDialog(QtGui.QDialog):
 
         # Let's fill out the 'existing address' combo box with addresses
         # from the 'Your Identities' tab.
-        for address in config.addresses(True):
+        for address in global_config.addresses(True):
             self.radioButtonExisting.click()
             self.comboBoxExisting.addItem(address)
         self.groupBoxDeterministic.setHidden(True)
@@ -231,7 +231,7 @@ class SpecialAddressBehaviorDialog(QtGui.QDialog):
     QDialog for special address behaviour (e.g. mailing list functionality)
     """
 
-    def __init__(self, parent=None, config=None):
+    def __init__(self, parent=None, config=global_config):
         super(SpecialAddressBehaviorDialog, self).__init__(parent)
         widgets.load('specialaddressbehavior.ui', self)
         self.address = parent.getCurrentAccount()
@@ -293,7 +293,7 @@ class SpecialAddressBehaviorDialog(QtGui.QDialog):
 
 class EmailGatewayDialog(QtGui.QDialog):
     """QDialog for email gateway control"""
-    def __init__(self, parent, config=None, account=None):
+    def __init__(self, parent, config=global_config, account=None):
         super(EmailGatewayDialog, self).__init__(parent)
         widgets.load('emailgateway.ui', self)
         self.parent = parent

--- a/src/bitmessageqt/address_dialogs.py
+++ b/src/bitmessageqt/address_dialogs.py
@@ -9,8 +9,9 @@ from PyQt4 import QtCore, QtGui
 
 import queues
 import widgets
-from account import AccountMixin, GatewayAccount, MailchuckAccount, accountClass, getSortedAccounts
+from account import AccountMixin, GatewayAccount, MailchuckAccount, accountClass
 from addresses import addBMIfNotPresent, decodeAddress, encodeVarint
+from bmconfigparser import config
 from inventory import Inventory
 from tr import _translate
 
@@ -120,7 +121,7 @@ class NewAddressDialog(QtGui.QDialog):
 
         # Let's fill out the 'existing address' combo box with addresses
         # from the 'Your Identities' tab.
-        for address in getSortedAccounts():
+        for address in config.addresses(True):
             self.radioButtonExisting.click()
             self.comboBoxExisting.addItem(address)
         self.groupBoxDeterministic.setHidden(True)

--- a/src/bitmessageqt/addressvalidator.py
+++ b/src/bitmessageqt/addressvalidator.py
@@ -3,11 +3,12 @@ Address validator module.
 """
 # pylint: disable=too-many-branches,too-many-arguments
 
-from PyQt4 import QtGui
 from Queue import Empty
 
-from account import getSortedAccounts
+from PyQt4 import QtGui
+
 from addresses import decodeAddress, addBMIfNotPresent
+from bmconfigparser import config
 from queues import apiAddressGeneratorReturnQueue, addressGeneratorQueue
 from tr import _translate
 from utils import str_chan
@@ -124,7 +125,7 @@ class AddressPassPhraseValidatorMixin(object):
 
         if self.addressMandatory or address is not None:
             # check if address already exists:
-            if address in getSortedAccounts():
+            if address in config.addresses():
                 self.setError(_translate("AddressValidator", "Address already present as one of your identities."))
                 return (QtGui.QValidator.Intermediate, pos)
 

--- a/src/bitmessageqt/support.py
+++ b/src/bitmessageqt/support.py
@@ -77,7 +77,7 @@ def checkAddressBook(myapp):
 
 
 def checkHasNormalAddress():
-    for address in account.getSortedAccounts():
+    for address in config.addresses():
         acct = account.accountClass(address)
         if acct.type == AccountMixin.NORMAL and config.safeGetBoolean(address, 'enabled'):
             return address

--- a/src/bmconfigparser.py
+++ b/src/bmconfigparser.py
@@ -110,9 +110,12 @@ class BMConfigParser(SafeConfigParser):
         if filenames:
             SafeConfigParser.read(self, filenames)
 
-    def addresses(self):
+    def addresses(self, sort=False):
         """Return a list of local bitmessage addresses (from section labels)"""
-        return [x for x in self.sections() if x.startswith('BM-')]
+        sections = [x for x in self.sections() if x.startswith('BM-')]
+        if sort:
+            sections.sort(key=lambda item: self.get(item, 'label').lower())
+        return sections
 
     def save(self):
         """Save the runtime config onto the filesystem"""

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -75,6 +75,25 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(
             self.config.safeGetFloat('nonexistent', 'nonexistent', 42.0), 42.0)
 
+    def test_set(self):
+        """Check exceptions in set()"""
+        with self.assertRaises(TypeError):
+            self.config.set('bitmessagesettings', 'any', 42)
+        with self.assertRaises(ValueError):
+            self.config.set(
+                'bitmessagesettings', 'maxoutboundconnections', 'none')
+        with self.assertRaises(ValueError):
+            self.config.set(
+                'bitmessagesettings', 'maxoutboundconnections', '9')
+
+    def test_validate(self):
+        """Check validation"""
+        self.assertTrue(
+            self.config.validate('nonexistent', 'nonexistent', 'any'))
+        for val in range(9):
+            self.assertTrue(self.config.validate(
+                'bitmessagesettings', 'maxoutboundconnections', str(val)))
+
     def test_setTemp(self):
         """Set a temporary value and ensure it's returned by get()"""
         self.config.setTemp('bitmessagesettings', 'connect', 'true')
@@ -86,6 +105,16 @@ class TestConfig(unittest.TestCase):
         self.config.read_file(written_fp)
         self.assertIs(
             self.config.safeGetBoolean('bitmessagesettings', 'connect'), False)
+
+    def test_addresses(self):
+        """Check the addresses() method"""
+        self.config.read()
+        for num in range(1, 4):
+            addr = 'BM-%s' % num
+            self.config.add_section(addr)
+            self.config.set(addr, 'label', 'account %s' % (4 - num))
+        self.assertEqual(self.config.addresses(), ['BM-1', 'BM-2', 'BM-3'])
+        self.assertEqual(self.config.addresses(True), ['BM-3', 'BM-2', 'BM-1'])
 
     def test_reset(self):
         """Some logic for testing _reset()"""


### PR DESCRIPTION
Hi!

I propose to extend `bmconfigparser.BMConfigParser.addresses()` by a `sort` kwarg and reuse it in `bitmessageqt` instead of `account.getSortedAccounts()`.

I added tests for the `.addresses()` method and for validation.