### PR TITLE
Exclude random from bandit blacklist

### DIFF
--- a/src/helper_random.py
+++ b/src/helper_random.py
@@ -35,7 +35,7 @@ def randomsample(population, k):
     without replacement, its called
     partial shuffle.
     """
-    return random.sample(population, k)
+    return random.sample(population, k)  # nosec B311
 
 
 def randomrandrange(x, y=None):

--- a/src/network/asyncore_pollchoose.py
+++ b/src/network/asyncore_pollchoose.py
@@ -233,13 +233,13 @@ def select_poller(timeout=0.0, map=None):
             if err.args[0] in (WSAENOTSOCK, ):
                 return
 
-        for fd in random.sample(r, len(r)):
+        for fd in random.sample(r, len(r)):  # nosec B311
             obj = map.get(fd)
             if obj is None:
                 continue
             read(obj)
 
-        for fd in random.sample(w, len(w)):
+        for fd in random.sample(w, len(w)):  # nosec B311
             obj = map.get(fd)
             if obj is None:
                 continue
@@ -297,7 +297,7 @@ def poll_poller(timeout=0.0, map=None):
         except socket.error as err:
             if err.args[0] in (EBADF, WSAENOTSOCK, EINTR):
                 return
-        for fd, flags in random.sample(r, len(r)):
+        for fd, flags in random.sample(r, len(r)):  # nosec B311
             obj = map.get(fd)
             if obj is None:
                 continue
@@ -357,7 +357,7 @@ def epoll_poller(timeout=0.0, map=None):
             if err.args[0] != EINTR:
                 raise
             r = []
-        for fd, flags in random.sample(r, len(r)):
+        for fd, flags in random.sample(r, len(r)):  # nosec B311
             obj = map.get(fd)
             if obj is None:
                 continue
@@ -420,7 +420,7 @@ def kqueue_poller(timeout=0.0, map=None):
 
         events = kqueue_poller.pollster.control(updates, selectables, timeout)
         if len(events) > 1:
-            events = random.sample(events, len(events))
+            events = random.sample(events, len(events))  # nosec B311
 
         for event in events:
             fd = event.ident

--- a/src/network/dandelion.py
+++ b/src/network/dandelion.py
@@ -198,7 +198,7 @@ class Dandelion:  # pylint: disable=old-style-class
         with self.lock:
             try:
                 # random two connections
-                self.stem = sample(
+                self.stem = sample(  # nosec B311
                     self.pool.outboundConnections.values(), MAX_STEMS)
             # not enough stems available
             except ValueError:

--- a/src/network/tcp.py
+++ b/src/network/tcp.py
@@ -200,7 +200,8 @@ class TCPConnection(BMProto, TLSDispatcher):
                     elemCount = min(
                         len(filtered),
                         maxAddrCount / 2 if n else maxAddrCount)
-                    addrs[s] = random.sample(filtered, elemCount)
+                    addrs[s] = random.sample(filtered,
+                                             elemCount)  # nosec B311
         for substream in addrs:
             for peer, params in addrs[substream]:
                 templist.append((substream, peer, params["lastseen"]))


### PR DESCRIPTION
Bandit now complains about usage of `random`, this should be excluded in our tests as it's only used in non-cryptographic use cases.