### PR TITLE
Fixing docs build with py27

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
 mistune<=0.8.4
-m2r
+m2r<=0.2.1
 sphinxcontrib-apidoc
 docutils<=0.17.1
+
+


### PR DESCRIPTION
Hi!

m2r dropped python2 support in version 0.3.0 and now has `from urllib.parse import urlparse` It causes the `No module named parse` error in https://readthedocs.org/projects/pybitmessage/builds/23570209/