### PR TITLE
WIP: Build appimages using an appimage-builder built from our custom code

### DIFF
--- a/.buildbot/appimage/build.sh
+++ b/.buildbot/appimage/build.sh
@@ -20,15 +20,12 @@ function set_sourceline {
 
 function build_appimage {
     set_sourceline
-    rm -rf appimage-build
-    mkdir -p appimage-build/prime
-    wget -qO appimage-build/prime/runtime-${APPIMAGE_ARCH} "https://github.com/AppImage/AppImageKit/releases/download/continuous/obsolete-runtime-${APPIMAGE_ARCH}"
     ./${BUILDER} --recipe ${RECIPE} || exit 1
     rm -rf build
 }
 
 [ -f ${BUILDER} ] || wget -qO ${BUILDER} \
-    https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage \
+    "https://artifacts.bitmessage.at/appimage/38930/appimage-builder-0.1.dev1035%2Bgce669f6-x86_64.AppImage" \
     && chmod +x ${BUILDER}
 
 chmod 1777 /tmp


### PR DESCRIPTION
Hi!

I built an appimage for the recent appimage-builder code with fixes needed to build PyBitmessage, in particular:

- Add `__init__` in `modules.setup.apprun_3.helpers`
- Make the `comp` parameter optional in the schema and comment compression setting
- Handle an empty list in qt helper

The appimages, built by it, look working: https://buildbot.bitmessage.org/#/builders/33/builds/38932. Their size increased by about 3MB.