### PR TITLE
Don't use network for sending ACK

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1336,13 +1336,13 @@ class BMRPCDispatcher(object):
         inventoryHash = calculateInventoryHash(encryptedPayload)
         Inventory()[inventoryHash] = (
             objectType, toStreamNumber, encryptedPayload,
-            expiresTime, ''
+            expiresTime, b''
         )
         logger.info(
             'Broadcasting inv for msg(API disseminatePreEncryptedMsg'
             ' command): %s', hexlify(inventoryHash))
         queues.invQueue.put((toStreamNumber, inventoryHash))
-        return hexlify(inventoryHash)
+        return hexlify(inventoryHash).decode()
 
     @command('trashSentMessageByAckData')
     def HandleTrashSentMessageByAckDAta(self, ackdata):

--- a/src/inventory.py
+++ b/src/inventory.py
@@ -45,3 +45,6 @@ class Inventory():
     # hint for pylint: this is dictionary like object
     def __getitem__(self, key):
         return self._realInventory[key]
+
+    def __setitem__(self, key, value):
+        self._realInventory[key] = value

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -9,7 +9,6 @@ import re
 import socket
 import struct
 import time
-from binascii import hexlify
 
 # magic imports!
 import addresses
@@ -678,32 +677,3 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
             except AttributeError:
                 logger.debug('Disconnected socket closing')
         AdvancedDispatcher.handle_close(self)
-
-
-class BMStringParser(BMProto):
-    """
-    A special case of BMProto used by objectProcessor to send ACK
-    """
-    def __init__(self):
-        super(BMStringParser, self).__init__()
-        self.destination = Peer('127.0.0.1', 8444)
-        self.payload = None
-        ObjectTracker.__init__(self)
-
-    def send_data(self, data):
-        """Send object given by the data string"""
-        # This class is introduced specially for ACK sending, please
-        # change log strings if you are going to use it for something else
-        self.bm_proto_reset()
-        self.payload = data
-        try:
-            self.bm_command_object()
-        except BMObjectAlreadyHaveError:
-            pass  # maybe the same msg received on different nodes
-        except BMObjectExpiredError:
-            logger.debug(
-                'Sending ACK failure (expired): %s', hexlify(data))
-        except Exception as e:
-            logger.debug(
-                'Exception of type %s while sending ACK',
-                type(e), exc_info=True)

--- a/src/protocol.py
+++ b/src/protocol.py
@@ -436,6 +436,17 @@ def assembleErrorMessage(fatal=0, banTime=0, inventoryVector='', errorText=''):
 # Packet decoding
 
 
+def decodeObjectParameters(data):
+    """Decode the parameters of a raw object needed to put it in inventory"""
+    # BMProto.decode_payload_content("QQIvv")
+    expiresTime = unpack('>Q', data[8:16])[0]
+    objectType = unpack('>I', data[16:20])[0]
+    parserPos = 20 + decodeVarint(data[20:30])[1]
+    toStreamNumber = decodeVarint(data[parserPos:parserPos + 10])[0]
+
+    return objectType, toStreamNumber, expiresTime
+
+
 def decryptAndCheckPubkeyPayload(data, address):
     """
     Version 4 pubkeys are encrypted. This function is run when we

--- a/src/tests/samples.py
+++ b/src/tests/samples.py
@@ -54,3 +54,12 @@ sample_subscription_addresses = [
     'BM-2cWQLCBGorT9pUGkYSuGGVr9LzE4mRnQaq',
     'BM-GtovgYdgs7qXPkoYaRgrLFuFKz1SFpsw']
 sample_subscription_name = 'test sub'
+
+
+sample_object_expires = 1712271487
+# from minode import structure
+# obj = structure.Object(
+#     b'\x00' * 8, sample_object_expires, 42, 1, 2, b'HELLO')
+# .. do pow and obj.to_bytes()
+sample_object_data = unhexlify(
+    '00000000001be7fc00000000660f307f0000002a010248454c4c4f')

--- a/src/tests/test_packets.py
+++ b/src/tests/test_packets.py
@@ -5,7 +5,8 @@ from struct import pack
 
 from pybitmessage import addresses, protocol
 
-from .samples import sample_addr_data
+from .samples import (
+    sample_addr_data, sample_object_data, sample_object_expires)
 from .test_protocol import TestSocketInet
 
 
@@ -48,6 +49,14 @@ class TestSerialize(TestSocketInet):
         head = unhexlify(b'%x' % protocol.magic)
         self.assertEqual(
             protocol.CreatePacket(b'ping')[:len(head)], head)
+
+    def test_decode_obj_parameters(self):
+        """Check parameters decoded from a sample object"""
+        objectType, toStreamNumber, expiresTime = \
+            protocol.decodeObjectParameters(sample_object_data)
+        self.assertEqual(objectType, 42)
+        self.assertEqual(toStreamNumber, 2)
+        self.assertEqual(expiresTime, sample_object_expires)
 
     def test_encodehost(self):
         """Check the result of protocol.encodeHost()"""


### PR DESCRIPTION
Hi!

After careful reading of the code I found a simple replacement for `network.bmproto.BMStringParser()` . Both `objectProcessor` and API `HandleDisseminatePreEncryptedMsg` handler do it by putting the payload into the inventory. To decode the object parameters I defined a corresponding function `decodeObjectParameters()` in the `protocol`.

Need to add more tests.