### PR TITLE
Minor visual changes for the Network Status connections table

### DIFF
--- a/src/bitmessageqt/networkstatus.py
+++ b/src/bitmessageqt/networkstatus.py
@@ -192,12 +192,13 @@ class NetworkStatus(QtGui.QWidget, RetranslateMixin):
                 0, 1,
                 QtGui.QTableWidgetItem("%s" % (rating))
             )
-            if outbound:
-                brush = QtGui.QBrush(QtGui.QColor("yellow"), QtCore.Qt.SolidPattern)
-            else:
-                brush = QtGui.QBrush(QtGui.QColor("green"), QtCore.Qt.SolidPattern)
+            brush = QtGui.QBrush(
+                QtGui.QColor("yellow" if outbound else "green"),
+                QtCore.Qt.SolidPattern)
             for j in range(1):
                 self.tableWidgetConnectionCount.item(0, j).setBackground(brush)
+                self.tableWidgetConnectionCount.item(0, j).setForeground(
+                    QtGui.QBrush(QtGui.QColor("black"), QtCore.Qt.SolidPattern))
             self.tableWidgetConnectionCount.item(0, 0).setData(QtCore.Qt.UserRole, destination)
             self.tableWidgetConnectionCount.item(0, 1).setData(QtCore.Qt.UserRole, outbound)
         else:

--- a/src/bitmessageqt/networkstatus.ui
+++ b/src/bitmessageqt/networkstatus.ui
@@ -78,6 +78,8 @@
             </colorrole>
            </disabled>
           </palette>
+         <property name="focusPolicy">
+          <enum>Qt::NoFocus</enum>
          </property>
          <property name="frameShape">
           <enum>QFrame::Box</enum>

--- a/src/bitmessageqt/networkstatus.ui
+++ b/src/bitmessageqt/networkstatus.ui
@@ -16,6 +16,13 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="styleSheet">
+   <string notr="true">
+STableWidget {
+    background: palette(Button);
+}
+</string>
+  </property>
   <layout class="QHBoxLayout" name="horizontalLayout_3">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
@@ -42,42 +49,6 @@
        </item>
        <item>
         <widget class="STableWidget" name="tableWidgetConnectionCount">
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>212</red>
-               <green>208</green>
-               <blue>200</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>212</red>
-               <green>208</green>
-               <blue>200</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="Base">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>212</red>
-               <green>208</green>
-               <blue>200</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
          <property name="focusPolicy">
           <enum>Qt::NoFocus</enum>
          </property>


### PR DESCRIPTION
Hi!

I disabled phantom "selection" of cells (which is actually a focus) in the connections table and made a couple of improvements for [dark] themes. One, discussed earlier in the chan, - to make text color black on bright backgrounds, and the second - removed a custom palette, replacing it with a stylesheet, which specifies background for the `STableWidget` as the "Button" role (or should it be "Window"?).

I recognize an intention to make the background not being white, but the chosen color may not fit some non-standard themes. This change also requires to restart the app after switching the theme.

I'd also change the peer background colors to some milder ones, e.g. "Gold" and "SeaGreen", but it's a matter of taste.