### PR TITLE
Possible fix for test_random_keys() failure on short keys

### DIFF
--- a/src/pyelliptic/ecc.py
+++ b/src/pyelliptic/ecc.py
@@ -107,12 +107,19 @@ class ECC(object):
         High level function which returns :
         curve(2) + len_of_pubkeyX(2) + pubkeyX + len_of_pubkeyY + pubkeyY
         """
+        ctx = OpenSSL.BN_CTX_new()
+        n = OpenSSL.BN_new()
+        group = OpenSSL.EC_GROUP_new_by_curve_name(self.curve)
+        OpenSSL.EC_GROUP_get_order(group, n, ctx)
+        key_len = OpenSSL.BN_num_bytes(n)
+        pubkey_x = self.pubkey_x.rjust(key_len, b'\x00')
+        pubkey_y = self.pubkey_y.rjust(key_len, b'\x00')
         return b''.join((
             pack('!H', self.curve),
-            pack('!H', len(self.pubkey_x)),
-            self.pubkey_x,
-            pack('!H', len(self.pubkey_y)),
-            self.pubkey_y,
+            pack('!H', len(pubkey_x)),
+            pubkey_x,
+            pack('!H', len(pubkey_y)),
+            pubkey_y,
         ))
 
     def get_privkey(self):

--- a/src/pyelliptic/tests/test_ecc.py
+++ b/src/pyelliptic/tests/test_ecc.py
@@ -1,5 +1,6 @@
 """Tests for ECC object"""
 
+import os
 import unittest
 from hashlib import sha512
 
@@ -29,6 +30,22 @@ class TestECC(unittest.TestCase):
         self.assertEqual(len(eccobj.privkey), 32)
         pubkey = eccobj.get_pubkey()
         self.assertEqual(pubkey[:4], b'\x02\xca\x00\x20')
+
+    def test_short_keys(self):
+        """Check formatting of the keys with leading zeroes"""
+        def sample_key(_):
+            return os.urandom(32), os.urandom(31), os.urandom(30)
+
+        try:
+            gen_orig = pyelliptic.ECC._generate
+            pyelliptic.ECC._generate = sample_key
+            eccobj = pyelliptic.ECC(curve='secp256k1')
+            pubkey = eccobj.get_pubkey()
+            self.assertEqual(pubkey[:4], b'\x02\xca\x00\x20')
+            self.assertEqual(pubkey[36:38], b'\x00\x20')
+            self.assertEqual(len(pubkey[38:]), 32)
+        finally:
+            pyelliptic.ECC._generate = gen_orig
 
     def test_decode_keys(self):
         """Check keys decoding"""

--- a/src/pyelliptic/tests/test_ecc.py
+++ b/src/pyelliptic/tests/test_ecc.py
@@ -33,7 +33,9 @@ class TestECC(unittest.TestCase):
 
     def test_short_keys(self):
         """Check formatting of the keys with leading zeroes"""
+        # pylint: disable=protected-access
         def sample_key(_):
+            """Fake ECC keypair"""
             return os.urandom(32), os.urandom(31), os.urandom(30)
 
         try:

--- a/src/pyelliptic/tests/test_ecc.py
+++ b/src/pyelliptic/tests/test_ecc.py
@@ -27,7 +27,7 @@ class TestECC(unittest.TestCase):
     def test_random_keys(self):
         """A dummy test for random keys in ECC object"""
         eccobj = pyelliptic.ECC(curve='secp256k1')
-        self.assertEqual(len(eccobj.privkey), 32)
+        self.assertTrue(len(eccobj.privkey) <= 32)
         pubkey = eccobj.get_pubkey()
         self.assertEqual(pubkey[:4], b'\x02\xca\x00\x20')
 


### PR DESCRIPTION
Hi!

This is a possible fix for failures like [this](https://buildbot.bitmessage.org/#/builders/33/builds/16794/steps/4/logs/stdio).
```
======================================================================
FAIL: test_random_keys (pybitmessage.pyelliptic.tests.test_ecc.TestECC)
A dummy test for random keys in ECC object
----------------------------------------------------------------------
Traceback (most recent call last):
 File "pybitmessage/pyelliptic/tests/test_ecc.py", line 31, in test_random_keys
 self.assertEqual(pubkey[:4], b'\x02\xca\x00\x20')
AssertionError: '\x02\xca\x00\x1f' != '\x02\xca\x00 '
```

I may be wrong. I preferred to pad the pubkey coordinates in `ECC.get_pubkey()` because I see the `b'\x02\xca\x00 '` literal [here](https://github.com/Bitmessage/PyBitmessage/blob/v0.6/src/highlevelcrypto.py#L34) in `highlevelcrypto`. Maybe I should've changed the pubkey parts of `test_random_keys()` instead, like I did for the privkey?