### PR TITLE
Remove excessive pylint comments

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -525,7 +525,7 @@ class BMRPCDispatcher(object):
             status, addressVersionNumber, streamNumber, ripe)
 
     @staticmethod
-    def _dump_inbox_message(  # pylint: disable=too-many-arguments
+    def _dump_inbox_message(
             msgid, toAddress, fromAddress, subject, received,
             message, encodingtype, read):
         subject = shared.fixPotentiallyInvalidUTF8Data(subject)
@@ -771,7 +771,6 @@ class BMRPCDispatcher(object):
         ))
         return queues.apiAddressGeneratorReturnQueue.get()
 
-    # pylint: disable=too-many-arguments
     @command('createDeterministicAddresses')
     def HandleCreateDeterministicAddresses(
         self, passphrase, numberOfAddresses=1, addressVersionNumber=0,

--- a/src/helper_search.py
+++ b/src/helper_search.py
@@ -28,7 +28,7 @@ def search_sql(
     :return: all messages where <where> field contains <what>
     :rtype: list[list]
     """
-    # pylint: disable=too-many-arguments, too-many-branches
+    # pylint: disable=too-many-branches
     if what:
         what = '%' + what + '%'
         if where == _translate("MainWindow", "To"):
@@ -84,7 +84,6 @@ def check_match(
     Check if a single message matches a filter (used when new messages
     are added to messagelists)
     """
-    # pylint: disable=too-many-arguments
     if not what:
         return True
 

--- a/src/network/bmobject.py
+++ b/src/network/bmobject.py
@@ -40,7 +40,7 @@ class BMObjectAlreadyHaveError(Exception):
     errorCodes = ("Already have this object")
 
 
-class BMObject(object):  # pylint: disable=too-many-instance-attributes
+class BMObject(object):
     """Bitmessage Object as a class."""
 
     # max TTL, 28 days and 3 hours
@@ -57,7 +57,7 @@ class BMObject(object):  # pylint: disable=too-many-instance-attributes
             streamNumber,
             data,
             payloadOffset
-    ):  # pylint: disable=too-many-arguments
+    ):
         self.nonce = nonce
         self.expiresTime = expiresTime
         self.objectType = objectType

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -27,8 +27,6 @@ logger = logging.getLogger('default')
 
 class BMConnectionPool(object):
     """Pool of all existing connections"""
-    # pylint: disable=too-many-instance-attributes
-
     trustedPeer = None
     """
     If the trustedpeer option is specified in keys.dat then this will

--- a/src/network/connectionpool.py
+++ b/src/network/connectionpool.py
@@ -27,6 +27,7 @@ logger = logging.getLogger('default')
 
 class BMConnectionPool(object):
     """Pool of all existing connections"""
+    # pylint: disable=too-many-instance-attributes
     trustedPeer = None
     """
     If the trustedpeer option is specified in keys.dat then this will

--- a/src/network/tls.py
+++ b/src/network/tls.py
@@ -43,8 +43,7 @@ else:
 
 class TLSDispatcher(AdvancedDispatcher):
     """TLS functionality for classes derived from AdvancedDispatcher"""
-    # pylint: disable=too-many-instance-attributes, too-many-arguments
-    # pylint: disable=super-init-not-called
+    # pylint: disable=too-many-instance-attributes,super-init-not-called
     def __init__(self, _=None, sock=None, certfile=None, keyfile=None,
                  server_side=False, ciphers=sslProtocolCiphers):
         self.want_read = self.want_write = True

--- a/src/protocol.py
+++ b/src/protocol.py
@@ -336,8 +336,9 @@ def assembleAddrMessage(peerList):
     return retval
 
 
-def assembleVersionMessage(  # pylint: disable=too-many-arguments
-    remoteHost, remotePort, participatingStreams, dandelion_enabled=True, server=False, nodeid=None,
+def assembleVersionMessage(
+    remoteHost, remotePort, participatingStreams,
+    dandelion_enabled=True, server=False, nodeid=None
 ):
     """
     Construct the payload of a version message,

--- a/src/pyelliptic/ecc.py
+++ b/src/pyelliptic/ecc.py
@@ -54,7 +54,7 @@ class ECC(object):
             pubkey_y=None,
             raw_privkey=None,
             curve='sect283r1',
-    ):  # pylint: disable=too-many-arguments
+    ):
         """
         For a normal and high level use, specifie pubkey,
         privkey (if you need) and the curve
@@ -478,7 +478,7 @@ class ECC(object):
             curve='sect283r1',
             ephemcurve=None,
             ciphername='aes-256-cbc',
-    ):  # pylint: disable=too-many-arguments
+    ):
         """ECDH encryption, keys supplied in binary data format"""
 
         if ephemcurve is None:

--- a/src/pyelliptic/eccblind.py
+++ b/src/pyelliptic/eccblind.py
@@ -208,7 +208,7 @@ class ECCBlind(object):  # pylint: disable=too-many-instance-attributes
                     self.value.serialize(),
                     self._ec_point_serialize(self.Q))
 
-    def __init__(self, curve="secp256k1", pubkey=None, privkey=None,  # pylint: disable=too-many-arguments
+    def __init__(self, curve="secp256k1", pubkey=None, privkey=None,
                  year=2025, month=11, value=0xFF):
         self.ctx = OpenSSL.BN_CTX_new()
 

--- a/src/upnp.py
+++ b/src/upnp.py
@@ -132,7 +132,7 @@ class Router:  # pylint: disable=old-style-class
             description,
             leaseDuration=0,
             enabled=1,
-    ):  # pylint: disable=too-many-arguments
+    ):
         """Add UPnP port mapping"""
 
         resp = self.soapRequest(self.upnp_schema + ':1', 'AddPortMapping', [


### PR DESCRIPTION
Hi!

I removed some of the comments disabling pylint `too-many-arguments` and `too-many-instance-attributes`, because after bb5f96cc we have design checker settings also for python2.7 pylint. For python3 they are in the [tox.ini](https://git.bitmessage.org/Bitmessage/PyBitmessage/src/branch/v0.6/setup.cfg#L23).