### PR TITLE
Add label argument to createChan API endpoint

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -779,10 +779,13 @@ class BMRPCDispatcher(object):
         return queues.apiAddressGeneratorReturnQueue.get()
 
     @command('createChan')
-    def HandleCreateChan(self, passphrase):
+    def HandleCreateChan(self, passphrase, label=None):
         """
         Creates a new chan. passphrase must be base64 encoded.
         Returns the corresponding Bitmessage address.
+
+        :param str passphrase: base64 encoded passphrase
+        :param str label: label to set for the chan
         """
 
         passphrase = self._decode(passphrase, "base64")
@@ -791,8 +794,9 @@ class BMRPCDispatcher(object):
         # It would be nice to make the label the passphrase but it is
         # possible that the passphrase contains non-utf-8 characters.
         try:
-            passphrase.decode('utf-8')
-            label = str_chan + ' ' + passphrase
+            if label is None:
+                passphrase.decode('utf-8')
+                label = str_chan + ' ' + passphrase
         except UnicodeDecodeError:
             label = str_chan + ' ' + repr(passphrase)
 


### PR DESCRIPTION
jsonrpclib throws errors sometimes due to the auto-generated labels that are based on the passphrases I set. Example:

```(-32603, '<class 'api.APIError'>:API Error 0021: Unexpected API Failure - bad interpolation variable reference '%(793569%(4"]'')```

This "%(793569%" is a substring of my label that's based on the passphrase and the error prevents any data from being received.

Because the passphrases I use are generated in a specific way, I can't just exclude certain character combinations as possibilities. Therefore, I propose adding the ability to set the label at the time of the chan creation, which will allow me to set the label to something different/safer than the passphrase.