### PR TITLE
Complete the cleanup of the lint-basic run

### DIFF
--- a/.buildbot/tox-bionic/test.sh
+++ b/.buildbot/tox-bionic/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-tox -e lint-basic # || exit 1
+tox -e lint-basic || exit 1
 tox

--- a/src/bitmessagekivy/identiconGeneration.py
+++ b/src/bitmessagekivy/identiconGeneration.py
@@ -40,7 +40,8 @@ def generate_hash(string):
     try:
         # make input case insensitive
         string = str.lower(string)
-        hash_object = hashlib.md5(str.encode(string))  # nosec B324, B303
+        hash_object = hashlib.md5(  # nosec B324, B303
+            str.encode(string))
         print(hash_object.hexdigest())
         # returned object is a hex string
         return hash_object.hexdigest()

--- a/src/network/knownnodes.py
+++ b/src/network/knownnodes.py
@@ -85,7 +85,7 @@ def pickle_deserialize_old_knownnodes(source):
     the new format is {Peer:{"lastseen":i, "rating":f}}
     """
     global knownNodes
-    knownNodes = pickle.load(source)
+    knownNodes = pickle.load(source)  # nosec B301
     for stream in knownNodes.keys():
         for node, params in knownNodes[stream].iteritems():
             if isinstance(params, (float, int)):

--- a/src/proofofwork.py
+++ b/src/proofofwork.py
@@ -276,8 +276,8 @@ def buildCPoW():
                   '-f', 'Makefile.bsd'])  # nosec B607, B603
         else:
             # GNU make
-            call(["make", "-C", os.path.join(paths.codePath(),
-                  "bitmsghash")])  # nosec B607, B603
+            call([  # nosec B607, B603
+                "make", "-C", os.path.join(paths.codePath(), "bitmsghash")])
         if os.path.exists(os.path.join(paths.codePath(), "bitmsghash", "bitmsghash.so")):
             init()
             notifyBuild(True)

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     bandit
     flake8
 commands =
-    bandit -r --exit-zero -s B105,B301,B411,B413,B608,B101 \
+    bandit -r -s B101,B411,B413,B608 \
     -x checkdeps.*,bitmessagecurses,bitmessageqt,tests pybitmessage
     flake8 pybitmessage --count --select=E9,F63,F7,F82 \
     --show-source --statistics


### PR DESCRIPTION
Hi!

I fixed the rest of the bandit warnings and enabled fail fast in `test.sh`.