### PR TITLE
Trying to fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,12 @@
 version: 2
 
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "2.7"
+
 python:
-  version: 2.7
   install:
     - requirements: docs/requirements.txt
-    - method: setuptools
+    - method: pip
       path: .
-  system_packages: false


### PR DESCRIPTION
Hi!

Readthedocs is failing again: https://readthedocs.org/projects/pybitmessage/builds/23141653/ I tried to fix the config.