### PR TITLE
Use six to avoid obsolete unittest assertions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # PyBitmessage Installation Instructions
 - Binary (64bit, no separate installation of dependencies required)
-    - Windows: https://download.bitmessage.org/snapshots/
+    - Windows: https://artifacts.bitmessage.at/winebuild/
     - Linux AppImages: https://artifacts.bitmessage.at/appimage/
     - Linux snaps: https://artifacts.bitmessage.at/snap/
     - Mac (not up to date): https://github.com/Bitmessage/PyBitmessage/releases/tag/v0.6.1

--- a/src/tests/test_addressgenerator.py
+++ b/src/tests/test_addressgenerator.py
@@ -2,6 +2,7 @@
 
 from binascii import unhexlify
 
+import six
 from six.moves import queue
 
 from .partial import TestPartialRun
@@ -91,8 +92,8 @@ class TestAddressGenerator(TestPartialRun):
         self.command_queue.put((
             'createRandomAddress', 4, 1, 'test_random', 1, '', False, 0, 0))
         addr = self.return_queue.get()
-        self.assertRegexpMatches(addr, r'^BM-')
-        self.assertRegexpMatches(addr[3:], r'[a-zA-Z1-9]+$')
+        six.assertRegex(self, addr, r'^BM-')
+        six.assertRegex(self, addr[3:], r'[a-zA-Z1-9]+$')
         self.assertLessEqual(len(addr[3:]), 40)
 
         self.assertEqual(

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -5,11 +5,11 @@ Tests using API.
 import base64
 import json
 import time
-
 from binascii import hexlify
-from six.moves import xmlrpc_client  # nosec
 
 import psutil
+import six
+from six.moves import xmlrpc_client  # nosec
 
 from .samples import (
     sample_deterministic_addr3, sample_deterministic_addr4, sample_seed,
@@ -174,29 +174,29 @@ class TestAPI(TestAPIProto):
         self.assertEqual(
             self.api.getDeterministicAddress(self._seed, 3, 1),
             sample_deterministic_addr3)
-        self.assertRegexpMatches(
-            self.api.getDeterministicAddress(self._seed, 2, 1),
+        six.assertRegex(
+            self, self.api.getDeterministicAddress(self._seed, 2, 1),
             r'^API Error 0002:')
 
         # This is here until the streams will be implemented
-        self.assertRegexpMatches(
-            self.api.getDeterministicAddress(self._seed, 3, 2),
+        six.assertRegex(
+            self, self.api.getDeterministicAddress(self._seed, 3, 2),
             r'API Error 0003:')
-        self.assertRegexpMatches(
-            self.api.createDeterministicAddresses(self._seed, 1, 4, 2),
+        six.assertRegex(
+            self, self.api.createDeterministicAddresses(self._seed, 1, 4, 2),
             r'API Error 0003:')
 
-        self.assertRegexpMatches(
-            self.api.createDeterministicAddresses('', 1),
+        six.assertRegex(
+            self, self.api.createDeterministicAddresses('', 1),
             r'API Error 0001:')
-        self.assertRegexpMatches(
-            self.api.createDeterministicAddresses(self._seed, 1, 2),
+        six.assertRegex(
+            self, self.api.createDeterministicAddresses(self._seed, 1, 2),
             r'API Error 0002:')
-        self.assertRegexpMatches(
-            self.api.createDeterministicAddresses(self._seed, 0),
+        six.assertRegex(
+            self, self.api.createDeterministicAddresses(self._seed, 0),
             r'API Error 0004:')
-        self.assertRegexpMatches(
-            self.api.createDeterministicAddresses(self._seed, 1000),
+        six.assertRegex(
+            self, self.api.createDeterministicAddresses(self._seed, 1000),
             r'API Error 0005:')
 
         addresses = json.loads(
@@ -210,8 +210,8 @@ class TestAPI(TestAPIProto):
     def test_create_random_address(self):
         """API command 'createRandomAddress': basic BM-address validation"""
         addr = self._add_random_address('random_1')
-        self.assertRegexpMatches(addr, r'^BM-')
-        self.assertRegexpMatches(addr[3:], r'[a-zA-Z1-9]+$')
+        six.assertRegex(self, addr, r'^BM-')
+        six.assertRegex(self, addr[3:], r'[a-zA-Z1-9]+$')
         # Whitepaper says "around 36 character"
         self.assertLessEqual(len(addr[3:]), 40)
         self.assertEqual(self.api.deleteAddress(addr), 'success')
@@ -411,7 +411,7 @@ class TestAPI(TestAPIProto):
             self.assertEqual(self.api.enableAddress(addr, False), 'success')
             result = self.api.sendBroadcast(
                 addr, base64.encodestring('test_subject'), msg)
-            self.assertRegexpMatches(result, r'^API Error 0014:')
+            six.assertRegex(self, result, r'^API Error 0014:')
         finally:
             self.assertEqual(self.api.deleteAddress(addr), 'success')
 
@@ -420,7 +420,7 @@ class TestAPI(TestAPIProto):
         result = self.api.sendBroadcast(
             'BM-GtovgYdgs7qXPkoYaRgrLFuFKz1SFpsw',
             base64.encodestring('test_subject'), msg)
-        self.assertRegexpMatches(result, r'^API Error 0013:')
+        six.assertRegex(self, result, r'^API Error 0013:')
 
     def test_chan(self):
         """Testing chan creation/joining"""
@@ -435,7 +435,7 @@ class TestAPI(TestAPIProto):
             self.assertEqual(self.api.joinChan(self._seed, addr), 'success')
             self.assertEqual(self.api.leaveChan(addr), 'success')
         # Joining with wrong address should fail
-        self.assertRegexpMatches(
-            self.api.joinChan(self._seed, 'BM-2cWzSnwjJ7yRP3nLEW'),
+        six.assertRegex(
+            self, self.api.joinChan(self._seed, 'BM-2cWzSnwjJ7yRP3nLEW'),
             r'^API Error 0008:'
         )

--- a/src/tests/test_inventory.py
+++ b/src/tests/test_inventory.py
@@ -7,6 +7,8 @@ import tempfile
 import time
 import unittest
 
+import six
+
 from pybitmessage import highlevelcrypto
 from pybitmessage.storage import storage
 
@@ -50,8 +52,8 @@ class TestStorageAbstract(unittest.TestCase):
 
     def test_inventory_storage(self):
         """Check inherited abstract methods"""
-        with self.assertRaisesRegexp(
-            TypeError, "^Can't instantiate abstract class.*"
+        with six.assertRaisesRegex(
+            self, TypeError, "^Can't instantiate abstract class.*"
             "methods __contains__, __delitem__, __getitem__, __iter__,"
             " __len__, __setitem__"
         ):  # pylint: disable=abstract-class-instantiated

--- a/src/tests/test_logger.py
+++ b/src/tests/test_logger.py
@@ -5,6 +5,8 @@ Testing the logger configuration
 import os
 import tempfile
 
+import six
+
 from .test_process import TestProcessProto
 
 
@@ -52,5 +54,5 @@ handlers=default
 
         self._stop_process()
         data = open(self.log_file).read()
-        self.assertRegexpMatches(data, self.pattern)
-        self.assertRegexpMatches(data, 'Loaded logger configuration')
+        six.assertRegex(self, data, self.pattern)
+        six.assertRegex(self, data, 'Loaded logger configuration')


### PR DESCRIPTION
Hello!

I removed some deprecation warnings in tests output, like [here](https://buildbot.bitmessage.org/#/builders/33/builds/29633/steps/7/logs/stdio) in line 954, 832, 830. Inspired by one of the recent PRs.