### PR TITLE
Check the return of buildscripts/winbuild.sh in winebuild task

### DIFF
--- a/.buildbot/appimage/build.sh
+++ b/.buildbot/appimage/build.sh
@@ -45,4 +45,5 @@ set_sourceline
 ./${BUILDER} --recipe ${RECIPE}
 
 mkdir -p ../out
+sha256sum PyBitmessage*.AppImage > ../out/SHA256SUMS
 cp PyBitmessage*.AppImage ../out

--- a/.buildbot/snap/build.sh
+++ b/.buildbot/snap/build.sh
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
-cd packages && snapcraft
+pushd packages && snapcraft || exit 1
 
-cd ..
+popd
 mkdir -p ../out
 mv packages/pybitmessage*.snap ../out
+cd ../out
+sha256sum pybitmessage*.snap > SHA256SUMS

--- a/.buildbot/winebuild/build.sh
+++ b/.buildbot/winebuild/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-xvfb-run -a buildscripts/winbuild.sh
+xvfb-run -a buildscripts/winbuild.sh || exit 1
 
 mkdir -p ../out
 mv packages/pyinstaller/dist/*.exe ../out

--- a/.buildbot/winebuild/build.sh
+++ b/.buildbot/winebuild/build.sh
@@ -3,4 +3,6 @@
 xvfb-run -a buildscripts/winbuild.sh || exit 1
 
 mkdir -p ../out
-mv packages/pyinstaller/dist/*.exe ../out
+mv packages/pyinstaller/dist/Bitmessage*.exe ../out
+cd ../out
+sha256sum Bitmessage*.exe > SHA256SUMS


### PR DESCRIPTION
I forgot to make it fail if the dry run fails. And also to check the exit status of `snapcraft`.