### PR TITLE
Fix qt plugins by copying the qt.conf from the old appimage

### DIFF
--- a/packages/AppImage/AppImageBuilder.yml
+++ b/packages/AppImage/AppImageBuilder.yml
@@ -20,6 +20,7 @@ AppDir:
 
   after_runtime:
     - sed -i "s|GTK_.*||g" AppDir/AppRun.env
+    - cp packages/AppImage/qt.conf AppDir/usr/bin/
 
   apt:
     arch: !ENV '${ARCH}'

--- a/packages/AppImage/qt.conf
+++ b/packages/AppImage/qt.conf
@@ -1,0 +1,2 @@
+[Paths]
+Prefix = ../lib/x86_64-linux-gnu/qt4


### PR DESCRIPTION
Hi!

I found this missing config while I was searching for the reason why `QtGui.QTextBrowser` fails to render jpeg images in the appimages built using `appimage-builder`. Apparently it fixes also tray icon and notifications on Ubuntu.