### PR TITLE
Refactor telenuim_process: Add a sleep(1) in tearDown

### DIFF
--- a/src/bitmessagekivy/tests/telenium_process.py
+++ b/src/bitmessagekivy/tests/telenium_process.py
@@ -54,7 +54,13 @@ class TeleniumTestProcess(TeleniumTestCase):
     def tearDownClass(cls):
         """Ensures that pybitmessage stopped and removes files"""
         # pylint: disable=no-member
-        super(TeleniumTestProcess, cls).tearDownClass()
+        try:
+            sleep(1)
+            cls.process.kill()
+        except:
+            # pylint: disable=bad-super-call
+            sleep(1)
+            super(TeleniumTestCase, cls).tearDownClass()
         cleanup()
 
     def assert_wait_no_except(self, selector, timeout=-1, value='inbox'):


### PR DESCRIPTION
## Repository contributions to the PyBitmessage project

### Code

- Refactor `telenium_process.py`, add `sleep(1)` in `teadDown()` before `super` call