### PR TITLE
fix kivy build - restrict setuptools < 71

### DIFF
--- a/.buildbot/kivy/Dockerfile
+++ b/.buildbot/kivy/Dockerfile
@@ -15,4 +15,4 @@ RUN apt-get install -yq \
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install --upgrade setuptools pip
+RUN pip3 install --upgrade 'setuptools<71' pip


### PR DESCRIPTION
Kivy build fails with setuptool >= 71. More information [here](https://github.com/pypa/setuptools/issues/4478)
