### PR TITLE
Use buffer() in Python2 and use memoryview in Python3

### DIFF
--- a/src/class_singleWorker.py
+++ b/src/class_singleWorker.py
@@ -30,6 +30,7 @@ from bmconfigparser import config
 from helper_sql import sqlExecute, sqlQuery
 from network import knownnodes, StoppableThread
 from six.moves import configparser, queue
+import six
 
 
 def sizeof_fmt(num, suffix='h/s'):
@@ -515,9 +516,15 @@ class singleWorker(StoppableThread):
             payload, TTL, log_prefix='(For onionpeer object)')
 
         inventoryHash = highlevelcrypto.calculateInventoryHash(payload)
+        if six.PY2:
+            payload_buffer = buffer(payload)
+            tag_buffer = buffer(tag)
+        else:  # assume six.PY3
+            payload_buffer = memoryview(payload)
+            tag_buffer = memoryview(tag)
         state.Inventory[inventoryHash] = (
-            objectType, streamNumber, buffer(payload),  # noqa: F821
-            embeddedTime, buffer(tag)  # noqa: F821
+            objectType, streamNumber, payload_buffer,  # noqa: F821
+            embeddedTime, tag_buffer  # noqa: F821
         )
         self.logger.info(
             'sending inv (within sendOnionPeerObj function) for object: %s',

--- a/src/network/bmproto.py
+++ b/src/network/bmproto.py
@@ -9,6 +9,7 @@ import re
 import socket
 import struct
 import time
+import six
 
 # magic imports!
 import addresses
@@ -409,8 +410,12 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
 
         try:
             self.object.checkObjectByType()
+            if six.PY2:
+                data_buffer = buffer(self.object.data)
+            else:  # assume six.PY3
+                data_buffer = memoryview(self.object.data)
             objectProcessorQueue.put((
-                self.object.objectType, buffer(self.object.data)))  # noqa: F821
+                self.object.objectType, data_buffer))  # noqa: F821
         except BMObjectInvalidError:
             BMProto.stopDownloadingObject(self.object.inventoryHash, True)
         else:
@@ -424,10 +429,16 @@ class BMProto(AdvancedDispatcher, ObjectTracker):
             state.Dandelion.removeHash(
                 self.object.inventoryHash, "cycle detection")
 
+        if six.PY2:
+            object_buffer = buffer(self.payload[objectOffset:])
+            tag_buffer = buffer(self.object.tag)
+        else:  # assume six.PY3
+            object_buffer = memoryview(self.payload[objectOffset:])
+            tag_buffer = memoryview(self.object.tag)
         state.Inventory[self.object.inventoryHash] = (
             self.object.objectType, self.object.streamNumber,
-            buffer(self.payload[objectOffset:]), self.object.expiresTime,  # noqa: F821
-            buffer(self.object.tag)  # noqa: F821
+            object_buffer, self.object.expiresTime,  # noqa: F821
+            tag_buffer  # noqa: F821
         )
         self.handleReceivedObject(
             self.object.streamNumber, self.object.inventoryHash)


### PR DESCRIPTION
This patch is a Python2-Python3 compatibility issue.

The builtin function buffer() in Python2 is renamed to memoryview() in Python3.
Although memoryview() is also defined in Python2, its behavior has subtle difference, so buffer() can not be simply replaced to memoryview().
Python seems not to be able to pass argument in reference in function parameter, so it is not able to define a function that choose the implementaton of buffer()/memoryview().
So branching by if statement seems to be necessary.
