### PR TITLE
Devcontainer compatibility fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,6 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-setuptools \
     python2.7 \
     python2.7-dev \
+    python-six \
     python3 \
     python3-dev \
     python3-flake8 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
             ],
             "settings": {
                 "flake8.args": ["--config=setup.cfg"],
-                "pylint.args": ["--rcfile=setup.cfg"],
+                "pylint.args": ["--rcfile=setup.cfg", "--init-hook", "import sys;sys.path.append('src')"],
                 "terminal.integrated.shell.linux": "/usr/bin/zsh",
                 "terminal.integrated.defaultProfile.linux": "zsh",
                 "terminal.integrated.fontFamily": "'SourceCodePro+Powerline+Awesome Regular'",


### PR DESCRIPTION
- missing Python 2 six
- pylint relative imports