### PR TITLE
Add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:latest
+
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl \
+    flake8 \
+    gh \
+    git \
+    gnupg2 \
+    jq \
+    libcap-dev \
+    libssl-dev \
+    pylint \
+    python3 \
+    python3-dev \
+    python3-flake8 \
+    python3-pip \
+    python3-pycodestyle \
+    software-properties-common \
+    sudo \
+    zsh
+
+RUN apt-add-repository ppa:deadsnakes/ppa
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python2.7 python2.7-dev
+
+RUN pip install 'tox<4' 'virtualenv<20.22.0'
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && chsh -s /usr/bin/zsh user \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER $USERNAME
+WORKDIR /home/$USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+    "name": "Codespaces Python3",
+    "extensions": [
+        "cschleiden.vscode-github-actions",
+        "eamodio.gitlens",
+        "github.vscode-pull-request-github",
+        "ms-azuretools.vscode-docker",
+        "ms-python.flake8",
+        "ms-python.pylint",
+        "ms-python.python",
+        "ms-vsliveshare.vsliveshare",
+        "nwgh.bandit",
+	"the-compiler.python-tox",
+        "vscode-icons-team.vscode-icons",
+        "visualstudioexptteam.vscodeintellicode"
+    ],
+    "dockerFile": "Dockerfile",
+    "postCreateCommand": "pip3 install -r requirements.txt",
+    "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/home/user/.local/bin"
+    },
+    "settings": {
+        "flake8.args": ["--config=setup.cfg"],
+        "pylint.args": ["--rcfile=setup.cfg"],
+        "terminal.integrated.shell.linux": "/usr/bin/zsh",
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.fontFamily": "'SourceCodePro+Powerline+Awesome Regular'",
+        "terminal.integrated.fontSize": 14,
+        "files.exclude": {
+            "**/CODE_OF_CONDUCT.md": true,
+            "**/LICENSE": true
+        }
+    }
+}


### PR DESCRIPTION
Adds devcontainer configuration. I tested it with GitHub Codespaces. It includes:

- highlighting: pylint, flake8 and bandit. Uses `setup.cfg` for overrides. I'm not fully sure if pycodestyle is supported or not. Bandit doesn't use overrides from `tox.ini` yet.
- python 2 as well as 3 is supported
- limited support for tox, you can run it directly in the terminal. You can also run it from the "Testing" tab, but then for some reason the `tox.ini` needs to be open in an editor, and it also just runs in the terminal
- It's still not 100% equivalent to the buildbot tests, for example tor support is missing, but most of what a developer needs is available