### PR TITLE
Fix appimage build broken upstream

### DIFF
--- a/.buildbot/appimage/Dockerfile
+++ b/.buildbot/appimage/Dockerfile
@@ -25,4 +25,4 @@ RUN wget -qO appimage-builder-x86_64.AppImage \
 
 ADD . .
 
-CMD .buildbot/tox-bionic/build.sh
+CMD .buildbot/appimage/build.sh

--- a/.buildbot/appimage/build.sh
+++ b/.buildbot/appimage/build.sh
@@ -20,6 +20,9 @@ function set_sourceline {
 
 function build_appimage {
     set_sourceline
+    rm -rf appimage-build
+    mkdir -p appimage-build/prime
+    wget -qO appimage-build/prime/runtime-${APPIMAGE_ARCH} "https://github.com/AppImage/AppImageKit/releases/download/continuous/obsolete-runtime-${APPIMAGE_ARCH}"
     ./${BUILDER} --recipe ${RECIPE} || exit 1
     rm -rf build
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,7 @@ docker:
 
 ```
 $ docker build -t bm-appimage -f .buildbot/appimage/Dockerfile .
-$ docker run -t --rm -v "$(pwd)"/dist:/out bm-appimage .buildbot/appimage/build.sh
+$ docker run -t --rm -v "$(pwd)"/dist:/out bm-appimage
 ```
 
 The appimages should be in the dist dir.


### PR DESCRIPTION
Hi!

I'm applying a [workaround](https://github.com/AppImageCrafters/appimage-builder/issues/375#issuecomment-3111104921) for the recently broken appimage building: manually download the runtime before calling `appimage-builder`.