### PR TITLE
Move most of the code testing UDP from core tests to test_network

### DIFF
--- a/src/tests/core.py
+++ b/src/tests/core.py
@@ -310,26 +310,6 @@ class TestCore(unittest.TestCase):
         else:
             return self.fail('No Announcer thread found')
 
-        for _ in range(20):  # wait for UDP socket
-            for sock in BMConnectionPool().udpSockets.values():
-                thread.announceSelf()
-                break
-            else:
-                time.sleep(1)
-                continue
-            break
-        else:
-            self.fail('UDP socket is not started')
-
-        for _ in range(20):
-            if state.discoveredPeers:
-                peer = state.discoveredPeers.keys()[0]
-                self.assertEqual(peer.port, 8444)
-                break
-            time.sleep(1)
-        else:
-            self.fail('No self in discovered peers')
-
     @staticmethod
     def _decode_msg(data, pattern):
         proto = BMProto()

--- a/src/tests/test_network.py
+++ b/src/tests/test_network.py
@@ -63,6 +63,31 @@ class TestNetwork(TestPartialRun):
         else:
             self.fail('Have not started any connection in 30 sec')
 
+    def test_udp(self):
+        """Invoke AnnounceThread.announceSelf() and check discovered peers"""
+        for _ in range(20):
+            if self.pool.udpSockets:
+                break
+            time.sleep(1)
+        else:
+            self.fail('No UDP sockets found in 20 sec')
+
+        for _ in range(10):
+            try:
+                self.state.announceThread.announceSelf()
+            except AttributeError:
+                self.fail('state.announceThread is not set properly')
+            time.sleep(1)
+            try:
+                peer = self.state.discoveredPeers.popitem()[0]
+            except KeyError:
+                continue
+            else:
+                self.assertEqual(peer.port, 8444)
+                break
+        else:
+            self.fail('No self in discovered peers')
+
     @classmethod
     def tearDownClass(cls):
         super(TestNetwork, cls).tearDownClass()

--- a/src/tests/test_network.py
+++ b/src/tests/test_network.py
@@ -19,6 +19,7 @@ class TestNetwork(TestPartialRun):
         cls.state.maximumNumberOfHalfOpenConnections = 4
 
         cls.config.set('bitmessagesettings', 'sendoutgoingconnections', 'True')
+        cls.config.set('bitmessagesettings', 'udp', 'True')
 
         # config variable is still used inside of the network ):
         import network
@@ -34,18 +35,14 @@ class TestNetwork(TestPartialRun):
     def test_threads(self):
         """Ensure all the network threads started"""
         threads = {
-            "AddrBroadcaster", "Asyncore", "Downloader", "InvBroadcaster",
-            "Uploader"}
-        extra = (
-            self.config.getint('threads', 'receive')
-            + self.config.safeGetBoolean('bitmessagesettings', 'udp'))
+            "AddrBroadcaster", "Announcer", "Asyncore", "Downloader",
+            "InvBroadcaster", "Uploader"}
+        extra = self.config.getint('threads', 'receive')
         for thread in threading.enumerate():
             try:
                 threads.remove(thread.name)
             except KeyError:
-                extra -= (
-                    thread.name == "Announcer"
-                    or thread.name.startswith("ReceiveQueue_"))
+                extra -= thread.name.startswith("ReceiveQueue_")
 
         self.assertEqual(len(threads), 0)
         self.assertEqual(extra, 0)


### PR DESCRIPTION
Hi!

I moved the code causing failures like [this](https://buildbot.bitmessage.org/#/builders/33/builds/19356/steps/4/logs/stdio) into the `TestNetwork` test case and slightly improved the logic.

```
FAIL: test_udp (tests.core.TestCore)
check default udp setting and presence of Announcer thread
----------------------------------------------------------------------
Traceback (most recent call last):
 File "/var/lib/buildbot/workers/default/multibuild_child/build/src/tests/core.py", line 331, in test_udp
 self.fail('No self in discovered peers')
AssertionError: No self in discovered peers

```

Even if it fail there, what I didn't observed so far, the `py27` tox environment will be fully executed and coverage won't be decreased to 13%.