### PR TITLE
Additionally quote vars in appimage/build.sh

### DIFF
--- a/.buildbot/appimage/build.sh
+++ b/.buildbot/appimage/build.sh
@@ -8,7 +8,7 @@ git remote add -f upstream https://github.com/Bitmessage/PyBitmessage.git
 HEAD="$(git rev-parse HEAD)"
 UPSTREAM="$(git merge-base --fork-point upstream/v0.6)"
 export APP_VERSION=$(git describe --tags | cut -d- -f1,3 | tr -d v)
-[ $HEAD != $UPSTREAM ] && APP_VERSION="${APP_VERSION}-alpha"
+[ "$HEAD" != "$UPSTREAM" ] && APP_VERSION="${APP_VERSION}-alpha"
 
 function set_sourceline {
     if [ ${ARCH} == amd64 ]; then


### PR DESCRIPTION
Hi!

The appimage, built from my recent push, surprisingly had no `alpha` suffix. The [log](https://buildbot.bitmessage.org/#/builders/33/builds/33585/steps/4/logs/stdio) says
```
.buildbot/appimage/build.sh: line 11: [: 965978fa5c7b6a5a3af071c2a07c196c1a388914: unary operator expected
```

It seems fixed by adding the additional quotes.