### PR TITLE
Don't put compiled bitmsghash.so into the dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ __pycache__
 .buildozer
 .tox
 mprofile_*
+**.so


### PR DESCRIPTION
Hi!

I faced the "maximum recursion depth exceeded" issue once again, running the `docker-test.sh` script. It was caused by an existing `bitmsghash.co` linked against openssl-3.0.