### PR TITLE
Disambiguate the appimage builds

### DIFF
--- a/.buildbot/appimage/build.sh
+++ b/.buildbot/appimage/build.sh
@@ -4,7 +4,11 @@ export APPIMAGE_EXTRACT_AND_RUN=1
 BUILDER=appimage-builder-x86_64.AppImage
 RECIPE=packages/AppImage/AppImageBuilder.yml
 
+git remote add -f upstream https://github.com/Bitmessage/PyBitmessage.git
+HEAD="$(git rev-parse HEAD)"
+UPSTREAM="$(git merge-base --fork-point upstream/v0.6)"
 export APP_VERSION=$(git describe --tags | cut -d- -f1,3 | tr -d v)
+[ $HEAD != $UPSTREAM ] && APP_VERSION="${APP_VERSION}-alpha"
 
 function set_sourceline {
     if [ ${ARCH} == amd64 ]; then

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,10 +2,41 @@
 - Binary (64bit, no separate installation of dependencies required)
     - Windows: https://download.bitmessage.org/snapshots/
     - Linux AppImages: https://artifacts.bitmessage.at/appimage/
-	- Linux snaps: https://artifacts.bitmessage.at/snap/
+    - Linux snaps: https://artifacts.bitmessage.at/snap/
     - Mac (not up to date): https://github.com/Bitmessage/PyBitmessage/releases/tag/v0.6.1
 - Source
     `git clone git://github.com/Bitmessage/PyBitmessage.git`
+
+## Notes on the AppImages
+
+The [AppImage](https://docs.appimage.org/introduction/index.html)
+is a bundle, built by the
+[appimage-builder](https://github.com/AppImageCrafters/appimage-builder) from
+the Ubuntu Bionic deb files, the sources and `bitmsghash.so`, precompiled for
+3 architectures, using the `packages/AppImage/AppImageBuilder.yml` recipe.
+
+When you run the appimage the bundle is loop mounted to a location like
+`/tmp/.mount_PyBitm97wj4K` with `squashfs-tools`.
+
+The appimage name has several informational filds:
+```
+PyBitmessage-<VERSION>-g<COMMITHASH>[-alpha]-<ARCH>.AppImage
+```
+
+E.g. `PyBitmessage-0.6.3.2-ge571ba8a-x86_64.AppImage` is an appimage, built from
+the `v0.6` for x86_64 and `PyBitmessage-0.6.3.2-g9de2aaf1-alpha-aarch64.AppImage`
+is one, built from some development branch for arm64.
+
+You can also build the appimage with local code. For that you need installed
+docker:
+
+```
+$ docker build -t bm-appimage -f .buildbot/appimage/Dockerfile .
+$ docker run -t --rm -v "$(pwd)"/dist:/out bm-appimage .buildbot/appimage/build.sh
+```
+
+The appimages should be in the dist dir.
+
 
 ## Helper Script for building from source
 Go to the directory with PyBitmessage source code and run:


### PR DESCRIPTION
Hi!

I propose adding the `alpha` suffixes to the version of appimages, built from a development (none `v0.6`) branch.