### PR TITLE
Replacing travis_xenial_python_2.7 with a buildbot_multibuild dir

### DIFF
--- a/.buildbot/tox-xenial/Dockerfile
+++ b/.buildbot/tox-xenial/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:xenial
+
+RUN apt-get update
+
+# Common apt packages
+RUN apt-get install -yq --no-install-suggests --no-install-recommends \
+    software-properties-common build-essential libcap-dev libffi-dev \
+    libssl-dev python-all-dev python-pip python-setuptools python3-dev
+
+# wget
+RUN apt-get install -yq --no-install-suggests --no-install-recommends \
+    libgmp-dev m4 pkgconf wget
+
+RUN wget "https://ftp.gnu.org/gnu/nettle/nettle-3.9.1.tar.gz" \
+    && tar -zxf nettle-3.9.1.tar.gz
+
+RUN cd nettle-3.9.1 \
+    && ./configure --disable-openssl --enable-shared \
+    && make && make install
+
+RUN wget "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.16.tar.xz" \
+    && tar -Jxf gnutls-3.6.16.tar.xz
+
+RUN apt-get remove -yq libgnutls30
+
+RUN cd gnutls-3.6.16 \
+    && ./configure --prefix=/usr --without-p11-kit \
+    --with-included-libtasn1 --with-included-unistring --without-idn \
+    && make && make install
+
+RUN wget "https://ftp.gnu.org/gnu/wget/wget2-2.1.0.tar.gz" \
+    && tar -zxf wget2-2.1.0.tar.gz
+
+RUN apt-get remove -yq wget
+
+RUN cd wget2-2.1.0 \
+    && ./configure --without-libpsl --prefix=/usr \
+    GNUTLS_CFLAGS=-I/usr/include/gnutls/ GNUTLS_LIBS=-L/usr/lib \
+    && make && make install \
+    && mv /usr/bin/wget2 /usr/bin/wget
+
+RUN wget -O /usr/local/bin/buildbot_entrypoint.sh http://git.bitmessage.org/Bitmessage/buildbot-scripts/raw/branch/master/docker/xenial/entrypoint.sh
+
+RUN pip install --upgrade pip==20.0.1
+RUN pip install --upgrade setuptools
+RUN pip install tox
+
+ADD . .
+
+CMD .buildbot/tox-xenial/test.sh

--- a/.buildbot/tox-xenial/test.sh
+++ b/.buildbot/tox-xenial/test.sh
@@ -1,0 +1,1 @@
+../tox-bionic/test.sh

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
     coverage run -a -m tests
 
 [testenv:lint-basic]
+skip_install = true
 basepython = python3
 deps =
     bandit
@@ -38,11 +39,16 @@ commands = python setup.py build_sphinx
 skip_install = true
 commands = python pybitmessage/bitmessagemain.py -t
 
+[testenv:py35]
+skip_install = true
+
 [testenv:reset]
+skip_install = true
 deps = coverage
 commands = coverage erase
 
 [testenv:stats]
+skip_install = true
 deps = coverage
 commands =
     coverage report


### PR DESCRIPTION
Hi!

I'm not sure if this is going to work. Currently it crashes on downloading buildbot entry point script in the same way as `travis_xenial_python_2.7` does trying to download `travis2bash.sh`.