### PR TITLE
Possible replacement for buildbot/PyBitmessage-pylint

### DIFF
--- a/.buildbot/tox-jammy/test.sh
+++ b/.buildbot/tox-jammy/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-tox -e lint-basic # || exit 1
+tox -e lint || exit 1
 tox -e py310

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,14 @@ commands =
     flake8 pybitmessage --count --select=E9,F63,F7,F82 \
     --show-source --statistics
 
+[testenv:lint]
+skip_install = true
+basepython = python3
+deps =
+     -rrequirements.txt
+     pylint
+commands = pylint --rcfile=tox.ini --exit-zero pybitmessage
+
 [testenv:py27]
 sitepackages = true
 
@@ -65,3 +73,14 @@ omit =
 
 [coverage:report]
 ignore_errors = true
+
+[pylint.main]
+disable =
+    invalid-name,consider-using-f-string,fixme,raise-missing-from,
+    super-with-arguments,unnecessary-pass,unknown-option-value,
+    unspecified-encoding,useless-object-inheritance,useless-option-value
+ignore = bitmessagecurses,bitmessagekivy,bitmessageqt,messagetypes,mockbm,
+    network,plugins,umsgpack,bitmessagecli.py
+
+max-args = 8
+max-attributes = 8


### PR DESCRIPTION
Hi!

I added a tox env for full code linting, currently running only pylint, and used it in the test script for the jammy buildbot dir.