### PR TITLE
Fix failures of test_send_broadcast() in test_api

### DIFF
--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -369,7 +369,7 @@ class TestAPI(TestAPIProto):
                 'doingbroadcastpow', 'broadcastqueued', 'broadcastsent'))
 
             start = time.time()
-            while status == 'doingbroadcastpow':
+            while status != 'broadcastsent':
                 spent = int(time.time() - start)
                 if spent > 30:
                     self.fail('PoW is taking too much time: %ss' % spent)


### PR DESCRIPTION
Hi!

I believe that I fixed a bug in `test_send_broadcast()` causing failures like [this](https://buildbot.bitmessage.org/#/builders/16/builds/13896):

```
Traceback (most recent call last):
 File "pybitmessage/tests/test_api.py", line 402, in test_send_broadcast
 self.api.getAllSentMessageIds())['sentMessageIds'])
AssertionError: {'msgid': u'5605772eeac74553a27187dd5b3ab9b7'} not found in [{u'msgid': u'f65e7d168f2f4b51b690b07684bd7b15'}, {u'msgid': u'dfbe7c3e3925e83575dd7f9332b811b6ee4ca3c01347896cec3a1d5a5ab1cb88'}]

```

But there is another interesting [exception](https://buildbot.bitmessage.org/#/builders/16/builds/13915), related to the previous PR.