### PR TITLE
Remove core tests from coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
 deps = -rrequirements.txt
 commands =
     python checkdeps.py
-    coverage run -a src/bitmessagemain.py -t
+    python src/bitmessagemain.py -t
     coverage run -a -m tests
 
 [testenv:lint-basic]


### PR DESCRIPTION
Hi!

I believe it's time to consider core tests a part of blind tests together with those, inherited from `test_process.TestProcessProto`. This makes the coverage deterministic and more fair.

