### PR TITLE
Functions for key generation

### DIFF
--- a/src/tests/samples.py
+++ b/src/tests/samples.py
@@ -43,8 +43,9 @@ sample_point = (
 )
 
 sample_seed = b'TIGER, tiger, burning bright. In the forests of the night'
-# Deterministic addresses with stream 1 and versions 3, 4
+# RIPE hash on step 22 with signing key nonce 42
 sample_deterministic_ripe = b'00cfb69416ae76f68a81c459de4e13460c7d17eb'
+# Deterministic addresses with stream 1 and versions 3, 4
 sample_deterministic_addr3 = 'BM-2DBPTgeSawWYZceFD69AbDT5q4iUWtj1ZN'
 sample_deterministic_addr4 = 'BM-2cWzSnwjJ7yRP3nLEWUV5LisTZyREWSzUK'
 sample_daddr3_512 = 18875720106589866286514488037355423395410802084648916523381

--- a/src/tests/test_crypto.py
+++ b/src/tests/test_crypto.py
@@ -8,7 +8,7 @@ import unittest
 from abc import ABCMeta, abstractmethod
 from binascii import hexlify
 
-from pybitmessage import highlevelcrypto
+from pybitmessage import highlevelcrypto, fallback
 
 
 try:
@@ -94,8 +94,8 @@ class TestHighlevelcrypto(unittest.TestCase):
         enkey = highlevelcrypto.deterministic_keys(sample_seed, b'+')[1]
         self.assertEqual(
             sample_deterministic_ripe,
-            hexlify(TestHashlib._hashdigest(
-                hashlib.sha512(sigkey + enkey).digest())))
+            hexlify(fallback.RIPEMD160Hash(
+                hashlib.sha512(sigkey + enkey).digest()).digest()))
 
     def test_signatures(self):
         """Verify sample signatures and newly generated ones"""

--- a/src/tests/test_crypto.py
+++ b/src/tests/test_crypto.py
@@ -17,10 +17,10 @@ except ImportError:
     RIPEMD160 = None
 
 from .samples import (
-    sample_double_sha512, sample_hash_data,
+    sample_deterministic_ripe, sample_double_sha512, sample_hash_data,
     sample_msg, sample_pubsigningkey, sample_pubencryptionkey,
     sample_privsigningkey, sample_privencryptionkey, sample_ripe,
-    sample_sig, sample_sig_sha1
+    sample_seed, sample_sig, sample_sig_sha1
 )
 
 
@@ -80,6 +80,22 @@ class TestHighlevelcrypto(unittest.TestCase):
             self.assertEqual(len(data), n)
             self.assertNotEqual(len(set(data)), 1)
             self.assertNotEqual(data, highlevelcrypto.randomBytes(n))
+
+    def test_random_keys(self):
+        """Dummy checks for random keys"""
+        priv, pub = highlevelcrypto.random_keys()
+        self.assertEqual(len(priv), 32)
+        self.assertEqual(highlevelcrypto.pointMult(priv), pub)
+
+    def test_deterministic_keys(self):
+        """Generate deterministic keys, make ripe and compare it to sample"""
+        # encodeVarint(42) = b'*'
+        sigkey = highlevelcrypto.deterministic_keys(sample_seed, b'*')[1]
+        enkey = highlevelcrypto.deterministic_keys(sample_seed, b'+')[1]
+        self.assertEqual(
+            sample_deterministic_ripe,
+            hexlify(TestHashlib._hashdigest(
+                hashlib.sha512(sigkey + enkey).digest())))
 
     def test_signatures(self):
         """Verify sample signatures and newly generated ones"""


### PR DESCRIPTION
Hi!

This is another part of the old branch `crypto`: key generation. Here `random_keys()` reuses `randomBytes()` and `deterministic_keys()` returns the pair of keys for the given nonce, address generator still needs to choose the nonce by checking the resulting ripe hash.