### PR TITLE
Specify xvfbwrapper dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ PyQt5;python_version>="3.7" and platform_machine=="x86_64"
 mock;python_version<="2.7"
 python_prctl;platform_system=="Linux"
 six
-xvfbwrapper;platform_system=="Linux"
+xvfbwrapper<0.2.10;platform_system=="Linux"


### PR DESCRIPTION
Hi!

The [recent xvfbwrapper](https://pypi.org/project/xvfbwrapper/0.2.10/) is python3 only. It [breaks py27](https://buildbot.bitmessage.org/#/builders/33/builds/37292) in tox-bionic.