### PR TITLE
Android version bump

### DIFF
--- a/packages/android/buildozer.spec
+++ b/packages/android/buildozer.spec
@@ -28,7 +28,7 @@ source.include_exts = py,png,jpg,kv,atlas,tflite,sql,json
 #source.exclude_patterns = license,images/*/*.jpg
 
 # (str) Application versioning (method 1)
-version = 0.1.1
+version = 0.1.2
 
 # (str) Application versioning (method 2)
 # version.regex = __version__ = ['"](.*)['"]


### PR DESCRIPTION
Publishing an Play Store requires a version bump as the current version has already been published.