### PR TITLE
Downgrade devcontainer ubuntu

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 ARG USERNAME=user
 ARG USER_UID=1000


### PR DESCRIPTION
- just released noble doesn't seem to have python-2.7 anymore so we're downgrading to jammy