### PR TITLE
Fix the test for proofofwork.LogOutput()

### DIFF
--- a/src/tests/test_log.py
+++ b/src/tests/test_log.py
@@ -14,8 +14,8 @@ class TestLog(unittest.TestCase):
         sys.hexversion < 0x3000000, 'assertLogs is new in version 3.4')
     def test_LogOutput(self):
         """Use proofofwork.LogOutput to log output of a shell command"""
-        def echo():
-            """Call the echo shell command"""
-            with proofofwork.LogOutput():
+        with self.assertLogs('default') as cm:  # pylint: disable=no-member
+            with proofofwork.LogOutput('+'):
                 subprocess.call(['echo', 'HELLO'])
-        self.assertLogs(echo(), 'HELLO')  # pylint: disable=no-member
+
+        self.assertEqual(cm.output, ['INFO:default:+: HELLO\n'])


### PR DESCRIPTION
Hi!

Apparently the `unittest.TestCase.assertLogs()` is only used as a context manager. I fixed `test_log` by the proper use.