### PR TITLE
Use import paths compatible with both Python2 and Python3

### DIFF
--- a/src/bitmessageqt/__init__.py
+++ b/src/bitmessageqt/__init__.py
@@ -22,38 +22,38 @@ import shared
 import state
 from debug import logger
 from tr import _translate
-from account import (
+from .account import (
     accountClass, getSortedSubscriptions,
     BMAccount, GatewayAccount, MailchuckAccount, AccountColor)
 from addresses import decodeAddress, addBMIfNotPresent
-from bitmessageui import Ui_MainWindow
+from bitmessageqt.bitmessageui import Ui_MainWindow
 from bmconfigparser import config
 import namecoin
-from messageview import MessageView
-from migrationwizard import Ui_MigrationWizard
-from foldertree import (
+from .messageview import MessageView
+from .migrationwizard import Ui_MigrationWizard
+from .foldertree import (
     AccountMixin, Ui_FolderWidget, Ui_AddressWidget, Ui_SubscriptionWidget,
     MessageList_AddressWidget, MessageList_SubjectWidget,
     Ui_AddressBookWidgetItemLabel, Ui_AddressBookWidgetItemAddress,
     MessageList_TimeWidget)
-import settingsmixin
-import support
+from bitmessageqt import settingsmixin
+from bitmessageqt import support
 from helper_sql import sqlQuery, sqlExecute, sqlExecuteChunked, sqlStoredProcedure
 import helper_addressbook
 import helper_search
 import l10n
-from utils import str_broadcast_subscribers, avatarize
-import dialogs
+from .utils import str_broadcast_subscribers, avatarize
+from bitmessageqt import dialogs
 from network.stats import pendingDownload, pendingUpload
-from uisignaler import UISignaler
+from .uisignaler import UISignaler
 import paths
 from proofofwork import getPowType
 import queues
 import shutdown
-from statusbar import BMStatusBar
-import sound
+from .statusbar import BMStatusBar
+from bitmessageqt import sound
 # This is needed for tray icon
-import bitmessage_icons_rc  # noqa:F401 pylint: disable=unused-import
+from bitmessageqt import bitmessage_icons_rc  # noqa:F401 pylint: disable=unused-import
 import helper_sent
 
 try:

--- a/src/bitmessageqt/address_dialogs.py
+++ b/src/bitmessageqt/address_dialogs.py
@@ -8,9 +8,9 @@ import hashlib
 from PyQt4 import QtCore, QtGui
 
 import queues
-import widgets
+from bitmessageqt import widgets
 import state
-from account import AccountMixin, GatewayAccount, MailchuckAccount, accountClass
+from .account import AccountMixin, GatewayAccount, MailchuckAccount, accountClass
 from addresses import addBMIfNotPresent, decodeAddress, encodeVarint
 from bmconfigparser import config as global_config
 from tr import _translate

--- a/src/bitmessageqt/addressvalidator.py
+++ b/src/bitmessageqt/addressvalidator.py
@@ -11,7 +11,7 @@ from addresses import decodeAddress, addBMIfNotPresent
 from bmconfigparser import config
 from queues import apiAddressGeneratorReturnQueue, addressGeneratorQueue
 from tr import _translate
-from utils import str_chan
+from .utils import str_chan
 
 
 class AddressPassPhraseValidatorMixin(object):

--- a/src/bitmessageqt/bitmessageui.py
+++ b/src/bitmessageqt/bitmessageui.py
@@ -9,12 +9,12 @@
 
 from PyQt4 import QtCore, QtGui
 from bmconfigparser import config
-from foldertree import AddressBookCompleter
-from messageview import MessageView
-from messagecompose import MessageCompose
-import settingsmixin
-from networkstatus import NetworkStatus
-from blacklist import Blacklist
+from .foldertree import AddressBookCompleter
+from .messageview import MessageView
+from .messagecompose import MessageCompose
+from bitmessageqt import settingsmixin
+from .networkstatus import NetworkStatus
+from .blacklist import Blacklist
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8

--- a/src/bitmessageqt/blacklist.py
+++ b/src/bitmessageqt/blacklist.py
@@ -3,13 +3,13 @@ from PyQt4 import QtCore, QtGui
 import widgets
 from addresses import addBMIfNotPresent
 from bmconfigparser import config
-from dialogs import AddAddressDialog
+from .dialogs import AddAddressDialog
 from helper_sql import sqlExecute, sqlQuery
 from queues import UISignalQueue
-from retranslateui import RetranslateMixin
+from .retranslateui import RetranslateMixin
 from tr import _translate
-from uisignaler import UISignaler
-from utils import avatarize
+from .uisignaler import UISignaler
+from .utils import avatarize
 
 
 class Blacklist(QtGui.QWidget, RetranslateMixin):

--- a/src/bitmessageqt/dialogs.py
+++ b/src/bitmessageqt/dialogs.py
@@ -5,14 +5,14 @@ Custom dialog classes
 from PyQt4 import QtGui
 
 import paths
-import widgets
-from address_dialogs import (
+from bitmessageqt import widgets
+from .address_dialogs import (
     AddAddressDialog, EmailGatewayDialog, NewAddressDialog,
     NewSubscriptionDialog, RegenerateAddressesDialog,
     SpecialAddressBehaviorDialog
 )
-from newchandialog import NewChanDialog
-from settings import SettingsDialog
+from .newchandialog import NewChanDialog
+from .settings import SettingsDialog
 from tr import _translate
 from version import softwareVersion
 

--- a/src/bitmessageqt/foldertree.py
+++ b/src/bitmessageqt/foldertree.py
@@ -10,9 +10,9 @@ from PyQt4 import QtCore, QtGui
 
 from bmconfigparser import config
 from helper_sql import sqlExecute, sqlQuery
-from settingsmixin import SettingsMixin
+from .settingsmixin import SettingsMixin
 from tr import _translate
-from utils import avatarize
+from .utils import avatarize
 
 # for pylupdate
 _translate("MainWindow", "inbox")

--- a/src/bitmessageqt/messageview.py
+++ b/src/bitmessageqt/messageview.py
@@ -7,7 +7,7 @@ zoom and URL click warning popup
 
 from PyQt4 import QtCore, QtGui
 
-from safehtmlparser import SafeHTMLParser
+from .safehtmlparser import SafeHTMLParser
 from tr import _translate
 
 

--- a/src/bitmessageqt/networkstatus.py
+++ b/src/bitmessageqt/networkstatus.py
@@ -9,11 +9,11 @@ from PyQt4 import QtCore, QtGui
 import l10n
 import network.stats
 import state
-import widgets
+from bitmessageqt import widgets
 from network import connectionpool, knownnodes
-from retranslateui import RetranslateMixin
+from .retranslateui import RetranslateMixin
 from tr import _translate
-from uisignaler import UISignaler
+from .uisignaler import UISignaler
 
 
 class NetworkStatus(QtGui.QWidget, RetranslateMixin):

--- a/src/bitmessageqt/newchandialog.py
+++ b/src/bitmessageqt/newchandialog.py
@@ -6,13 +6,13 @@ src/bitmessageqt/newchandialog.py
 
 from PyQt4 import QtCore, QtGui
 
-import widgets
+from bitmessageqt import widgets
 from addresses import addBMIfNotPresent
-from addressvalidator import AddressValidator, PassPhraseValidator
+from .addressvalidator import AddressValidator, PassPhraseValidator
 from queues import (
     addressGeneratorQueue, apiAddressGeneratorReturnQueue, UISignalQueue)
 from tr import _translate
-from utils import str_chan
+from .utils import str_chan
 
 
 class NewChanDialog(QtGui.QDialog):

--- a/src/bitmessageqt/retranslateui.py
+++ b/src/bitmessageqt/retranslateui.py
@@ -1,7 +1,7 @@
 from os import path
 from PyQt4 import QtGui
 from debug import logger
-import widgets
+from bitmessageqt import widgets
 
 class RetranslateMixin(object):
     def retranslateUi(self):

--- a/src/bitmessageqt/settings.py
+++ b/src/bitmessageqt/settings.py
@@ -16,7 +16,7 @@ import openclpow
 import paths
 import queues
 import state
-import widgets
+from bitmessageqt import widgets
 from bmconfigparser import config as config_obj
 from helper_sql import sqlExecute, sqlStoredProcedure
 from helper_startup import start_proxyconfig

--- a/src/bitmessageqt/support.py
+++ b/src/bitmessageqt/support.py
@@ -8,7 +8,7 @@ import time
 
 from PyQt4 import QtCore
 
-import account
+from bitmessageqt import account
 import defaults
 import network.stats
 import paths
@@ -16,12 +16,12 @@ import proofofwork
 import queues
 import state
 from bmconfigparser import config
-from foldertree import AccountMixin
+from .foldertree import AccountMixin
 from helper_sql import sqlExecute, sqlQuery
 from l10n import getTranslationLanguage
 from openclpow import openclEnabled
 from pyelliptic.openssl import OpenSSL
-from settings import getSOCKSProxyType
+from .settings import getSOCKSProxyType
 from version import softwareVersion
 from tr import _translate
 

--- a/src/bitmessageqt/tests/__init__.py
+++ b/src/bitmessageqt/tests/__init__.py
@@ -1,9 +1,9 @@
 """bitmessageqt tests"""
 
-from addressbook import TestAddressbook
-from main import TestMain, TestUISignaler
-from settings import TestSettings
-from support import TestSupport
+from .addressbook import TestAddressbook
+from .main import TestMain, TestUISignaler
+from .settings import TestSettings
+from .support import TestSupport
 
 __all__ = [
     "TestAddressbook", "TestMain", "TestSettings", "TestSupport",

--- a/src/bitmessageqt/tests/addressbook.py
+++ b/src/bitmessageqt/tests/addressbook.py
@@ -1,7 +1,7 @@
 import helper_addressbook
 from bitmessageqt.support import createAddressIfNeeded
 
-from main import TestBase
+from .main import TestBase
 
 
 class TestAddressbook(TestBase):

--- a/src/bitmessageqt/tests/settings.py
+++ b/src/bitmessageqt/tests/settings.py
@@ -1,7 +1,7 @@
 import threading
 import time
 
-from main import TestBase
+from .main import TestBase
 from bmconfigparser import config
 from bitmessageqt import settings
 

--- a/src/bitmessageqt/tests/support.py
+++ b/src/bitmessageqt/tests/support.py
@@ -4,7 +4,7 @@ import sys
 
 from shared import isAddressInMyAddressBook
 
-from main import TestBase
+from .main import TestBase
 
 
 class TestSupport(TestBase):

--- a/src/network/__init__.py
+++ b/src/network/__init__.py
@@ -12,7 +12,7 @@ def start(config, state):
     """Start network threads"""
     import state
     from .announcethread import AnnounceThread
-    import connectionpool  # pylint: disable=relative-import
+    from network import connectionpool
     from .addrthread import AddrThread
     from .dandelion import Dandelion
     from .downloadthread import DownloadThread

--- a/src/network/addrthread.py
+++ b/src/network/addrthread.py
@@ -4,12 +4,12 @@ Announce addresses as they are received from other hosts
 from six.moves import queue
 
 # magic imports!
-import connectionpool
+from network import connectionpool
 from helper_random import randomshuffle
 from protocol import assembleAddrMessage
 from queues import addrQueue  # FIXME: init with queue
 
-from threads import StoppableThread
+from .threads import StoppableThread
 
 
 class AddrThread(StoppableThread):

--- a/src/network/advanceddispatcher.py
+++ b/src/network/advanceddispatcher.py
@@ -7,7 +7,7 @@ import time
 
 import network.asyncore_pollchoose as asyncore
 import state
-from threads import BusyError, nonBlocking
+from .threads import BusyError, nonBlocking
 
 
 class ProcessingError(Exception):

--- a/src/network/announcethread.py
+++ b/src/network/announcethread.py
@@ -4,12 +4,12 @@ Announce myself (node address)
 import time
 
 # magic imports!
-import connectionpool
+from network import connectionpool
 from bmconfigparser import config
 from protocol import assembleAddrMessage
 
-from node import Peer
-from threads import StoppableThread
+from .node import Peer
+from .threads import StoppableThread
 
 
 class AnnounceThread(StoppableThread):

--- a/src/network/bmobject.py
+++ b/src/network/bmobject.py
@@ -6,7 +6,7 @@ import time
 
 import protocol
 import state
-import connectionpool
+import network.connectionpool  # use long name to address recursive import
 from highlevelcrypto import calculateInventoryHash
 
 logger = logging.getLogger('default')
@@ -99,7 +99,7 @@ class BMObject(object):  # pylint: disable=too-many-instance-attributes
             logger.warning(
                 'The object has invalid stream: %s', self.streamNumber)
             raise BMObjectInvalidError()
-        if self.streamNumber not in connectionpool.pool.streams:
+        if self.streamNumber not in network.connectionpool.pool.streams:
             logger.debug(
                 'The streamNumber %i isn\'t one we are interested in.',
                 self.streamNumber)

--- a/src/network/connectionchooser.py
+++ b/src/network/connectionchooser.py
@@ -5,7 +5,7 @@ Select which node to connect to
 import logging
 import random
 
-import knownnodes
+from network import knownnodes
 import protocol
 import state
 from bmconfigparser import config

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -8,19 +8,19 @@ import socket
 import sys
 import time
 
-import asyncore_pollchoose as asyncore
+from network import asyncore_pollchoose as asyncore
 import helper_random
-import knownnodes
+from network import knownnodes
 import protocol
 import state
 from bmconfigparser import config
-from connectionchooser import chooseConnection
-from node import Peer
-from proxy import Proxy
-from tcp import (
+from .connectionchooser import chooseConnection
+from .node import Peer
+from .proxy import Proxy
+from .tcp import (
     bootstrap, Socks4aBMConnection, Socks5BMConnection,
     TCPConnection, TCPServer)
-from udp import UDPSocket
+from .udp import UDPSocket
 
 logger = logging.getLogger('default')
 

--- a/src/network/dandelion.py
+++ b/src/network/dandelion.py
@@ -7,7 +7,7 @@ from random import choice, expovariate, sample
 from threading import RLock
 from time import time
 
-import connectionpool
+from network import connectionpool
 import state
 from queues import invQueue
 

--- a/src/network/downloadthread.py
+++ b/src/network/downloadthread.py
@@ -6,9 +6,9 @@ import state
 import addresses
 import helper_random
 import protocol
-import connectionpool
-from objectracker import missingObjects
-from threads import StoppableThread
+from network import connectionpool
+from .objectracker import missingObjects
+from .threads import StoppableThread
 
 
 class DownloadThread(StoppableThread):

--- a/src/network/http.py
+++ b/src/network/http.py
@@ -1,10 +1,10 @@
 import socket
 
-from advanceddispatcher import AdvancedDispatcher
-import asyncore_pollchoose as asyncore
-from proxy import ProxyError
-from socks5 import Socks5Connection, Socks5Resolver
-from socks4a import Socks4aConnection, Socks4aResolver
+from .advanceddispatcher import AdvancedDispatcher
+from network import asyncore_pollchoose as asyncore
+from .proxy import ProxyError
+from .socks5 import Socks5Connection, Socks5Resolver
+from .socks4a import Socks4aConnection, Socks4aResolver
 
 
 class HttpError(ProxyError):

--- a/src/network/invthread.py
+++ b/src/network/invthread.py
@@ -8,9 +8,9 @@ from time import time
 import addresses
 import protocol
 import state
-import connectionpool
+from network import connectionpool
 from queues import invQueue
-from threads import StoppableThread
+from .threads import StoppableThread
 
 
 def handleExpiredDandelion(expired):

--- a/src/network/networkthread.py
+++ b/src/network/networkthread.py
@@ -2,9 +2,9 @@
 A thread to handle network concerns
 """
 import network.asyncore_pollchoose as asyncore
-import connectionpool
+from network import connectionpool
 from queues import excQueue
-from threads import StoppableThread
+from .threads import StoppableThread
 
 
 class BMNetworkThread(StoppableThread):

--- a/src/network/objectracker.py
+++ b/src/network/objectracker.py
@@ -5,7 +5,7 @@ import time
 from threading import RLock
 
 import state
-import connectionpool
+import network.connectionpool  # use long name to address recursive import
 from randomtrackingdict import RandomTrackingDict
 
 haveBloom = False
@@ -100,7 +100,7 @@ class ObjectTracker(object):
 
     def handleReceivedObject(self, streamNumber, hashid):
         """Handling received object"""
-        for i in connectionpool.pool.connections():
+        for i in network.connectionpool.pool.connections():
             if not i.fullyEstablished:
                 continue
             try:

--- a/src/network/proxy.py
+++ b/src/network/proxy.py
@@ -6,10 +6,10 @@ import logging
 import socket
 import time
 
-import asyncore_pollchoose as asyncore
-from advanceddispatcher import AdvancedDispatcher
+from network import asyncore_pollchoose as asyncore
+from .advanceddispatcher import AdvancedDispatcher
 from bmconfigparser import config
-from node import Peer
+from .node import Peer
 
 logger = logging.getLogger('default')
 

--- a/src/network/receivequeuethread.py
+++ b/src/network/receivequeuethread.py
@@ -5,10 +5,10 @@ import errno
 import Queue
 import socket
 
-import connectionpool
+from network import connectionpool
 from network.advanceddispatcher import UnknownStateError
 from queues import receiveDataQueue
-from threads import StoppableThread
+from .threads import StoppableThread
 
 
 class ReceiveQueueThread(StoppableThread):

--- a/src/network/socks4a.py
+++ b/src/network/socks4a.py
@@ -6,7 +6,7 @@ import logging
 import socket
 import struct
 
-from proxy import GeneralProxyError, Proxy, ProxyError
+from .proxy import GeneralProxyError, Proxy, ProxyError
 
 logger = logging.getLogger('default')
 

--- a/src/network/socks5.py
+++ b/src/network/socks5.py
@@ -7,8 +7,8 @@ import logging
 import socket
 import struct
 
-from node import Peer
-from proxy import GeneralProxyError, Proxy, ProxyError
+from .node import Peer
+from .proxy import GeneralProxyError, Proxy, ProxyError
 
 logger = logging.getLogger('default')
 

--- a/src/network/stats.py
+++ b/src/network/stats.py
@@ -3,9 +3,9 @@ Network statistics
 """
 import time
 
-import asyncore_pollchoose as asyncore
-import connectionpool
-from objectracker import missingObjects
+from network import asyncore_pollchoose as asyncore
+from network import connectionpool
+from .objectracker import missingObjects
 
 
 lastReceivedTimestamp = time.time()

--- a/src/network/udp.py
+++ b/src/network/udp.py
@@ -8,12 +8,12 @@ import time
 # magic imports!
 import protocol
 import state
-import connectionpool
+import network.connectionpool  # use long name to address recursive import
 from queues import receiveDataQueue
 
-from bmproto import BMProto
-from node import Peer
-from objectracker import ObjectTracker
+from .bmproto import BMProto
+from .node import Peer
+from .objectracker import ObjectTracker
 
 
 logger = logging.getLogger('default')
@@ -82,7 +82,7 @@ class UDPSocket(BMProto):  # pylint: disable=too-many-instance-attributes
         remoteport = False
         for seenTime, stream, _, ip, port in addresses:
             decodedIP = protocol.checkIPAddress(str(ip))
-            if stream not in connectionpool.pool.streams:
+            if stream not in network.connectionpool.pool.streams:
                 continue
             if (seenTime < time.time() - protocol.MAX_TIME_OFFSET
                     or seenTime > time.time() + protocol.MAX_TIME_OFFSET):

--- a/src/network/uploadthread.py
+++ b/src/network/uploadthread.py
@@ -6,9 +6,9 @@ import time
 import helper_random
 import protocol
 import state
-import connectionpool
+from network import connectionpool
 from randomtrackingdict import RandomTrackingDict
-from threads import StoppableThread
+from .threads import StoppableThread
 
 
 class UploadThread(StoppableThread):


### PR DESCRIPTION
Restrictions for import paths are different in Python2 and Python3.
This patch fixes existing import paths to be compatible with both Python2 and Python3.
