### PR TITLE
Handle xdg.Exceptions.ParsingError in desktop_xdg plugin

### DIFF
--- a/src/plugins/desktop_xdg.py
+++ b/src/plugins/desktop_xdg.py
@@ -2,24 +2,23 @@
 
 import os
 
-from xdg import BaseDirectory, Menu
+from xdg import BaseDirectory, Menu, Exceptions
 
 
 class DesktopXDG(object):
     """pyxdg Freedesktop desktop implementation"""
     def __init__(self):
-        menu_entry = Menu.parse().getMenu('Office').getMenuEntry(
-            'pybitmessage.desktop')
-        self.desktop = menu_entry.DesktopEntry if menu_entry else None
+        try:
+            self.desktop = Menu.parse().getMenu('Office').getMenuEntry(
+                'pybitmessage.desktop').DesktopEntry
+        except Exceptions.ParsingError:
+            raise TypeError  # TypeError disables startonlogon
         appimage = os.getenv('APPIMAGE')
         if appimage:
             self.desktop.set('Exec', appimage)
 
     def adjust_startonlogon(self, autostart=False):
         """Configure autostart according to settings"""
-        if not self.desktop:
-            return
-
         autostart_path = os.path.join(
             BaseDirectory.xdg_config_home, 'autostart', 'pybitmessage.desktop')
         if autostart:


### PR DESCRIPTION
Hello!

These changes is a potential fix for https://github.com/Bitmessage/PyBitmessage/issues/2089. Start on logon will be disabled on such distros like the Mint 21 Cinnamon. Need to check.
