### PR TITLE
Move sphinx_rtd_theme into the docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 mistune<=0.8.4
 m2r<=0.2.1
+sphinx_rtd_theme
 sphinxcontrib-apidoc
 docutils<=0.17.1
-
-

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from src.version import softwareVersion
 
 
 EXTRAS_REQUIRE = {
-    'docs': ['sphinx', 'sphinx_rtd_theme'],
+    'docs': ['sphinx'],
     'gir': ['pygobject'],
     'json': ['jsonrpclib'],
     'notify2': ['notify2'],


### PR DESCRIPTION
Hi!

I hope this is a final fix for readthedocs [build](https://readthedocs.org/projects/pybitmessage/builds/23591029). I didn't notice this change because the tox environment [uses both deps](https://github.com/Bitmessage/PyBitmessage/blob/v0.6/tox.ini#L33).