### PR TITLE
Append commit abbreviation to the snap version for non-release builds

### DIFF
--- a/.buildbot/snap/build.sh
+++ b/.buildbot/snap/build.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+git remote add -f upstream https://github.com/Bitmessage/PyBitmessage.git
+HEAD="$(git rev-parse HEAD)"
+UPSTREAM="$(git merge-base --fork-point upstream/v0.6)"
+SNAP_DIFF="$(git diff upstream/v0.6 -- packages/snap .buildbot/snap)"
+
+[ -z "${SNAP_DIFF}" ] && [ $HEAD != $UPSTREAM ] && exit 0
+
 pushd packages && snapcraft || exit 1
 
 popd

--- a/packages/snap/snapcraft.yaml
+++ b/packages/snap/snapcraft.yaml
@@ -28,7 +28,7 @@ parts:
     source: https://github.com/Bitmessage/PyBitmessage.git
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version $(git describe --tags --abbrev=0 | tr -d v)
+      snapcraftctl set-version $(git describe --tags | cut -d- -f1,3 | tr -d v)
     plugin: python
     python-version: python2
     build-packages:


### PR DESCRIPTION
Hello!

This makes the snap files more like the appimages to ease distinguishing between builds.

With the additional change into `.buildbot/snap/build.sh` the snaps are built only for merges into `v0.6` and branches, having changes into the snap recipe or its buildbot dir.