### PR TITLE
Add API endpoint to return inbound and outbound connections

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -91,6 +91,7 @@ from bmconfigparser import config
 from debug import logger
 from helper_sql import SqlBulkExecute, sqlExecute, sqlQuery, sqlStoredProcedure, sql_ready
 from inventory import Inventory
+from network import BMConnectionPool
 from network.threads import StoppableThread
 from six.moves import queue
 from version import softwareVersion
@@ -1439,6 +1440,33 @@ class BMRPCDispatcher(object):
             'networkStatus': networkStatus,
             'softwareName': 'PyBitmessage',
             'softwareVersion': softwareVersion
+        }
+
+    @command('listConnections')
+    def HandleListConnections(self):
+        """
+        Returns bitmessage connection information as dict with keys *inbound,
+        *outbound.
+        """
+        inboundConnections = []
+        outboundConnections = []
+        for i in BMConnectionPool().inboundConnections.values():
+            inboundConnections.append({
+                'host': i.destination.host,
+                'port': i.destination.port,
+                'fullyEstablished': i.fullyEstablished,
+                'userAgent': str(i.userAgent)
+            })
+        for i in BMConnectionPool().outboundConnections.values():
+            outboundConnections.append({
+                'host': i.destination.host,
+                'port': i.destination.port,
+                'fullyEstablished': i.fullyEstablished,
+                'userAgent': str(i.userAgent)
+            })
+        return {
+            'inbound': inboundConnections,
+            'outbound': outboundConnections
         }
 
     @command('helloWorld')

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -157,6 +157,12 @@ class TestAPI(TestAPIProto):
         else:
             self.assertGreater(status["networkConnections"], 0)
 
+    def test_listconnections_consistency(self):
+        """Checking the return of API command 'listConnections'"""
+        result = json.loads(self.api.listConnections())
+        self.assertGreaterEqual(len(result["inbound"]), 0)
+        self.assertGreaterEqual(len(result["outbound"]), 0)
+
     def test_list_addresses(self):
         """Checking the return of API command 'listAddresses'"""
         self.assertEqual(


### PR DESCRIPTION
Included is a new API endpoint that returns the inbound and outbound connection information (host, port, and fullyEstablished) as well as the corresponding test in test_api.py.