### PR TITLE
Move loading cryptors into objectProcessor init.

### DIFF
--- a/src/bitmessagemain.py
+++ b/src/bitmessagemain.py
@@ -32,7 +32,6 @@ import traceback
 import defaults
 # Network subsystem
 import network
-import shared
 import shutdown
 import state
 
@@ -181,9 +180,6 @@ class Main(object):
         Inventory()  # init
 
         if state.enableObjProc:  # Not needed if objproc is disabled
-            shared.reloadMyAddressHashes()
-            shared.reloadBroadcastSendersForWhichImWatching()
-
             # Start the address generation thread
             addressGeneratorThread = addressGenerator()
             # close the main program even if there are threads left

--- a/src/class_objectProcessor.py
+++ b/src/class_objectProcessor.py
@@ -48,7 +48,7 @@ class objectProcessor(threading.Thread):
         random.seed()
         if sql_ready.wait(sql_timeout) is False:
             logger.fatal('SQL thread is not started in %s sec', sql_timeout)
-            os._exit(1)
+            os._exit(1)  # pylint: disable=protected-access
         shared.reloadMyAddressHashes()
         shared.reloadBroadcastSendersForWhichImWatching()
         # It may be the case that the last time Bitmessage was running,

--- a/src/class_objectProcessor.py
+++ b/src/class_objectProcessor.py
@@ -44,12 +44,14 @@ class objectProcessor(threading.Thread):
     def __init__(self):
         threading.Thread.__init__(self, name="objectProcessor")
         random.seed()
+        sql_ready.wait()
+        shared.reloadMyAddressHashes()
+        shared.reloadBroadcastSendersForWhichImWatching()
         # It may be the case that the last time Bitmessage was running,
         # the user closed it before it finished processing everything in the
         # objectProcessorQueue. Assuming that Bitmessage wasn't closed
         # forcefully, it should have saved the data in the queue into the
         # objectprocessorqueue table. Let's pull it out.
-        sql_ready.wait()
         queryreturn = sqlQuery(
             'SELECT objecttype, data FROM objectprocessorqueue')
         for objectType, data in queryreturn:

--- a/src/helper_sql.py
+++ b/src/helper_sql.py
@@ -33,6 +33,8 @@ sql_available = False
 sql_ready = threading.Event()
 """set by `.threads.sqlThread` when ready for processing (after
    initialization is done)"""
+sql_timeout = 60
+"""timeout for waiting for sql_ready in seconds"""
 
 
 def sqlQuery(sql_statement, *args):


### PR DESCRIPTION
Hello!

I found a floating bug on windows:

```
2022-12-19 01:52:30,013 - CRITICAL - Unhandled exception
Traceback (most recent call last):
 File "bitmessagemain.py", line 390, in <module>
 File "bitmessagemain.py", line 386, in main
 File "bitmessagemain.py", line 185, in start
 File "shared.py", line 157, in reloadBroadcastSendersForWhichImWatching
 File "helper_sql.py", line 46, in sqlQuery
AssertionError
```

I admit that moving `shared.reloadBroadcastSendersForWhichImWatching()` should be enough to solve it, but it seems logical to move all the cryptors as they mostly used (should be) by object processor. Also I like removing the import of `shared`.

So far I have no idea how to test this though.