### PR TITLE
A test for random address generation

### DIFF
--- a/src/class_singleWorker.py
+++ b/src/class_singleWorker.py
@@ -201,10 +201,11 @@ class singleWorker(StoppableThread):
                 'Could not read or decode privkey for address %s', address)
             raise ValueError
 
-        privSigningKeyHex = hexlify(
-            highlevelcrypto.decodeWalletImportFormat(privSigningKeyBase58))
+        privSigningKeyHex = hexlify(highlevelcrypto.decodeWalletImportFormat(
+            privSigningKeyBase58.encode()))
         privEncryptionKeyHex = hexlify(
-            highlevelcrypto.decodeWalletImportFormat(privEncryptionKeyBase58))
+            highlevelcrypto.decodeWalletImportFormat(
+                privEncryptionKeyBase58.encode()))
 
         # The \x04 on the beginning of the public keys are not sent.
         # This way there is only one acceptable way to encode
@@ -1113,7 +1114,7 @@ class singleWorker(StoppableThread):
                     continue
                 privEncryptionKeyHex = hexlify(
                     highlevelcrypto.decodeWalletImportFormat(
-                        privEncryptionKeyBase58))
+                        privEncryptionKeyBase58.encode()))
                 pubEncryptionKeyBase256 = unhexlify(highlevelcrypto.privToPub(
                     privEncryptionKeyHex))[1:]
                 requiredAverageProofOfWorkNonceTrialsPerByte = \

--- a/src/shared.py
+++ b/src/shared.py
@@ -102,8 +102,8 @@ def reloadMyAddressHashes():
         # Returns a simple 32 bytes of information encoded in 64 Hex characters
         try:
             privEncryptionKey = hexlify(
-                highlevelcrypto.decodeWalletImportFormat(
-                    config.get(addressInKeysFile, 'privencryptionkey')
+                highlevelcrypto.decodeWalletImportFormat(config.get(
+                    addressInKeysFile, 'privencryptionkey').encode()
                 ))
         except ValueError:
             logger.error(

--- a/src/tests/test_addressgenerator.py
+++ b/src/tests/test_addressgenerator.py
@@ -85,3 +85,17 @@ class TestAddressGenerator(TestPartialRun):
             self.config.getboolean(sample_deterministic_addr4, 'chan'))
         self.assertTrue(
             self.config.getboolean(sample_deterministic_addr4, 'enabled'))
+
+    def test_random(self):
+        """Test random address"""
+        self.command_queue.put((
+            'createRandomAddress', 4, 1, 'test_random', 1, '', False, 0, 0))
+        addr = self.return_queue.get()
+        self.assertRegexpMatches(addr, r'^BM-')
+        self.assertRegexpMatches(addr[3:], r'[a-zA-Z1-9]+$')
+        self.assertLessEqual(len(addr[3:]), 40)
+
+        self.assertEqual(
+            self.worker_queue.get(), ('sendOutOrStoreMyV4Pubkey', addr))
+        self.assertEqual(self.config.get(addr, 'label'), 'test_random')
+        self.assertTrue(self.config.getboolean(addr, 'enabled'))


### PR DESCRIPTION
Hi!

After rewriting of `decodeWalletImportFormat()` the test for random address is working. The fix for python3 is trivial and documented [here](https://github.com/Bitmessage/PyBitmessage/blob/v0.6/src/tests/samples.py#L88): the argument should be bytes.