### PR TITLE
Warn user about onionservicesonly setting

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -1758,7 +1758,6 @@ class MyForm(settingsmixin.SMainWindow):
     connected = False
 
     def setStatusIcon(self, color):
-        # print 'setting status icon color'
         _notifications_enabled = not config.getboolean(
             'bitmessagesettings', 'hidetrayconnectionnotifications')
         if color == 'red':
@@ -1771,14 +1770,24 @@ class MyForm(settingsmixin.SMainWindow):
                     'Bitmessage',
                     _translate("MainWindow", "Connection lost"),
                     sound.SOUND_DISCONNECTED)
-            if not config.safeGetBoolean('bitmessagesettings', 'upnp') and \
-                    config.get('bitmessagesettings', 'socksproxytype') == "none":
+            proxy = config.safeGet(
+                'bitmessagesettings', 'socksproxytype', 'none')
+            if proxy == 'none' and not config.safeGetBoolean(
+                    'bitmessagesettings', 'upnp'):
                 self.updateStatusBar(
                     _translate(
                         "MainWindow",
                         "Problems connecting? Try enabling UPnP in the Network"
                         " Settings"
                     ))
+            elif proxy == 'SOCKS5' and config.safeGetBoolean(
+                    'bitmessagesettings', 'onionservicesonly'):
+                self.updateStatusBar((
+                    _translate(
+                        "MainWindow",
+                        "With recent tor you may never connect having"
+                        " 'onionservicesonly' set in your config."), 1
+                ))
             self.connected = False
 
             if self.actionStatus is not None:
@@ -4307,5 +4316,7 @@ def run():
     # only show after wizards and connect dialogs have completed
     if not config.getboolean('bitmessagesettings', 'startintray'):
         myapp.show()
+        QtCore.QTimer.singleShot(
+            30000, lambda: myapp.setStatusIcon(state.statusIconColor))
 
     app.exec_()

--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -1760,10 +1760,13 @@ class MyForm(settingsmixin.SMainWindow):
     def setStatusIcon(self, color):
         _notifications_enabled = not config.getboolean(
             'bitmessagesettings', 'hidetrayconnectionnotifications')
+        if color not in ('red', 'yellow', 'green'):
+            return
+
+        self.pushButtonStatusIcon.setIcon(
+            QtGui.QIcon(":/newPrefix/images/%sicon.png" % color))
+        state.statusIconColor = color
         if color == 'red':
-            self.pushButtonStatusIcon.setIcon(
-                QtGui.QIcon(":/newPrefix/images/redicon.png"))
-            state.statusIconColor = 'red'
             # if the connection is lost then show a notification
             if self.connected and _notifications_enabled:
                 self.notifierShow(
@@ -1794,41 +1797,26 @@ class MyForm(settingsmixin.SMainWindow):
                 self.actionStatus.setText(_translate(
                     "MainWindow", "Not Connected"))
                 self.setTrayIconFile("can-icon-24px-red.png")
-        if color == 'yellow':
-            if self.statusbar.currentMessage() == 'Warning: You are currently not connected. Bitmessage will do the work necessary to send the message but it won\'t send until you connect.':
-                self.statusbar.clearMessage()
-            self.pushButtonStatusIcon.setIcon(
-                QtGui.QIcon(":/newPrefix/images/yellowicon.png"))
-            state.statusIconColor = 'yellow'
-            # if a new connection has been established then show a notification
-            if not self.connected and _notifications_enabled:
-                self.notifierShow(
-                    'Bitmessage',
-                    _translate("MainWindow", "Connected"),
-                    sound.SOUND_CONNECTED)
-            self.connected = True
+            return
 
-            if self.actionStatus is not None:
-                self.actionStatus.setText(_translate(
-                    "MainWindow", "Connected"))
-                self.setTrayIconFile("can-icon-24px-yellow.png")
-        if color == 'green':
-            if self.statusbar.currentMessage() == 'Warning: You are currently not connected. Bitmessage will do the work necessary to send the message but it won\'t send until you connect.':
-                self.statusbar.clearMessage()
-            self.pushButtonStatusIcon.setIcon(
-                QtGui.QIcon(":/newPrefix/images/greenicon.png"))
-            state.statusIconColor = 'green'
-            if not self.connected and _notifications_enabled:
-                self.notifierShow(
-                    'Bitmessage',
-                    _translate("MainWindow", "Connected"),
-                    sound.SOUND_CONNECTION_GREEN)
-            self.connected = True
+        if self.statusbar.currentMessage() == (
+            "Warning: You are currently not connected. Bitmessage will do"
+            " the work necessary to send the message but it won't send"
+            " until you connect."
+        ):
+            self.statusbar.clearMessage()
+        # if a new connection has been established then show a notification
+        if not self.connected and _notifications_enabled:
+            self.notifierShow(
+                'Bitmessage',
+                _translate("MainWindow", "Connected"),
+                sound.SOUND_CONNECTED)
+        self.connected = True
 
-            if self.actionStatus is not None:
-                self.actionStatus.setText(_translate(
-                    "MainWindow", "Connected"))
-                self.setTrayIconFile("can-icon-24px-green.png")
+        if self.actionStatus is not None:
+            self.actionStatus.setText(_translate(
+                "MainWindow", "Connected"))
+            self.setTrayIconFile("can-icon-24px-%s.png" % color)
 
     def initTrayIcon(self, iconFileName, app):
         self.currentTrayIconFileName = iconFileName

--- a/src/bitmessageqt/settings.py
+++ b/src/bitmessageqt/settings.py
@@ -6,6 +6,7 @@ import os
 import sys
 import tempfile
 
+import six
 from PyQt4 import QtCore, QtGui
 
 import debug
@@ -159,6 +160,26 @@ class SettingsDialog(QtGui.QDialog):
             0 if not self._proxy_type
             else self.comboBoxProxyType.findText(self._proxy_type))
         self.comboBoxProxyTypeChanged(self.comboBoxProxyType.currentIndex())
+
+        if self._proxy_type:
+            for node, info in six.iteritems(
+                knownnodes.knownNodes.get(
+                    min(state.streamsInWhichIAmParticipating), [])
+            ):
+                if (
+                    node.host.endswith('.onion') and len(node.host) > 22
+                    and not info.get('self')
+                ):
+                    break
+            else:
+                if self.checkBoxOnionOnly.isChecked():
+                    self.checkBoxOnionOnly.setText(
+                        self.checkBoxOnionOnly.text() + ", " + _translate(
+                            "MainWindow", "may cause connection problems!"))
+                    self.checkBoxOnionOnly.setStyleSheet(
+                        "QCheckBox { color : red; }")
+                else:
+                    self.checkBoxOnionOnly.setEnabled(False)
 
         self.lineEditSocksHostname.setText(
             config.get('bitmessagesettings', 'sockshostname'))


### PR DESCRIPTION
Hi!

I added a statusbar alert about the 'onionservicesonly' setting, like that mentioning UPnP and a comment next to the checkbox where it's set. If user has no v3 onion nodes the checkbox is disabled.