### PR TITLE
Code Quality

### DIFF
--- a/src/class_singleWorker.py
+++ b/src/class_singleWorker.py
@@ -1370,7 +1370,9 @@ class singleWorker(StoppableThread):
                         'bitmessagesettings', 'apinotifypath')
 
                     if apiNotifyPath:
-                        call([apiNotifyPath, "newMessage"])
+                        # There is no additional risk of remote exploitation or
+                        # privilege escalation
+                        call([apiNotifyPath, "newMessage"])  # nosec:B603
 
     def requestPubKey(self, toAddress):
         """Send a getpubkey object"""

--- a/src/class_smtpDeliver.py
+++ b/src/class_smtpDeliver.py
@@ -22,11 +22,8 @@ class smtpDeliver(StoppableThread):
     _instance = None
 
     def stopThread(self):
-        # pylint: disable=no-member
-        try:
-            queues.UISignallerQueue.put(("stopThread", "data"))
-        except:  # noqa:E722
-            pass
+        """Relay shutdown instruction"""
+        queues.UISignalQueue.put(("stopThread", "data"))
         super(smtpDeliver, self).stopThread()
 
     @classmethod

--- a/src/depends.py
+++ b/src/depends.py
@@ -287,7 +287,7 @@ def check_openssl():
             path = ctypes.util.find_library('ssl')
             if path not in paths:
                 paths.append(path)
-        except:  # noqa:E722
+        except:  # nosec:B110 pylint:disable=bare-except
             pass
 
     openssl_version = None

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     bandit
     flake8
 commands =
-    bandit -r --exit-zero -s B105,B301,B411,B413,B608 \
+    bandit -r --exit-zero -s B105,B301,B411,B413,B608,B101 \
     -x checkdeps.*,bitmessagecurses,bitmessageqt,tests pybitmessage
     flake8 pybitmessage --count --select=E9,F63,F7,F82 \
     --show-source --statistics


### PR DESCRIPTION
## Code quality improvements

* Fixed bandit warning B603 for subprocess call in file
* Fixed typo - from `queues.UISignallerQueue` to `queues.UISignalQueue`
* Included B101 to tox.ini file to ignore assert warning 
* Suppressed try except warning