### PR TITLE
Move randomBytes to highlevelcrypto

### DIFF
--- a/src/helper_ackPayload.py
+++ b/src/helper_ackPayload.py
@@ -22,26 +22,26 @@ def genAckPayload(streamNumber=1, stealthLevel=0):
        - level 1: a getpubkey request for a (random) dummy key hash
        - level 2: a standard message, encrypted to a random pubkey
     """
-    if stealthLevel == 2:      # Generate privacy-enhanced payload
+    if stealthLevel == 2:  # Generate privacy-enhanced payload
         # Generate a dummy privkey and derive the pubkey
         dummyPubKeyHex = highlevelcrypto.privToPub(
-            hexlify(helper_random.randomBytes(32)))
+            hexlify(highlevelcrypto.randomBytes(32)))
         # Generate a dummy message of random length
         # (the smallest possible standard-formatted message is 234 bytes)
-        dummyMessage = helper_random.randomBytes(
+        dummyMessage = highlevelcrypto.randomBytes(
             helper_random.randomrandrange(234, 801))
         # Encrypt the message using standard BM encryption (ECIES)
         ackdata = highlevelcrypto.encrypt(dummyMessage, dummyPubKeyHex)
         acktype = 2  # message
         version = 1
 
-    elif stealthLevel == 1:    # Basic privacy payload (random getpubkey)
-        ackdata = helper_random.randomBytes(32)
+    elif stealthLevel == 1:  # Basic privacy payload (random getpubkey)
+        ackdata = highlevelcrypto.randomBytes(32)
         acktype = 0  # getpubkey
         version = 4
 
     else:            # Minimum viable payload (non stealth)
-        ackdata = helper_random.randomBytes(32)
+        ackdata = highlevelcrypto.randomBytes(32)
         acktype = 2  # message
         version = 1
 

--- a/src/helper_random.py
+++ b/src/helper_random.py
@@ -1,12 +1,7 @@
 """Convenience functions for random operations. Not suitable for security / cryptography operations."""
 
-import os
 import random
 
-try:
-    from pyelliptic.openssl import OpenSSL
-except ImportError:
-    from .pyelliptic.openssl import OpenSSL
 
 NoneType = type(None)
 
@@ -14,14 +9,6 @@ NoneType = type(None)
 def seed():
     """Initialize random number generator"""
     random.seed()
-
-
-def randomBytes(n):
-    """Method randomBytes."""
-    try:
-        return os.urandom(n)
-    except NotImplementedError:
-        return OpenSSL.rand(n)
 
 
 def randomshuffle(population):

--- a/src/highlevelcrypto.py
+++ b/src/highlevelcrypto.py
@@ -8,6 +8,7 @@ High level cryptographic functions based on `.pyelliptic` OpenSSL bindings.
 """
 
 import hashlib
+import os
 from binascii import hexlify
 
 import pyelliptic
@@ -17,7 +18,8 @@ from pyelliptic import arithmetic as a
 
 __all__ = [
     'decodeWalletImportFormat', 'encodeWalletImportFormat',
-    'encrypt', 'makeCryptor', 'pointMult', 'privToPub', 'sign', 'verify']
+    'encrypt', 'makeCryptor', 'pointMult', 'privToPub', 'randomBytes',
+    'sign', 'verify']
 
 
 # WIF (uses arithmetic ):
@@ -47,6 +49,16 @@ def encodeWalletImportFormat(privKey):
     privKey = b'\x80' + privKey
     checksum = hashlib.sha256(hashlib.sha256(privKey).digest()).digest()[0:4]
     return a.changebase(privKey + checksum, 256, 58)
+
+
+# Random
+
+def randomBytes(n):
+    """Get n random bytes"""
+    try:
+        return os.urandom(n)
+    except NotImplementedError:
+        return OpenSSL.rand(n)
 
 
 def makeCryptor(privkey, curve='secp256k1'):

--- a/src/network/tcp.py
+++ b/src/network/tcp.py
@@ -16,7 +16,7 @@ import l10n
 import protocol
 import state
 from bmconfigparser import config
-from helper_random import randomBytes
+from highlevelcrypto import randomBytes
 from inventory import Inventory
 from queues import invQueue, receiveDataQueue, UISignalQueue
 from tr import _translate

--- a/src/tests/test_crypto.py
+++ b/src/tests/test_crypto.py
@@ -66,6 +66,14 @@ class TestCrypto(RIPEMD160TestCase, unittest.TestCase):
 class TestHighlevelcrypto(unittest.TestCase):
     """Test highlevelcrypto public functions"""
 
+    def test_randomBytes(self):
+        """Dummy checks for random bytes"""
+        for n in (8, 32, 64):
+            data = highlevelcrypto.randomBytes(n)
+            self.assertEqual(len(data), n)
+            self.assertNotEqual(len(set(data)), 1)
+            self.assertNotEqual(data, highlevelcrypto.randomBytes(n))
+
     def test_signatures(self):
         """Verify sample signatures and newly generated ones"""
         pubkey_hex = hexlify(sample_pubsigningkey)


### PR DESCRIPTION
Hi!

This is another excerpt of the old branch `crypto`: `randomBytes()` belongs to the `highlevelcrypto` because it uses `pyelliptic` and should be used for the keys generation.