### PR TITLE
Reenabling EOL py27 and py36 in tox according to its FAQ

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+requires = virtualenv<20.22.0
 envlist = reset,py{27,27-portable,35,36,38,39,310},stats
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Hi!

As you can see in the recent builds, without this change tox currently runs only `py38` on `bionic` and `py38,py39` on `focal`. The later probably needs invalidating docker cache.