### PR TITLE
Integrate BIGNUM pointers

### DIFF
--- a/src/highlevelcrypto.py
+++ b/src/highlevelcrypto.py
@@ -18,16 +18,13 @@ from bmconfigparser import config
 __all__ = ['encrypt', 'makeCryptor', 'pointMult', 'privToPub', 'sign', 'verify']
 
 
-def makeCryptor(privkey):
+def makeCryptor(privkey, curve='secp256k1'):
     """Return a private `.pyelliptic.ECC` instance"""
     private_key = a.changebase(privkey, 16, 256, minlen=32)
     public_key = pointMult(private_key)
-    privkey_bin = b'\x02\xca\x00\x20' + private_key
-    pubkey_bin = (
-        b'\x02\xca\x00\x20' + public_key[1:-32] + b'\x00\x20' + public_key[-32:]
-    )
     cryptor = pyelliptic.ECC(
-        curve='secp256k1', privkey=privkey_bin, pubkey=pubkey_bin)
+        pubkey_x=public_key[1:-32], pubkey_y=public_key[-32:],
+        raw_privkey=private_key, curve=curve)
     return cryptor
 
 

--- a/src/highlevelcrypto.py
+++ b/src/highlevelcrypto.py
@@ -134,9 +134,6 @@ def pointMult(secret):
             mb = OpenSSL.create_string_buffer(size)
             OpenSSL.i2o_ECPublicKey(k, OpenSSL.byref(OpenSSL.pointer(mb)))
 
-            OpenSSL.EC_POINT_free(pub_key)
-            OpenSSL.BN_free(priv_key)
-            OpenSSL.EC_KEY_free(k)
             return mb.raw
 
         except Exception:
@@ -144,3 +141,7 @@ def pointMult(secret):
             import time
             traceback.print_exc()
             time.sleep(0.2)
+        finally:
+            OpenSSL.EC_POINT_free(pub_key)
+            OpenSSL.BN_free(priv_key)
+            OpenSSL.EC_KEY_free(k)

--- a/src/pyelliptic/ecc.py
+++ b/src/pyelliptic/ecc.py
@@ -18,28 +18,31 @@ class ECC(object):
     Asymmetric encryption with Elliptic Curve Cryptography (ECC)
     ECDH, ECDSA and ECIES
 
+        >>> from binascii import hexlify
         >>> import pyelliptic
 
         >>> alice = pyelliptic.ECC() # default curve: sect283r1
         >>> bob = pyelliptic.ECC(curve='sect571r1')
 
         >>> ciphertext = alice.encrypt("Hello Bob", bob.get_pubkey())
-        >>> print bob.decrypt(ciphertext)
+        >>> print(bob.decrypt(ciphertext))
 
         >>> signature = bob.sign("Hello Alice")
         >>> # alice's job :
-        >>> print pyelliptic.ECC(
-        >>>     pubkey=bob.get_pubkey()).verify(signature, "Hello Alice")
+        >>> print(pyelliptic.ECC(
+        >>>     pubkey=bob.get_pubkey()).verify(signature, "Hello Alice"))
 
         >>> # ERROR !!!
         >>> try:
         >>>     key = alice.get_ecdh_key(bob.get_pubkey())
         >>> except:
-        >>>     print("For ECDH key agreement, the keys must be defined on the same curve !")
+        >>>     print(
+                    "For ECDH key agreement, the keys must be defined"
+                    " on the same curve!")
 
         >>> alice = pyelliptic.ECC(curve='sect571r1')
-        >>> print alice.get_ecdh_key(bob.get_pubkey()).encode('hex')
-        >>> print bob.get_ecdh_key(alice.get_pubkey()).encode('hex')
+        >>> print(hexlify(alice.get_ecdh_key(bob.get_pubkey())))
+        >>> print(hexlify(bob.get_ecdh_key(alice.get_pubkey())))
 
     """
 
@@ -53,7 +56,7 @@ class ECC(object):
             curve='sect283r1',
     ):  # pylint: disable=too-many-arguments
         """
-        For a normal and High level use, specifie pubkey,
+        For a normal and high level use, specifie pubkey,
         privkey (if you need) and the curve
         """
         if isinstance(curve, str):
@@ -87,12 +90,12 @@ class ECC(object):
     @staticmethod
     def get_curves():
         """
-        static method, returns the list of all the curves available
+        Static method, returns the list of all the curves available
         """
         return OpenSSL.curves.keys()
 
     def get_curve(self):
-        """Encryption object from curve name"""
+        """The name of currently used curve"""
         return OpenSSL.get_curve_by_id(self.curve)
 
     def get_curve_id(self):
@@ -157,9 +160,9 @@ class ECC(object):
             key = OpenSSL.EC_KEY_new_by_curve_name(self.curve)
             if key == 0:
                 raise Exception("[OpenSSL] EC_KEY_new_by_curve_name FAIL ...")
-            if (OpenSSL.EC_KEY_generate_key(key)) == 0:
+            if OpenSSL.EC_KEY_generate_key(key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_generate_key FAIL ...")
-            if (OpenSSL.EC_KEY_check_key(key)) == 0:
+            if OpenSSL.EC_KEY_check_key(key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_check_key FAIL ...")
             priv_key = OpenSSL.EC_KEY_get0_private_key(key)
 
@@ -192,7 +195,7 @@ class ECC(object):
     def get_ecdh_key(self, pubkey):
         """
         High level function. Compute public key with the local private key
-        and returns a 512bits shared key
+        and returns a 512bits shared key.
         """
         curve, pubkey_x, pubkey_y, _ = ECC._decode_pubkey(pubkey)
         if curve != self.curve:
@@ -214,16 +217,16 @@ class ECC(object):
             other_group = OpenSSL.EC_KEY_get0_group(other_key)
             other_pub_key = OpenSSL.EC_POINT_new(other_group)
 
-            if (OpenSSL.EC_POINT_set_affine_coordinates_GFp(other_group,
-                                                            other_pub_key,
-                                                            other_pub_key_x,
-                                                            other_pub_key_y,
-                                                            0)) == 0:
+            if OpenSSL.EC_POINT_set_affine_coordinates_GFp(other_group,
+                                                           other_pub_key,
+                                                           other_pub_key_x,
+                                                           other_pub_key_y,
+                                                           0) == 0:
                 raise Exception(
                     "[OpenSSL] EC_POINT_set_affine_coordinates_GFp FAIL ...")
-            if (OpenSSL.EC_KEY_set_public_key(other_key, other_pub_key)) == 0:
+            if OpenSSL.EC_KEY_set_public_key(other_key, other_pub_key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_set_public_key FAIL ...")
-            if (OpenSSL.EC_KEY_check_key(other_key)) == 0:
+            if OpenSSL.EC_KEY_check_key(other_key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_check_key FAIL ...")
 
             own_key = OpenSSL.EC_KEY_new_by_curve_name(self.curve)
@@ -232,7 +235,7 @@ class ECC(object):
             own_priv_key = OpenSSL.BN_bin2bn(
                 self.privkey, len(self.privkey), None)
 
-            if (OpenSSL.EC_KEY_set_private_key(own_key, own_priv_key)) == 0:
+            if OpenSSL.EC_KEY_set_private_key(own_key, own_priv_key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_set_private_key FAIL ...")
 
             if OpenSSL._hexversion > 0x10100000 and not OpenSSL._libreSSL:
@@ -258,7 +261,7 @@ class ECC(object):
     def check_key(self, privkey, pubkey):
         """
         Check the public key and the private key.
-        The private key is optional (replace by None)
+        The private key is optional (replace by None).
         """
         curve, pubkey_x, pubkey_y, _ = ECC._decode_pubkey(pubkey)
         if privkey is None:
@@ -286,22 +289,22 @@ class ECC(object):
             pub_key_y = OpenSSL.BN_bin2bn(pubkey_y, len(pubkey_y), None)
 
             if privkey is not None:
-                if (OpenSSL.EC_KEY_set_private_key(key, priv_key)) == 0:
+                if OpenSSL.EC_KEY_set_private_key(key, priv_key) == 0:
                     raise Exception(
                         "[OpenSSL] EC_KEY_set_private_key FAIL ...")
 
             group = OpenSSL.EC_KEY_get0_group(key)
             pub_key = OpenSSL.EC_POINT_new(group)
 
-            if (OpenSSL.EC_POINT_set_affine_coordinates_GFp(group, pub_key,
-                                                            pub_key_x,
-                                                            pub_key_y,
-                                                            0)) == 0:
+            if OpenSSL.EC_POINT_set_affine_coordinates_GFp(group, pub_key,
+                                                           pub_key_x,
+                                                           pub_key_y,
+                                                           0) == 0:
                 raise Exception(
                     "[OpenSSL] EC_POINT_set_affine_coordinates_GFp FAIL ...")
-            if (OpenSSL.EC_KEY_set_public_key(key, pub_key)) == 0:
+            if OpenSSL.EC_KEY_set_public_key(key, pub_key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_set_public_key FAIL ...")
-            if (OpenSSL.EC_KEY_check_key(key)) == 0:
+            if OpenSSL.EC_KEY_check_key(key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_check_key FAIL ...")
             return 0
 
@@ -339,21 +342,21 @@ class ECC(object):
             pub_key_y = OpenSSL.BN_bin2bn(self.pubkey_y, len(self.pubkey_y),
                                           None)
 
-            if (OpenSSL.EC_KEY_set_private_key(key, priv_key)) == 0:
+            if OpenSSL.EC_KEY_set_private_key(key, priv_key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_set_private_key FAIL ...")
 
             group = OpenSSL.EC_KEY_get0_group(key)
             pub_key = OpenSSL.EC_POINT_new(group)
 
-            if (OpenSSL.EC_POINT_set_affine_coordinates_GFp(group, pub_key,
-                                                            pub_key_x,
-                                                            pub_key_y,
-                                                            0)) == 0:
+            if OpenSSL.EC_POINT_set_affine_coordinates_GFp(group, pub_key,
+                                                           pub_key_x,
+                                                           pub_key_y,
+                                                           0) == 0:
                 raise Exception(
                     "[OpenSSL] EC_POINT_set_affine_coordinates_GFp FAIL ...")
-            if (OpenSSL.EC_KEY_set_public_key(key, pub_key)) == 0:
+            if OpenSSL.EC_KEY_set_public_key(key, pub_key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_set_public_key FAIL ...")
-            if (OpenSSL.EC_KEY_check_key(key)) == 0:
+            if OpenSSL.EC_KEY_check_key(key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_check_key FAIL ...")
 
             if OpenSSL._hexversion > 0x10100000 and not OpenSSL._libreSSL:
@@ -362,12 +365,13 @@ class ECC(object):
                 OpenSSL.EVP_MD_CTX_init(md_ctx)
             OpenSSL.EVP_DigestInit_ex(md_ctx, digest_alg(), None)
 
-            if (OpenSSL.EVP_DigestUpdate(md_ctx, buff, size)) == 0:
+            if OpenSSL.EVP_DigestUpdate(md_ctx, buff, size) == 0:
                 raise Exception("[OpenSSL] EVP_DigestUpdate FAIL ...")
             OpenSSL.EVP_DigestFinal_ex(md_ctx, digest, dgst_len)
             OpenSSL.ECDSA_sign(0, digest, dgst_len.contents, sig, siglen, key)
-            if (OpenSSL.ECDSA_verify(0, digest, dgst_len.contents, sig,
-                                     siglen.contents, key)) != 1:
+            if OpenSSL.ECDSA_verify(
+                0, digest, dgst_len.contents, sig, siglen.contents, key
+            ) != 1:
                 raise Exception("[OpenSSL] ECDSA_verify FAIL ...")
 
             return sig.raw[:siglen.contents.value]
@@ -386,7 +390,7 @@ class ECC(object):
     def verify(self, sig, inputb, digest_alg=OpenSSL.digest_ecdsa_sha1):
         """
         Verify the signature with the input and the local public key.
-        Returns a boolean
+        Returns a boolean.
         """
         try:
             bsig = OpenSSL.malloc(sig, len(sig))
@@ -409,22 +413,22 @@ class ECC(object):
             group = OpenSSL.EC_KEY_get0_group(key)
             pub_key = OpenSSL.EC_POINT_new(group)
 
-            if (OpenSSL.EC_POINT_set_affine_coordinates_GFp(group, pub_key,
-                                                            pub_key_x,
-                                                            pub_key_y,
-                                                            0)) == 0:
+            if OpenSSL.EC_POINT_set_affine_coordinates_GFp(group, pub_key,
+                                                           pub_key_x,
+                                                           pub_key_y,
+                                                           0) == 0:
                 raise Exception(
                     "[OpenSSL] EC_POINT_set_affine_coordinates_GFp FAIL ...")
-            if (OpenSSL.EC_KEY_set_public_key(key, pub_key)) == 0:
+            if OpenSSL.EC_KEY_set_public_key(key, pub_key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_set_public_key FAIL ...")
-            if (OpenSSL.EC_KEY_check_key(key)) == 0:
+            if OpenSSL.EC_KEY_check_key(key) == 0:
                 raise Exception("[OpenSSL] EC_KEY_check_key FAIL ...")
             if OpenSSL._hexversion > 0x10100000 and not OpenSSL._libreSSL:
                 OpenSSL.EVP_MD_CTX_new(md_ctx)
             else:
                 OpenSSL.EVP_MD_CTX_init(md_ctx)
             OpenSSL.EVP_DigestInit_ex(md_ctx, digest_alg(), None)
-            if (OpenSSL.EVP_DigestUpdate(md_ctx, binputb, len(inputb))) == 0:
+            if OpenSSL.EVP_DigestUpdate(md_ctx, binputb, len(inputb)) == 0:
                 raise Exception("[OpenSSL] EVP_DigestUpdate FAIL ...")
 
             OpenSSL.EVP_DigestFinal_ex(md_ctx, digest, dgst_len)
@@ -468,7 +472,7 @@ class ECC(object):
             ephemcurve=None,
             ciphername='aes-256-cbc',
     ):  # pylint: disable=too-many-arguments
-        """ECHD encryption, keys supplied in binary data format"""
+        """ECDH encryption, keys supplied in binary data format"""
 
         if ephemcurve is None:
             ephemcurve = curve
@@ -476,7 +480,7 @@ class ECC(object):
         key = sha512(ephem.raw_get_ecdh_key(pubkey_x, pubkey_y)).digest()
         key_e, key_m = key[:32], key[32:]
         pubkey = ephem.get_pubkey()
-        _iv = OpenSSL.rand(OpenSSL.get_cipher(ciphername).get_blocksize())
+        _iv = Cipher.gen_IV(ciphername)
         ctx = Cipher(key_e, _iv, 1, ciphername)
         ciphertext = _iv + pubkey + ctx.ciphering(data)
         mac = hmac_sha256(key_m, ciphertext)

--- a/src/pyelliptic/eccblind.py
+++ b/src/pyelliptic/eccblind.py
@@ -109,7 +109,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
         """
         ECC inversion
         """
-        inverse = OpenSSL.BN_mod_inverse(0, a, self.n, self.ctx)
+        inverse = OpenSSL.BN_mod_inverse(None, a, self.n, self.ctx)
         return inverse
 
     def ec_gen_keypair(self):
@@ -119,7 +119,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
         """
         d = self.ec_get_random()
         Q = OpenSSL.EC_POINT_new(self.group)
-        OpenSSL.EC_POINT_mul(self.group, Q, d, 0, 0, 0)
+        OpenSSL.EC_POINT_mul(self.group, Q, d, None, None, None)
         return (d, Q)
 
     def ec_Ftor(self, F):
@@ -139,7 +139,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
             x = OpenSSL.BN_new()
             y = OpenSSL.BN_new()
             OpenSSL.EC_POINT_get_affine_coordinates(
-                self.group, point, x, y, 0)
+                self.group, point, x, y, None)
             y_byte = (OpenSSL.BN_is_odd(y) & Y_BIT) | COMPRESSED_BIT
             l_ = OpenSSL.BN_num_bytes(self.n)
             try:
@@ -160,7 +160,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
     def _ec_point_deserialize(self, data):
         """Make a string into an EC point"""
         y_bit, x_raw = unpack(EC, data)
-        x = OpenSSL.BN_bin2bn(x_raw, OpenSSL.BN_num_bytes(self.n), 0)
+        x = OpenSSL.BN_bin2bn(x_raw, OpenSSL.BN_num_bytes(self.n), None)
         y_bit &= Y_BIT
         retval = OpenSSL.EC_POINT_new(self.group)
         OpenSSL.EC_POINT_set_compressed_coordinates(self.group,
@@ -184,7 +184,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
 
     def _bn_deserialize(self, data):
         """Make a BigNum out of string"""
-        x = OpenSSL.BN_bin2bn(data, OpenSSL.BN_num_bytes(self.n), 0)
+        x = OpenSSL.BN_bin2bn(data, OpenSSL.BN_num_bytes(self.n), None)
         return x
 
     def _init_privkey(self, privkey):
@@ -261,7 +261,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
 
         # R = kG
         self.R = OpenSSL.EC_POINT_new(self.group)
-        OpenSSL.EC_POINT_mul(self.group, self.R, self.k, 0, 0, 0)
+        OpenSSL.EC_POINT_mul(self.group, self.R, self.k, None, None, None)
 
         return self._ec_point_serialize(self.R)
 
@@ -286,17 +286,18 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
 
             # F = b^-1 * R...
             self.binv = self.ec_invert(self.b)
-            OpenSSL.EC_POINT_mul(self.group, temp, 0, self.R, self.binv, 0)
+            OpenSSL.EC_POINT_mul(self.group, temp, None, self.R, self.binv,
+                                 None)
             OpenSSL.EC_POINT_copy(self.F, temp)
 
             # ... + a*b^-1 * Q...
             OpenSSL.BN_mul(abinv, self.a, self.binv, self.ctx)
-            OpenSSL.EC_POINT_mul(self.group, temp, 0, self.Q, abinv, 0)
-            OpenSSL.EC_POINT_add(self.group, self.F, self.F, temp, 0)
+            OpenSSL.EC_POINT_mul(self.group, temp, None, self.Q, abinv, None)
+            OpenSSL.EC_POINT_add(self.group, self.F, self.F, temp, None)
 
             # ... + c*G
-            OpenSSL.EC_POINT_mul(self.group, temp, 0, self.G, self.c, 0)
-            OpenSSL.EC_POINT_add(self.group, self.F, self.F, temp, 0)
+            OpenSSL.EC_POINT_mul(self.group, temp, None, self.G, self.c, None)
+            OpenSSL.EC_POINT_add(self.group, self.F, self.F, temp, None)
 
         # F = (x0, y0)
         self.r = self.ec_Ftor(self.F)
@@ -355,10 +356,10 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
         lhs = OpenSSL.EC_POINT_new(self.group)
         rhs = OpenSSL.EC_POINT_new(self.group)
 
-        OpenSSL.EC_POINT_mul(self.group, lhs, s, 0, 0, 0)
+        OpenSSL.EC_POINT_mul(self.group, lhs, s, None, None, None)
 
-        OpenSSL.EC_POINT_mul(self.group, rhs, 0, self.Q, self.m, 0)
-        OpenSSL.EC_POINT_mul(self.group, rhs, 0, rhs, self.r, 0)
+        OpenSSL.EC_POINT_mul(self.group, rhs, None, self.Q, self.m, None)
+        OpenSSL.EC_POINT_mul(self.group, rhs, None, rhs, self.r, None)
         OpenSSL.EC_POINT_add(self.group, rhs, rhs, self.F, self.ctx)
 
         retval = OpenSSL.EC_POINT_cmp(self.group, lhs, rhs, self.ctx)

--- a/src/pyelliptic/openssl.py
+++ b/src/pyelliptic/openssl.py
@@ -392,7 +392,7 @@ class _OpenSSL(object):
         self.EVP_DigestUpdate = self._lib.EVP_DigestUpdate
         self.EVP_DigestUpdate.restype = ctypes.c_int
         self.EVP_DigestUpdate.argtypes = [ctypes.c_void_p,
-                                          ctypes.c_void_p, ctypes.c_int]
+                                          ctypes.c_void_p, ctypes.c_size_t]
 
         self.EVP_DigestFinal = self._lib.EVP_DigestFinal
         self.EVP_DigestFinal.restype = ctypes.c_int
@@ -472,7 +472,7 @@ class _OpenSSL(object):
         self.HMAC = self._lib.HMAC
         self.HMAC.restype = ctypes.c_void_p
         self.HMAC.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int,
-                              ctypes.c_void_p, ctypes.c_int,
+                              ctypes.c_void_p, ctypes.c_size_t,
                               ctypes.c_void_p, ctypes.c_void_p]
 
         try:

--- a/src/pyelliptic/openssl.py
+++ b/src/pyelliptic/openssl.py
@@ -72,6 +72,29 @@ def get_version(library):
     return (version, hexversion, cflags)
 
 
+class BIGNUM(ctypes.Structure):  # pylint: disable=too-few-public-methods
+    """OpenSSL's BIGNUM struct"""
+    _fields_ = [
+        ('d', ctypes.POINTER(ctypes.c_ulong)),
+        ('top', ctypes.c_int),
+        ('dmax', ctypes.c_int),
+        ('neg', ctypes.c_int),
+        ('flags', ctypes.c_int),
+    ]
+
+
+class EC_POINT(ctypes.Structure):  # pylint: disable=too-few-public-methods
+    """OpenSSL's EC_POINT struct"""
+    _fields_ = [
+        ('meth', ctypes.c_void_p),
+        ('curve_name', ctypes.c_int),
+        ('X', ctypes.POINTER(BIGNUM)),
+        ('Y', ctypes.POINTER(BIGNUM)),
+        ('Z', ctypes.POINTER(BIGNUM)),
+        ('Z_is_one', ctypes.c_int),
+    ]
+
+
 class _OpenSSL(object):
     """
     Wrapper for OpenSSL using ctypes
@@ -91,38 +114,38 @@ class _OpenSSL(object):
         self.create_string_buffer = ctypes.create_string_buffer
 
         self.BN_new = self._lib.BN_new
-        self.BN_new.restype = ctypes.c_void_p
+        self.BN_new.restype = ctypes.POINTER(BIGNUM)
         self.BN_new.argtypes = []
 
         self.BN_free = self._lib.BN_free
         self.BN_free.restype = None
-        self.BN_free.argtypes = [ctypes.c_void_p]
+        self.BN_free.argtypes = [ctypes.POINTER(BIGNUM)]
 
         self.BN_clear_free = self._lib.BN_clear_free
         self.BN_clear_free.restype = None
-        self.BN_clear_free.argtypes = [ctypes.c_void_p]
+        self.BN_clear_free.argtypes = [ctypes.POINTER(BIGNUM)]
 
         self.BN_num_bits = self._lib.BN_num_bits
         self.BN_num_bits.restype = ctypes.c_int
-        self.BN_num_bits.argtypes = [ctypes.c_void_p]
+        self.BN_num_bits.argtypes = [ctypes.POINTER(BIGNUM)]
 
         self.BN_bn2bin = self._lib.BN_bn2bin
         self.BN_bn2bin.restype = ctypes.c_int
-        self.BN_bn2bin.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        self.BN_bn2bin.argtypes = [ctypes.POINTER(BIGNUM), ctypes.c_void_p]
 
         try:
             self.BN_bn2binpad = self._lib.BN_bn2binpad
             self.BN_bn2binpad.restype = ctypes.c_int
-            self.BN_bn2binpad.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+            self.BN_bn2binpad.argtypes = [ctypes.POINTER(BIGNUM), ctypes.c_void_p,
                                           ctypes.c_int]
         except AttributeError:
             # optional, we have a workaround
             pass
 
         self.BN_bin2bn = self._lib.BN_bin2bn
-        self.BN_bin2bn.restype = ctypes.c_void_p
+        self.BN_bin2bn.restype = ctypes.POINTER(BIGNUM)
         self.BN_bin2bn.argtypes = [ctypes.c_void_p, ctypes.c_int,
-                                   ctypes.c_void_p]
+                                   ctypes.POINTER(BIGNUM)]
 
         self.EC_KEY_free = self._lib.EC_KEY_free
         self.EC_KEY_free.restype = None
@@ -141,11 +164,11 @@ class _OpenSSL(object):
         self.EC_KEY_check_key.argtypes = [ctypes.c_void_p]
 
         self.EC_KEY_get0_private_key = self._lib.EC_KEY_get0_private_key
-        self.EC_KEY_get0_private_key.restype = ctypes.c_void_p
+        self.EC_KEY_get0_private_key.restype = ctypes.POINTER(BIGNUM)
         self.EC_KEY_get0_private_key.argtypes = [ctypes.c_void_p]
 
         self.EC_KEY_get0_public_key = self._lib.EC_KEY_get0_public_key
-        self.EC_KEY_get0_public_key.restype = ctypes.c_void_p
+        self.EC_KEY_get0_public_key.restype = ctypes.POINTER(EC_POINT)
         self.EC_KEY_get0_public_key.argtypes = [ctypes.c_void_p]
 
         self.EC_KEY_get0_group = self._lib.EC_KEY_get0_group
@@ -156,9 +179,9 @@ class _OpenSSL(object):
             self._lib.EC_POINT_get_affine_coordinates_GFp
         self.EC_POINT_get_affine_coordinates_GFp.restype = ctypes.c_int
         self.EC_POINT_get_affine_coordinates_GFp.argtypes = [ctypes.c_void_p,
-                                                             ctypes.c_void_p,
-                                                             ctypes.c_void_p,
-                                                             ctypes.c_void_p,
+                                                             ctypes.POINTER(EC_POINT),
+                                                             ctypes.POINTER(BIGNUM),
+                                                             ctypes.POINTER(BIGNUM),
                                                              ctypes.c_void_p]
 
         try:
@@ -170,20 +193,20 @@ class _OpenSSL(object):
                 self._lib.EC_POINT_get_affine_coordinates_GF2m
         self.EC_POINT_get_affine_coordinates.restype = ctypes.c_int
         self.EC_POINT_get_affine_coordinates.argtypes = [ctypes.c_void_p,
-                                                         ctypes.c_void_p,
-                                                         ctypes.c_void_p,
-                                                         ctypes.c_void_p,
+                                                         ctypes.POINTER(EC_POINT),
+                                                         ctypes.POINTER(BIGNUM),
+                                                         ctypes.POINTER(BIGNUM),
                                                          ctypes.c_void_p]
 
         self.EC_KEY_set_private_key = self._lib.EC_KEY_set_private_key
         self.EC_KEY_set_private_key.restype = ctypes.c_int
         self.EC_KEY_set_private_key.argtypes = [ctypes.c_void_p,
-                                                ctypes.c_void_p]
+                                                ctypes.POINTER(BIGNUM)]
 
         self.EC_KEY_set_public_key = self._lib.EC_KEY_set_public_key
         self.EC_KEY_set_public_key.restype = ctypes.c_int
         self.EC_KEY_set_public_key.argtypes = [ctypes.c_void_p,
-                                               ctypes.c_void_p]
+                                               ctypes.POINTER(EC_POINT)]
 
         self.EC_KEY_set_group = self._lib.EC_KEY_set_group
         self.EC_KEY_set_group.restype = ctypes.c_int
@@ -194,9 +217,9 @@ class _OpenSSL(object):
             self._lib.EC_POINT_set_affine_coordinates_GFp
         self.EC_POINT_set_affine_coordinates_GFp.restype = ctypes.c_int
         self.EC_POINT_set_affine_coordinates_GFp.argtypes = [ctypes.c_void_p,
-                                                             ctypes.c_void_p,
-                                                             ctypes.c_void_p,
-                                                             ctypes.c_void_p,
+                                                             ctypes.POINTER(EC_POINT),
+                                                             ctypes.POINTER(BIGNUM),
+                                                             ctypes.POINTER(BIGNUM),
                                                              ctypes.c_void_p]
 
         try:
@@ -208,9 +231,9 @@ class _OpenSSL(object):
                 self._lib.EC_POINT_set_affine_coordinates_GF2m
         self.EC_POINT_set_affine_coordinates.restype = ctypes.c_int
         self.EC_POINT_set_affine_coordinates.argtypes = [ctypes.c_void_p,
-                                                         ctypes.c_void_p,
-                                                         ctypes.c_void_p,
-                                                         ctypes.c_void_p,
+                                                         ctypes.POINTER(EC_POINT),
+                                                         ctypes.POINTER(BIGNUM),
+                                                         ctypes.POINTER(BIGNUM),
                                                          ctypes.c_void_p]
 
         try:
@@ -219,38 +242,39 @@ class _OpenSSL(object):
         except AttributeError:
             # OpenSSL docs say only use this for backwards compatibility
             self.EC_POINT_set_compressed_coordinates = \
-                self._lib.EC_POINT_set_compressed_coordinates_GF2m
+                self._lib.EC_POINT_set_compressed_coordinates_GFp
         self.EC_POINT_set_compressed_coordinates.restype = ctypes.c_int
         self.EC_POINT_set_compressed_coordinates.argtypes = [ctypes.c_void_p,
-                                                             ctypes.c_void_p,
-                                                             ctypes.c_void_p,
+                                                             ctypes.POINTER(EC_POINT),
+                                                             ctypes.POINTER(BIGNUM),
                                                              ctypes.c_int,
                                                              ctypes.c_void_p]
 
         self.EC_POINT_new = self._lib.EC_POINT_new
-        self.EC_POINT_new.restype = ctypes.c_void_p
+        self.EC_POINT_new.restype = ctypes.POINTER(EC_POINT)
         self.EC_POINT_new.argtypes = [ctypes.c_void_p]
 
         self.EC_POINT_free = self._lib.EC_POINT_free
         self.EC_POINT_free.restype = None
-        self.EC_POINT_free.argtypes = [ctypes.c_void_p]
+        self.EC_POINT_free.argtypes = [ctypes.POINTER(EC_POINT)]
 
         self.BN_CTX_free = self._lib.BN_CTX_free
         self.BN_CTX_free.restype = None
         self.BN_CTX_free.argtypes = [ctypes.c_void_p]
 
         self.EC_POINT_mul = self._lib.EC_POINT_mul
-        self.EC_POINT_mul.restype = None
+        self.EC_POINT_mul.restype = ctypes.c_int
         self.EC_POINT_mul.argtypes = [ctypes.c_void_p,
-                                      ctypes.c_void_p,
-                                      ctypes.c_void_p,
-                                      ctypes.c_void_p,
+                                      ctypes.POINTER(EC_POINT),
+                                      ctypes.POINTER(BIGNUM),
+                                      ctypes.POINTER(EC_POINT),
+                                      ctypes.POINTER(BIGNUM),
                                       ctypes.c_void_p]
 
         self.EC_KEY_set_private_key = self._lib.EC_KEY_set_private_key
         self.EC_KEY_set_private_key.restype = ctypes.c_int
         self.EC_KEY_set_private_key.argtypes = [ctypes.c_void_p,
-                                                ctypes.c_void_p]
+                                                ctypes.POINTER(BIGNUM)]
 
         if self._hexversion >= 0x10100000 and not self._libreSSL:
             self.EC_KEY_OpenSSL = self._lib.EC_KEY_OpenSSL
@@ -469,70 +493,71 @@ class _OpenSSL(object):
         self.BN_CTX_new.argtypes = []
 
         self.BN_dup = self._lib.BN_dup
-        self.BN_dup.restype = ctypes.c_void_p
-        self.BN_dup.argtypes = [ctypes.c_void_p]
+        self.BN_dup.restype = ctypes.POINTER(BIGNUM)
+        self.BN_dup.argtypes = [ctypes.POINTER(BIGNUM)]
 
         self.BN_rand = self._lib.BN_rand
         self.BN_rand.restype = ctypes.c_int
-        self.BN_rand.argtypes = [ctypes.c_void_p,
+        self.BN_rand.argtypes = [ctypes.POINTER(BIGNUM),
+                                 ctypes.c_int,
                                  ctypes.c_int,
                                  ctypes.c_int]
 
         self.BN_set_word = self._lib.BN_set_word
         self.BN_set_word.restype = ctypes.c_int
-        self.BN_set_word.argtypes = [ctypes.c_void_p,
+        self.BN_set_word.argtypes = [ctypes.POINTER(BIGNUM),
                                      ctypes.c_ulong]
 
         self.BN_mul = self._lib.BN_mul
         self.BN_mul.restype = ctypes.c_int
-        self.BN_mul.argtypes = [ctypes.c_void_p,
-                                ctypes.c_void_p,
-                                ctypes.c_void_p,
+        self.BN_mul.argtypes = [ctypes.POINTER(BIGNUM),
+                                ctypes.POINTER(BIGNUM),
+                                ctypes.POINTER(BIGNUM),
                                 ctypes.c_void_p]
 
         self.BN_mod_add = self._lib.BN_mod_add
         self.BN_mod_add.restype = ctypes.c_int
-        self.BN_mod_add.argtypes = [ctypes.c_void_p,
-                                    ctypes.c_void_p,
-                                    ctypes.c_void_p,
-                                    ctypes.c_void_p,
+        self.BN_mod_add.argtypes = [ctypes.POINTER(BIGNUM),
+                                    ctypes.POINTER(BIGNUM),
+                                    ctypes.POINTER(BIGNUM),
+                                    ctypes.POINTER(BIGNUM),
                                     ctypes.c_void_p]
 
         self.BN_mod_inverse = self._lib.BN_mod_inverse
-        self.BN_mod_inverse.restype = ctypes.c_void_p
-        self.BN_mod_inverse.argtypes = [ctypes.c_void_p,
-                                        ctypes.c_void_p,
-                                        ctypes.c_void_p,
+        self.BN_mod_inverse.restype = ctypes.POINTER(BIGNUM)
+        self.BN_mod_inverse.argtypes = [ctypes.POINTER(BIGNUM),
+                                        ctypes.POINTER(BIGNUM),
+                                        ctypes.POINTER(BIGNUM),
                                         ctypes.c_void_p]
 
         self.BN_mod_mul = self._lib.BN_mod_mul
         self.BN_mod_mul.restype = ctypes.c_int
-        self.BN_mod_mul.argtypes = [ctypes.c_void_p,
-                                    ctypes.c_void_p,
-                                    ctypes.c_void_p,
-                                    ctypes.c_void_p,
+        self.BN_mod_mul.argtypes = [ctypes.POINTER(BIGNUM),
+                                    ctypes.POINTER(BIGNUM),
+                                    ctypes.POINTER(BIGNUM),
+                                    ctypes.POINTER(BIGNUM),
                                     ctypes.c_void_p]
 
         self.BN_lshift = self._lib.BN_lshift
         self.BN_lshift.restype = ctypes.c_int
-        self.BN_lshift.argtypes = [ctypes.c_void_p,
-                                   ctypes.c_void_p,
+        self.BN_lshift.argtypes = [ctypes.POINTER(BIGNUM),
+                                   ctypes.POINTER(BIGNUM),
                                    ctypes.c_int]
 
         self.BN_sub_word = self._lib.BN_sub_word
         self.BN_sub_word.restype = ctypes.c_int
-        self.BN_sub_word.argtypes = [ctypes.c_void_p,
+        self.BN_sub_word.argtypes = [ctypes.POINTER(BIGNUM),
                                      ctypes.c_ulong]
 
         self.BN_cmp = self._lib.BN_cmp
         self.BN_cmp.restype = ctypes.c_int
-        self.BN_cmp.argtypes = [ctypes.c_void_p,
-                                ctypes.c_void_p]
+        self.BN_cmp.argtypes = [ctypes.POINTER(BIGNUM),
+                                ctypes.POINTER(BIGNUM)]
 
         try:
             self.BN_is_odd = self._lib.BN_is_odd
             self.BN_is_odd.restype = ctypes.c_int
-            self.BN_is_odd.argtypes = [ctypes.c_void_p]
+            self.BN_is_odd.argtypes = [ctypes.POINTER(BIGNUM)]
         except AttributeError:
             # OpenSSL 1.1.0 implements this as a function, but earlier
             # versions as macro, so we need to workaround
@@ -540,7 +565,7 @@ class _OpenSSL(object):
 
         self.BN_bn2dec = self._lib.BN_bn2dec
         self.BN_bn2dec.restype = ctypes.c_char_p
-        self.BN_bn2dec.argtypes = [ctypes.c_void_p]
+        self.BN_bn2dec.argtypes = [ctypes.POINTER(BIGNUM)]
 
         self.EC_GROUP_new_by_curve_name = self._lib.EC_GROUP_new_by_curve_name
         self.EC_GROUP_new_by_curve_name.restype = ctypes.c_void_p
@@ -549,43 +574,43 @@ class _OpenSSL(object):
         self.EC_GROUP_get_order = self._lib.EC_GROUP_get_order
         self.EC_GROUP_get_order.restype = ctypes.c_int
         self.EC_GROUP_get_order.argtypes = [ctypes.c_void_p,
-                                            ctypes.c_void_p,
+                                            ctypes.POINTER(BIGNUM),
                                             ctypes.c_void_p]
 
         self.EC_GROUP_get_cofactor = self._lib.EC_GROUP_get_cofactor
         self.EC_GROUP_get_cofactor.restype = ctypes.c_int
         self.EC_GROUP_get_cofactor.argtypes = [ctypes.c_void_p,
-                                               ctypes.c_void_p,
+                                               ctypes.POINTER(BIGNUM),
                                                ctypes.c_void_p]
 
         self.EC_GROUP_get0_generator = self._lib.EC_GROUP_get0_generator
-        self.EC_GROUP_get0_generator.restype = ctypes.c_void_p
+        self.EC_GROUP_get0_generator.restype = ctypes.POINTER(EC_POINT)
         self.EC_GROUP_get0_generator.argtypes = [ctypes.c_void_p]
 
         self.EC_POINT_copy = self._lib.EC_POINT_copy
         self.EC_POINT_copy.restype = ctypes.c_int
-        self.EC_POINT_copy.argtypes = [ctypes.c_void_p,
-                                       ctypes.c_void_p]
+        self.EC_POINT_copy.argtypes = [ctypes.POINTER(EC_POINT),
+                                       ctypes.POINTER(EC_POINT)]
 
         self.EC_POINT_add = self._lib.EC_POINT_add
         self.EC_POINT_add.restype = ctypes.c_int
         self.EC_POINT_add.argtypes = [ctypes.c_void_p,
-                                      ctypes.c_void_p,
-                                      ctypes.c_void_p,
-                                      ctypes.c_void_p,
+                                      ctypes.POINTER(EC_POINT),
+                                      ctypes.POINTER(EC_POINT),
+                                      ctypes.POINTER(EC_POINT),
                                       ctypes.c_void_p]
 
         self.EC_POINT_cmp = self._lib.EC_POINT_cmp
         self.EC_POINT_cmp.restype = ctypes.c_int
         self.EC_POINT_cmp.argtypes = [ctypes.c_void_p,
-                                      ctypes.c_void_p,
-                                      ctypes.c_void_p,
+                                      ctypes.POINTER(EC_POINT),
+                                      ctypes.POINTER(EC_POINT),
                                       ctypes.c_void_p]
 
         self.EC_POINT_set_to_infinity = self._lib.EC_POINT_set_to_infinity
         self.EC_POINT_set_to_infinity.restype = ctypes.c_int
         self.EC_POINT_set_to_infinity.argtypes = [ctypes.c_void_p,
-                                                  ctypes.c_void_p]
+                                                  ctypes.POINTER(EC_POINT)]
 
         self._set_ciphers()
         self._set_curves()

--- a/src/pyelliptic/tests/__init__.py
+++ b/src/pyelliptic/tests/__init__.py
@@ -3,6 +3,7 @@ import sys
 if getattr(sys, 'frozen', None):
     from test_arithmetic import TestArithmetic
     from test_blindsig import TestBlindSig
+    from test_ecc import TestECC
     from test_openssl import TestOpenSSL
 
-    __all__ = ["TestArithmetic", "TestBlindSig", "TestOpenSSL"]
+    __all__ = ["TestArithmetic", "TestBlindSig", "TestECC", "TestOpenSSL"]

--- a/src/pyelliptic/tests/samples.py
+++ b/src/pyelliptic/tests/samples.py
@@ -1,0 +1,74 @@
+"""Testing samples"""
+
+from binascii import unhexlify
+
+# pubkey K
+sample_pubkey = unhexlify(
+    '0409d4e5c0ab3d25fe'
+    '048c64c9da1a242c'
+    '7f19417e9517cd26'
+    '6950d72c75571358'
+    '5c6178e97fe092fc'
+    '897c9a1f1720d577'
+    '0ae8eaad2fa8fcbd'
+    '08e9324a5dde1857'
+)
+
+sample_iv = unhexlify(
+    'bddb7c2829b08038'
+    '753084a2f3991681'
+)
+
+# Private key r
+sample_ephem_privkey = unhexlify(
+    '5be6facd941b76e9'
+    'd3ead03029fbdb6b'
+    '6e0809293f7fb197'
+    'd0c51f84e96b8ba4'
+)
+# Public key R
+sample_ephem_pubkey = unhexlify(
+    '040293213dcf1388b6'
+    '1c2ae5cf80fee6ff'
+    'ffc049a2f9fe7365'
+    'fe3867813ca81292'
+    'df94686c6afb565a'
+    'c6149b153d61b3b2'
+    '87ee2c7f997c1423'
+    '8796c12b43a3865a'
+)
+
+# First 32 bytes of H called key_e
+sample_enkey = unhexlify(
+    '1705438282678671'
+    '05263d4828efff82'
+    'd9d59cbf08743b69'
+    '6bcc5d69fa1897b4'
+)
+
+# Last 32 bytes of H called key_m
+sample_mackey = unhexlify(
+    'f83f1e9cc5d6b844'
+    '8d39dc6a9d5f5b7f'
+    '460e4a78e9286ee8'
+    'd91ce1660a53eacd'
+)
+
+# No padding of input!
+sample_data = b'The quick brown fox jumps over the lazy dog.'
+
+sample_ciphertext = unhexlify(
+    '64203d5b24688e25'
+    '47bba345fa139a5a'
+    '1d962220d4d48a0c'
+    'f3b1572c0d95b616'
+    '43a6f9a0d75af7ea'
+    'cc1bd957147bf723'
+)
+
+sample_mac = unhexlify(
+    'f2526d61b4851fb2'
+    '3409863826fd2061'
+    '65edc021368c7946'
+    '571cead69046e619'
+)

--- a/src/pyelliptic/tests/test_blindsig.py
+++ b/src/pyelliptic/tests/test_blindsig.py
@@ -58,7 +58,7 @@ class TestBlindSig(unittest.TestCase):
             x = OpenSSL.BN_new()
             y = OpenSSL.BN_new()
             OpenSSL.EC_POINT_get_affine_coordinates(
-                obj.group, obj.Q, x, y, 0)
+                obj.group, obj.Q, x, y, None)
             self.assertEqual(OpenSSL.BN_is_odd(y),
                              OpenSSL.BN_is_odd_compatible(y))
 
@@ -85,7 +85,7 @@ class TestBlindSig(unittest.TestCase):
                 self.assertEqual(OpenSSL.BN_cmp(y0, y1), 0)
                 self.assertEqual(OpenSSL.BN_cmp(x0, x1), 0)
                 self.assertEqual(OpenSSL.EC_POINT_cmp(obj.group, randompoint,
-                                                      secondpoint, 0), 0)
+                                                      secondpoint, None), 0)
             finally:
                 OpenSSL.BN_free(x0)
                 OpenSSL.BN_free(x1)

--- a/src/pyelliptic/tests/test_ecc.py
+++ b/src/pyelliptic/tests/test_ecc.py
@@ -1,11 +1,23 @@
 """Tests for ECC object"""
 
 import unittest
+from hashlib import sha512
 
 try:
-    from pyelliptic.ecc import ECC
+    import pyelliptic
 except ImportError:
-    from pybitmessage.pyelliptic import ECC
+    from pybitmessage import pyelliptic
+
+from .samples import (
+    sample_pubkey, sample_iv, sample_ephem_privkey, sample_ephem_pubkey,
+    sample_enkey, sample_mackey, sample_data, sample_ciphertext, sample_mac)
+
+
+sample_pubkey_x = sample_ephem_pubkey[1:-32]
+sample_pubkey_y = sample_ephem_pubkey[-32:]
+sample_pubkey_bin = (
+    b'\x02\xca\x00\x20' + sample_pubkey_x + b'\x00\x20' + sample_pubkey_y)
+sample_privkey_bin = b'\x02\xca\x00\x20' + sample_ephem_privkey
 
 
 class TestECC(unittest.TestCase):
@@ -13,7 +25,58 @@ class TestECC(unittest.TestCase):
 
     def test_random_keys(self):
         """A dummy test for random keys in ECC object"""
-        eccobj = ECC(curve='secp256k1')
+        eccobj = pyelliptic.ECC(curve='secp256k1')
         self.assertEqual(len(eccobj.privkey), 32)
         pubkey = eccobj.get_pubkey()
         self.assertEqual(pubkey[:4], b'\x02\xca\x00\x20')
+
+    def test_decode_keys(self):
+        """Check keys decoding"""
+        curve_secp256k1 = pyelliptic.OpenSSL.get_curve('secp256k1')
+        curve, raw_privkey, _ = pyelliptic.ECC._decode_privkey(
+            sample_privkey_bin)
+        self.assertEqual(curve, curve_secp256k1)
+        self.assertEqual(
+            pyelliptic.OpenSSL.get_curve_by_id(curve), 'secp256k1')
+        self.assertEqual(sample_ephem_privkey, raw_privkey)
+
+        curve, pubkey_x, pubkey_y, _ = pyelliptic.ECC._decode_pubkey(
+            sample_pubkey_bin)
+        self.assertEqual(curve, curve_secp256k1)
+        self.assertEqual(sample_pubkey_x, pubkey_x)
+        self.assertEqual(sample_pubkey_y, pubkey_y)
+
+    def test_encode_keys(self):
+        """Check keys encoding"""
+        cryptor = pyelliptic.ECC(
+            pubkey_x=sample_pubkey_x,
+            pubkey_y=sample_pubkey_y,
+            raw_privkey=sample_ephem_privkey, curve='secp256k1')
+        self.assertEqual(cryptor.get_privkey(), sample_privkey_bin)
+        self.assertEqual(cryptor.get_pubkey(), sample_pubkey_bin)
+
+    def test_encryption_parts(self):
+        """Check results of the encryption steps against samples in the Spec"""
+        ephem = pyelliptic.ECC(
+            pubkey_x=sample_pubkey_x,
+            pubkey_y=sample_pubkey_y,
+            raw_privkey=sample_ephem_privkey, curve='secp256k1')
+        key = sha512(ephem.raw_get_ecdh_key(
+            sample_pubkey[1:-32], sample_pubkey[-32:])).digest()
+        self.assertEqual(sample_enkey, key[:32])
+        self.assertEqual(sample_mackey, key[32:])
+
+        ctx = pyelliptic.Cipher(sample_enkey, sample_iv, 1)
+        self.assertEqual(ctx.ciphering(sample_data), sample_ciphertext)
+        self.assertEqual(
+            sample_mac,
+            pyelliptic.hash.hmac_sha256(
+                sample_mackey,
+                sample_iv + sample_pubkey_bin + sample_ciphertext))
+
+    def test_decryption(self):
+        """Check decription of a message by random cryptor"""
+        random_recipient = pyelliptic.ECC(curve='secp256k1')
+        payload = pyelliptic.ECC.encrypt(
+            sample_data, random_recipient.get_pubkey())
+        self.assertEqual(random_recipient.decrypt(payload), sample_data)

--- a/src/pyelliptic/tests/test_ecc.py
+++ b/src/pyelliptic/tests/test_ecc.py
@@ -32,6 +32,7 @@ class TestECC(unittest.TestCase):
 
     def test_decode_keys(self):
         """Check keys decoding"""
+        # pylint: disable=protected-access
         curve_secp256k1 = pyelliptic.OpenSSL.get_curve('secp256k1')
         curve, raw_privkey, _ = pyelliptic.ECC._decode_privkey(
             sample_privkey_bin)

--- a/src/pyelliptic/tests/test_ecc.py
+++ b/src/pyelliptic/tests/test_ecc.py
@@ -1,0 +1,19 @@
+"""Tests for ECC object"""
+
+import unittest
+
+try:
+    from pyelliptic.ecc import ECC
+except ImportError:
+    from pybitmessage.pyelliptic import ECC
+
+
+class TestECC(unittest.TestCase):
+    """The test case for ECC"""
+
+    def test_random_keys(self):
+        """A dummy test for random keys in ECC object"""
+        eccobj = ECC(curve='secp256k1')
+        self.assertEqual(len(eccobj.privkey), 32)
+        pubkey = eccobj.get_pubkey()
+        self.assertEqual(pubkey[:4], b'\x02\xca\x00\x20')


### PR DESCRIPTION
Hi!

I prepared your changes in `pyelliptic` that introduces BIGNUM and EC_POINT pointers:

* separated debug prints so they could be easily removed
* covered `pyelliptic.ecc` by tests (mainly encryption and decryption with samples found in the Specification)
* fixed a couple of errors (at least for linux)
* minor formatting changes

~~The problem with these changes I have so far: I haven't been able to reproduce the crash on Windows with the tests. The pointers fix blindsig tests with openssl > 1.0.1, but that's probably all. Current `Bitmessage_x64_0.6.3.2.exe` uses openssl-1.0.1h provided by PyQt4. The SLPro openssl-1.0.2 used for bitmsghash works on wine, but I couldn't load its `libeay32.dll` on Windows.~~